### PR TITLE
chore: EC2 user_dataで Java25/Node22/Docker/Git を自動インストール

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -214,6 +214,12 @@ resource "aws_instance" "app" {
     http_endpoint = "enabled"
   }
 
+  # cloud-init で Java25 / Node22 / Docker / Git を自動インストール
+  # スクリプトは infra/user_data.sh を参照
+  # user_data 変更時はインスタンス再作成（既存EC2を破棄して新規作成）
+  user_data                   = file("${path.module}/user_data.sh")
+  user_data_replace_on_change = true
+
   tags = {
     Name = "${local.name_prefix}-ec2"
   }

--- a/infra/user_data.sh
+++ b/infra/user_data.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# =====================================================================
+# user_data.sh — EC2 初回起動時の cloud-init スクリプト
+# =====================================================================
+# このスクリプトは EC2 が起動した直後に root 権限で1回だけ実行される。
+# ログは /var/log/cloud-init-output.log で確認可能。
+# 実行時のディレクトリは / なので、cd で移動するか絶対パスを使うこと。
+# =====================================================================
+set -euxo pipefail
+
+# 全出力を cloud-init のログに集約
+exec > >(tee -a /var/log/cloud-init-output.log) 2>&1
+
+echo "===== user_data started: $(date -Iseconds) ====="
+
+# ---------------------------------------------------------------------
+# 1. システム更新と基本ツール
+# ---------------------------------------------------------------------
+# 注意: Amazon Linux 2023 には curl-minimal がプリインストール済み。
+#       curl を明示インストールすると curl-minimal と競合してエラーになるので含めない。
+#       tar/gzip も AL2023 標準で入っているため省略。
+dnf update -y
+dnf install -y git
+
+# ---------------------------------------------------------------------
+# 2. Amazon Corretto 25 (JDK)
+# ---------------------------------------------------------------------
+echo "===== Installing Amazon Corretto 25 ====="
+rpm --import https://yum.corretto.aws/corretto.key
+curl -fsSL https://yum.corretto.aws/corretto.repo -o /etc/yum.repos.d/corretto.repo
+dnf install -y java-25-amazon-corretto-devel
+
+# ---------------------------------------------------------------------
+# 3. Node.js 22 (NodeSource RPM)
+# ---------------------------------------------------------------------
+echo "===== Installing Node.js 22 ====="
+curl -fsSL https://rpm.nodesource.com/setup_22.x | bash -
+dnf install -y nodejs
+
+# ---------------------------------------------------------------------
+# 4. Docker + Compose v2 plugin
+# ---------------------------------------------------------------------
+echo "===== Installing Docker ====="
+dnf install -y docker
+systemctl enable --now docker
+usermod -aG docker ec2-user
+
+echo "===== Installing Docker Compose v2 plugin ====="
+DOCKER_PLUGINS=/usr/local/lib/docker/cli-plugins
+mkdir -p "$DOCKER_PLUGINS"
+ARCH=$(uname -m)
+curl -fsSL "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-${ARCH}" \
+  -o "${DOCKER_PLUGINS}/docker-compose"
+chmod +x "${DOCKER_PLUGINS}/docker-compose"
+
+# ---------------------------------------------------------------------
+# 5. インストール結果の検証ログ出力
+# ---------------------------------------------------------------------
+echo "===== Verification ====="
+java --version
+javac --version
+node --version
+npm --version
+docker --version
+docker compose version
+git --version
+
+echo "===== user_data finished: $(date -Iseconds) ====="


### PR DESCRIPTION
## 関連 Issue

Closes #47

---

## 変更の概要

Phase 2 として、Phase 1 で構築した EC2 に対し、cloud-init (`user_data`) で開発ツール一式を自動インストールする仕組みを追加。

### 追加・変更ファイル

| ファイル | 変更内容 |
|---|---|
| `infra/user_data.sh` | 🆕 新規作成。cloud-init bash スクリプト |
| `infra/main.tf` | 🔄 `aws_instance.app` に `user_data` + `user_data_replace_on_change=true` を追加 |

### user_data.sh で行うこと

1. `dnf update` 後、Git のみ `dnf install`
   - ※ AL2023 プリインストール済みの `curl-minimal` と競合するため `curl` は含めない
2. **Amazon Corretto 25 (JDK)** インストール
3. **Node.js 22** (NodeSource RPM) インストール
4. **Docker** + **Compose v2 plugin** インストール、サービス自動起動、ec2-user を docker グループへ
5. インストールバージョンをログ出力

---

## 動作確認結果（実apply済）

| 項目 | 結果 |
|---|---|
| `terraform apply` | ✅ 成功 (1 added, 1 changed, 1 destroyed — user_data変更でEC2置換) |
| `cloud-init status` | ✅ `done` |
| `java --version` | ✅ openjdk 25.0.3 LTS |
| `node --version` | ✅ v22.22.2 |
| `npm --version` | ✅ 10.9.7 |
| `docker --version` | ✅ 25.0.14 |
| `docker compose version` | ✅ v5.1.3 |
| `git --version` | ✅ 2.50.1 |
| docker サービス | ✅ active + enabled |
| ec2-user の docker グループ | ✅ 所属済み |
| `docker run hello-world` | ✅ 成功 |
| `terraform fmt/validate/tflint/tfsec` | ✅ 全パス |
| `shellcheck user_data.sh` | ✅ パス |

## 動作確認時の注意点

- `user_data_replace_on_change=true` のため、user_data 変更時はEC2が破棄→再作成される（`Plan: 1 to add, 1 to change, 1 to destroy.`）
- EIP は維持されるためアクセス先IPは変わらない
- cloud-init 完了まで約3〜5分かかる（dnf update + パッケージダウンロード時間）

---

## トラブルシューティング履歴

最初の apply で curl 競合エラーが発生（`curl conflicts with curl-minimal`）。
原因：Amazon Linux 2023 には `curl-minimal` がプリインストールされており、`dnf install -y curl` が競合する。
対応：`curl` を install リストから外し、AL2023 標準の curl-minimal を利用する方針に変更。

---

## 変更の種別

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] style
- [ ] refactor
- [ ] test
- [x] chore（設定・ツール・依存関係の変更）

---

## 動作確認チェックリスト

- [x] `terraform apply` 成功
- [x] cloud-init status = done
- [x] 全ツール `--version` 応答
- [x] docker hello-world 実行成功
- [x] `.env` / アクセスキー / シークレットをコミットしていない

---

## レビュー時に特に確認してほしい点

- `user_data.sh` のパッケージインストール順序が妥当か
- shellcheck が通っているか
- `user_data_replace_on_change=true` の選択が妥当か（毎回EC2が再作成される）

---

## 後続作業（Phase 3 以降）

- [ ] Phase 3: EC2 に hideharu-AI を git clone してアプリ起動（DB/Backend/Frontend）
- [ ] Phase 4: RDS PostgreSQL 分離
- [ ] Phase 5: S3 + CloudFront でフロントエンド分離