### PR TITLE
fix: FlywayマイグレーションV3をIF NOT EXISTSで冪等化

### DIFF
--- a/task-board/backend/src/main/resources/db/migration/V3__add_index_tasks_status.sql
+++ b/task-board/backend/src/main/resources/db/migration/V3__add_index_tasks_status.sql
@@ -1,1 +1,1 @@
-CREATE INDEX idx_tasks_status ON tasks (status);
+CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks (status);


### PR DESCRIPTION
## 概要

`V3__add_index_tasks_status.sql` に `IF NOT EXISTS` を追加し、インデックスが既存でもSpring Bootが正常起動するようにした。

## 問題

DBコンテナを削除せずに再起動した場合など、`idx_tasks_status` が既にDBに存在する状態でFlywayのV3マイグレーションを実行すると以下のエラーで起動失敗する。

```
ERROR: relation "idx_tasks_status" already exists
```

## 変更内容

```sql
-- 修正前
CREATE INDEX idx_tasks_status ON tasks (status);

-- 修正後
CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks (status);
```

## テスト計画

- [ ] `idx_tasks_status` インデックスがDB上に存在する状態でSpring Bootを起動 → 正常起動すること
- [ ] インデックスが存在しない状態でSpring Bootを起動 → 正常にインデックスが作成されること

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)