### PR TITLE
feat: タスクの新規登録機能を実装

### DIFF
--- a/task-board/backend/build.gradle
+++ b/task-board/backend/build.gradle
@@ -19,6 +19,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/task-board/backend/src/main/java/com/taskboard/config/CorsConfig.java
+++ b/task-board/backend/src/main/java/com/taskboard/config/CorsConfig.java
@@ -15,7 +15,7 @@ public class CorsConfig {
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/api/**")
                         .allowedOrigins("http://localhost:5173")
-                        .allowedMethods("GET");
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
             }
         };
     }

--- a/task-board/backend/src/main/java/com/taskboard/domain/task/Task.java
+++ b/task-board/backend/src/main/java/com/taskboard/domain/task/Task.java
@@ -26,4 +26,16 @@ public class Task {
     private String status;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
+    public static Task from(TaskRequest request) {
+        Task task = new Task();
+        task.title = request.getTitle();
+        task.description = request.getDescription();
+        task.priority = request.getPriority();
+        task.dueDate = request.getDueDate();
+        task.status = request.getStatus() != null ? request.getStatus() : "todo";
+        task.createdAt = LocalDateTime.now();
+        task.updatedAt = LocalDateTime.now();
+        return task;
+    }
 }

--- a/task-board/backend/src/main/java/com/taskboard/domain/task/TaskController.java
+++ b/task-board/backend/src/main/java/com/taskboard/domain/task/TaskController.java
@@ -1,6 +1,7 @@
 package com.taskboard.domain.task;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -25,5 +26,11 @@ public class TaskController {
     @GetMapping("/status/{status}")
     public List<Task> getTasksByStatus(@PathVariable String status) {
         return taskService.getAllTasks(status);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Task createTask(@RequestBody TaskRequest request) {
+        return taskService.createTask(request);
     }
 }

--- a/task-board/backend/src/main/java/com/taskboard/domain/task/TaskController.java
+++ b/task-board/backend/src/main/java/com/taskboard/domain/task/TaskController.java
@@ -1,5 +1,6 @@
 package com.taskboard.domain.task;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -30,7 +31,7 @@ public class TaskController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public Task createTask(@RequestBody TaskRequest request) {
+    public Task createTask(@Valid @RequestBody TaskRequest request) {
         return taskService.createTask(request);
     }
 }

--- a/task-board/backend/src/main/java/com/taskboard/domain/task/TaskRequest.java
+++ b/task-board/backend/src/main/java/com/taskboard/domain/task/TaskRequest.java
@@ -1,5 +1,7 @@
 package com.taskboard.domain.task;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,6 +10,8 @@ import java.time.LocalDate;
 @Getter
 @NoArgsConstructor
 public class TaskRequest {
+    @NotBlank(message = "タイトルは必須です")
+    @Size(max = 100, message = "タイトルは100文字以内で入力してください")
     private String title;
     private String description;
     private String priority;

--- a/task-board/backend/src/main/java/com/taskboard/domain/task/TaskRequest.java
+++ b/task-board/backend/src/main/java/com/taskboard/domain/task/TaskRequest.java
@@ -1,0 +1,16 @@
+package com.taskboard.domain.task;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class TaskRequest {
+    private String title;
+    private String description;
+    private String priority;
+    private LocalDate dueDate;
+    private String status;
+}

--- a/task-board/backend/src/main/java/com/taskboard/domain/task/TaskService.java
+++ b/task-board/backend/src/main/java/com/taskboard/domain/task/TaskService.java
@@ -23,4 +23,8 @@ public class TaskService {
         return taskRepository.findById(id)
                 .orElseThrow(() -> new TaskNotFoundException(id));
     }
+
+    public Task createTask(TaskRequest request) {
+        return taskRepository.save(Task.from(request));
+    }
 }

--- a/task-board/backend/src/main/java/com/taskboard/exception/GlobalExceptionHandler.java
+++ b/task-board/backend/src/main/java/com/taskboard/exception/GlobalExceptionHandler.java
@@ -1,11 +1,14 @@
 package com.taskboard.exception;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.time.LocalDateTime;
+import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -16,5 +19,14 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public ErrorResponse handleTaskNotFound(TaskNotFoundException ex) {
         return new ErrorResponse(404, ex.getMessage(), LocalDateTime.now().toString());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleValidation(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .map(FieldError::getDefaultMessage)
+                .collect(Collectors.joining(", "));
+        return new ErrorResponse(400, message, LocalDateTime.now().toString());
     }
 }

--- a/task-board/backend/src/main/resources/db/migration/V3__add_index_tasks_status.sql
+++ b/task-board/backend/src/main/resources/db/migration/V3__add_index_tasks_status.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_tasks_status ON tasks (status);

--- a/task-board/backend/src/main/resources/db/migration/V3__add_index_tasks_status.sql
+++ b/task-board/backend/src/main/resources/db/migration/V3__add_index_tasks_status.sql
@@ -1,1 +1,1 @@
-CREATE INDEX idx_tasks_status ON tasks (status);
+CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks (status);

--- a/task-board/frontend/src/api/taskApi.js
+++ b/task-board/frontend/src/api/taskApi.js
@@ -10,3 +10,8 @@ export async function fetchTasksByStatus(status) {
   const response = await axios.get(`/api/tasks?status=${status}`)
   return response.data
 }
+
+export async function createTask(data) {
+  const response = await axios.post('/api/tasks', data)
+  return response.data
+}

--- a/task-board/frontend/src/components/Header.jsx
+++ b/task-board/frontend/src/components/Header.jsx
@@ -1,4 +1,6 @@
+import { useState } from 'react'
 import { useTaskContext } from '../context/TaskContext'
+import TaskFormModal from './TaskFormModal'
 
 const STATUS_BUTTONS = [
   { value: 'all',   label: 'すべて' },
@@ -13,38 +15,49 @@ function Header() {
   const dateStr = `${today.getFullYear()}年${today.getMonth() + 1}月${today.getDate()}日（${days[today.getDay()]}）`
 
   const { searchQuery, setSearchQuery, statusFilter, setStatusFilter } = useTaskContext()
+  const [showModal, setShowModal] = useState(false)
 
   return (
-    <header className="bg-blue-600 text-white px-6 py-4">
-      <div className="flex items-center gap-4 mb-3">
-        <h1 className="text-xl font-bold">タスク管理ボード</h1>
-        <p className="text-sm opacity-80">{dateStr}</p>
-      </div>
-      <div className="flex flex-wrap items-center gap-3">
-        <input
-          type="text"
-          placeholder="タスクを検索..."
-          value={searchQuery}
-          onChange={e => setSearchQuery(e.target.value)}
-          className="px-3 py-1.5 rounded-md text-gray-800 text-sm w-56 focus:outline-none focus:ring-2 focus:ring-white"
-        />
-        <div className="flex gap-2">
-          {STATUS_BUTTONS.map(btn => (
-            <button
-              key={btn.value}
-              onClick={() => setStatusFilter(btn.value)}
-              className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
-                statusFilter === btn.value
-                  ? 'bg-white text-blue-600'
-                  : 'bg-blue-500 text-white hover:bg-blue-400'
-              }`}
-            >
-              {btn.label}
-            </button>
-          ))}
+    <>
+      <header className="bg-blue-600 text-white px-6 py-4">
+        <div className="flex items-center gap-4 mb-3">
+          <h1 className="text-xl font-bold">タスク管理ボード</h1>
+          <p className="text-sm opacity-80">{dateStr}</p>
+          <button
+            onClick={() => setShowModal(true)}
+            className="ml-auto px-4 py-1.5 bg-white text-blue-600 text-sm font-bold rounded-md hover:bg-blue-50 transition-colors"
+          >
+            + 新規
+          </button>
         </div>
-      </div>
-    </header>
+        <div className="flex flex-wrap items-center gap-3">
+          <input
+            type="text"
+            placeholder="タスクを検索..."
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
+            className="px-3 py-1.5 rounded-md text-gray-800 text-sm w-56 focus:outline-none focus:ring-2 focus:ring-white"
+          />
+          <div className="flex gap-2">
+            {STATUS_BUTTONS.map(btn => (
+              <button
+                key={btn.value}
+                onClick={() => setStatusFilter(btn.value)}
+                className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                  statusFilter === btn.value
+                    ? 'bg-white text-blue-600'
+                    : 'bg-blue-500 text-white hover:bg-blue-400'
+                }`}
+              >
+                {btn.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </header>
+
+      {showModal && <TaskFormModal onClose={() => setShowModal(false)} />}
+    </>
   )
 }
 

--- a/task-board/frontend/src/components/TaskFormModal.jsx
+++ b/task-board/frontend/src/components/TaskFormModal.jsx
@@ -1,0 +1,159 @@
+import { useState } from 'react'
+import { useTaskContext } from '../context/TaskContext'
+
+const INITIAL_FORM = {
+  title: '',
+  description: '',
+  priority: 'medium',
+  dueDate: '',
+  status: 'todo',
+}
+
+function TaskFormModal({ onClose }) {
+  const { addTask } = useTaskContext()
+  const [form, setForm] = useState(INITIAL_FORM)
+  const [submitting, setSubmitting] = useState(false)
+  const [formError, setFormError] = useState('')
+
+  function handleChange(e) {
+    const { name, value } = e.target
+    setForm(prev => ({ ...prev, [name]: value }))
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    if (!form.title.trim()) {
+      setFormError('タイトルは必須です。')
+      return
+    }
+    setSubmitting(true)
+    setFormError('')
+    try {
+      await addTask({
+        title: form.title.trim(),
+        description: form.description.trim() || null,
+        priority: form.priority,
+        dueDate: form.dueDate || null,
+        status: form.status,
+      })
+      onClose()
+    } catch {
+      setFormError('登録に失敗しました。もう一度お試しください。')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      onClick={e => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-md mx-4 p-6">
+        <div className="flex items-center justify-between mb-5">
+          <h2 className="text-lg font-bold text-gray-800">新規タスクを登録</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 text-xl leading-none"
+          >
+            ✕
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              タイトル <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              name="title"
+              value={form.title}
+              onChange={handleChange}
+              maxLength={100}
+              placeholder="タスクのタイトルを入力"
+              className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">説明</label>
+            <textarea
+              name="description"
+              value={form.description}
+              onChange={handleChange}
+              maxLength={500}
+              rows={3}
+              placeholder="詳細説明（任意）"
+              className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+            />
+          </div>
+
+          <div className="flex gap-4">
+            <div className="flex-1">
+              <label className="block text-sm font-medium text-gray-700 mb-1">優先度</label>
+              <select
+                name="priority"
+                value={form.priority}
+                onChange={handleChange}
+                className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              >
+                <option value="high">高</option>
+                <option value="medium">中</option>
+                <option value="low">低</option>
+              </select>
+            </div>
+
+            <div className="flex-1">
+              <label className="block text-sm font-medium text-gray-700 mb-1">ステータス</label>
+              <select
+                name="status"
+                value={form.status}
+                onChange={handleChange}
+                className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              >
+                <option value="todo">やること</option>
+                <option value="doing">進行中</option>
+                <option value="done">完了</option>
+              </select>
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">期限日</label>
+            <input
+              type="date"
+              name="dueDate"
+              value={form.dueDate}
+              onChange={handleChange}
+              className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          {formError && (
+            <p className="text-sm text-red-500">{formError}</p>
+          )}
+
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm text-gray-600 border border-gray-300 rounded-md hover:bg-gray-50"
+            >
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50"
+            >
+              {submitting ? '登録中...' : '登録する'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default TaskFormModal

--- a/task-board/frontend/src/components/TaskFormModal.jsx
+++ b/task-board/frontend/src/components/TaskFormModal.jsx
@@ -37,8 +37,9 @@ function TaskFormModal({ onClose }) {
         status: form.status,
       })
       onClose()
-    } catch {
-      setFormError('登録に失敗しました。もう一度お試しください。')
+    } catch (err) {
+      const msg = err?.response?.data?.message
+      setFormError(msg ?? 'ネットワークエラーが発生しました。バックエンドが起動しているか確認してください。')
     } finally {
       setSubmitting(false)
     }

--- a/task-board/frontend/src/context/TaskContext.jsx
+++ b/task-board/frontend/src/context/TaskContext.jsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, useEffect, useMemo } from 'react'
-import { fetchAllTasks } from '../api/taskApi'
+import { fetchAllTasks, createTask as apiCreateTask } from '../api/taskApi'
 
 const TaskContext = createContext(null)
 
@@ -17,6 +17,11 @@ export function TaskProvider({ children }) {
       .finally(() => setLoading(false))
   }, [])
 
+  async function addTask(data) {
+    const created = await apiCreateTask(data)
+    setAllTasks(prev => [...prev, created])
+  }
+
   const tasks = useMemo(() => {
     return allTasks
       .filter(t => statusFilter === 'all' || t.status === statusFilter)
@@ -31,7 +36,7 @@ export function TaskProvider({ children }) {
   }, [allTasks, searchQuery, statusFilter])
 
   return (
-    <TaskContext.Provider value={{ tasks, loading, error, searchQuery, setSearchQuery, statusFilter, setStatusFilter }}>
+    <TaskContext.Provider value={{ tasks, loading, error, searchQuery, setSearchQuery, statusFilter, setStatusFilter, addTask }}>
       {children}
     </TaskContext.Provider>
   )


### PR DESCRIPTION
## 概要

- バックエンドに `POST /api/tasks` エンドポイントを追加
- フロントエンドに新規登録フォームモーダルを実装
- ヘッダーの「+ 新規」ボタンからタスクを作成できるようになった

## 変更ファイル

### バックエンド
| ファイル | 変更内容 |
|---|---|
| `TaskRequest.java`（新規） | POST リクエストを受け取る DTO |
| `Task.java` | `Task.from(request)` ファクトリメソッドを追加 |
| `TaskService.java` | `createTask` メソッドを追加 |
| `TaskController.java` | `@PostMapping` を追加（HTTP 201 を返す） |

### フロントエンド
| ファイル | 変更内容 |
|---|---|
| `taskApi.js` | `createTask(data)` 関数を追加（axios.post） |
| `TaskContext.jsx` | `addTask` 関数を追加・state を即時更新 |
| `TaskFormModal.jsx`（新規） | 入力フォームモーダル |
| `Header.jsx` | 「+ 新規」ボタンを追加 |

## テスト手順

- [ ] サービスを起動する（DB → バックエンド → フロントエンド）
- [ ] ヘッダーの「+ 新規」ボタンを押してモーダルが開くことを確認
- [ ] タイトル・説明・優先度・期限・ステータスを入力して「登録する」を押す
- [ ] ボードに新しいタスクカードが即時表示されることを確認
- [ ] DB に `POST /api/tasks` のデータが保存されていることを確認
- [ ] タイトル未入力で登録しようとするとエラーメッセージが表示されることを確認

Closes #25