### PR TITLE
feat: タスク READ API を実装し、テストデータを投入

### DIFF
--- a/task-board/backend/src/main/java/com/taskboard/domain/task/Task.java
+++ b/task-board/backend/src/main/java/com/taskboard/domain/task/Task.java
@@ -1,0 +1,29 @@
+package com.taskboard.domain.task;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "tasks")
+@Getter
+@NoArgsConstructor
+@ToString
+public class Task {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private String title;
+    private String description;
+    private String priority;
+    private LocalDate dueDate;
+    private String status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/task-board/backend/src/main/java/com/taskboard/domain/task/TaskController.java
+++ b/task-board/backend/src/main/java/com/taskboard/domain/task/TaskController.java
@@ -1,0 +1,29 @@
+package com.taskboard.domain.task;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/tasks")
+@RequiredArgsConstructor
+public class TaskController {
+
+    private final TaskService taskService;
+
+    @GetMapping
+    public List<Task> getAllTasks(@RequestParam(required = false) String status) {
+        return taskService.getAllTasks(status);
+    }
+
+    @GetMapping("/{id}")
+    public Task getTaskById(@PathVariable Integer id) {
+        return taskService.getTaskById(id);
+    }
+
+    @GetMapping("/status/{status}")
+    public List<Task> getTasksByStatus(@PathVariable String status) {
+        return taskService.getAllTasks(status);
+    }
+}

--- a/task-board/backend/src/main/java/com/taskboard/domain/task/TaskRepository.java
+++ b/task-board/backend/src/main/java/com/taskboard/domain/task/TaskRepository.java
@@ -1,0 +1,9 @@
+package com.taskboard.domain.task;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TaskRepository extends JpaRepository<Task, Integer> {
+    List<Task> findByStatus(String status);
+}

--- a/task-board/backend/src/main/java/com/taskboard/domain/task/TaskService.java
+++ b/task-board/backend/src/main/java/com/taskboard/domain/task/TaskService.java
@@ -1,0 +1,26 @@
+package com.taskboard.domain.task;
+
+import com.taskboard.exception.TaskNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TaskService {
+
+    private final TaskRepository taskRepository;
+
+    public List<Task> getAllTasks(String status) {
+        if (status != null && !status.isBlank()) {
+            return taskRepository.findByStatus(status);
+        }
+        return taskRepository.findAll();
+    }
+
+    public Task getTaskById(Integer id) {
+        return taskRepository.findById(id)
+                .orElseThrow(() -> new TaskNotFoundException(id));
+    }
+}

--- a/task-board/backend/src/main/java/com/taskboard/exception/GlobalExceptionHandler.java
+++ b/task-board/backend/src/main/java/com/taskboard/exception/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.taskboard.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    record ErrorResponse(int status, String message, String timestamp) {}
+
+    @ExceptionHandler(TaskNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ErrorResponse handleTaskNotFound(TaskNotFoundException ex) {
+        return new ErrorResponse(404, ex.getMessage(), LocalDateTime.now().toString());
+    }
+}

--- a/task-board/backend/src/main/java/com/taskboard/exception/TaskNotFoundException.java
+++ b/task-board/backend/src/main/java/com/taskboard/exception/TaskNotFoundException.java
@@ -1,0 +1,7 @@
+package com.taskboard.exception;
+
+public class TaskNotFoundException extends RuntimeException {
+    public TaskNotFoundException(Integer id) {
+        super("Task not found: id=" + id);
+    }
+}

--- a/task-board/backend/src/main/resources/application.yml
+++ b/task-board/backend/src/main/resources/application.yml
@@ -21,6 +21,10 @@ spring:
     locations: classpath:db/migration
     baseline-on-migrate: true
 
+  jackson:
+    serialization:
+      write-dates-as-timestamps: false
+
 server:
   port: 8080
 

--- a/task-board/backend/src/main/resources/db/migration/V2__insert_test_data.sql
+++ b/task-board/backend/src/main/resources/db/migration/V2__insert_test_data.sql
@@ -1,0 +1,8 @@
+INSERT INTO tasks (title, description, priority, due_date, status) VALUES
+  ('CI パイプライン構築',      'GitHub Actions でビルド・テスト自動化',   'high',   '2026-05-01', 'todo'),
+  ('DB設計',                  'タスクボードのERD作成',                    'high',   '2026-04-20', 'done'),
+  ('REST API 実装',            'Spring Boot で読み込みエンドポイント構築', 'high',   '2026-04-25', 'doing'),
+  ('ユニットテスト作成',       'サービス・リポジトリ層のカバレッジ確保',   'medium', '2026-05-10', 'todo'),
+  ('README 追加',              'セットアップ・使用方法のドキュメント整備', 'low',    '2026-05-15', 'todo'),
+  ('コードレビュー',           '初期実装のピアレビュー実施',               'medium', '2026-04-28', 'doing'),
+  ('ステージング環境デプロイ', 'Docker イメージをステージングに配備',      'low',    '2026-06-01', 'todo');


### PR DESCRIPTION
## 概要

タスクの読み取り（READ）APIをバックエンドに実装しました。

## 変更内容

- **Entity**: `Task.java` - tasksテーブルのJPAエンティティ
- **Repository**: `TaskRepository.java` - Spring Data JPA（`findByStatus`）
- **Service**: `TaskService.java` - 全件・ステータス別・ID指定の3メソッド
- **Controller**: `TaskController.java` - 3エンドポイント実装
- **例外処理**: `TaskNotFoundException` + `GlobalExceptionHandler`（404）
- **テストデータ**: `V2__insert_test_data.sql` - Flyway で7件自動投入
- **設定**: `application.yml` に Jackson 日付フォーマット設定を追加

## エンドポイント

| メソッド | URL | 説明 |
|---|---|---|
| GET | `/api/tasks` | 全件取得（`?status=xxx` フィルタ対応） |
| GET | `/api/tasks/{id}` | ID指定で1件取得 |
| GET | `/api/tasks/status/{status}` | ステータス別取得 |

## 動作確認済み

- 全件取得: 7件返却 ✅
- ステータスフィルタ: todo(4件)/doing(2件)/done(1件) ✅
- ID指定取得: 200 ✅
- 存在しないID: 404 + エラーJSON ✅

Closes #9