### PR TITLE
chore: AI誤操作による本番環境破壊を防ぐ多層防御を実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,10 @@ Issue・PR には必ずラベルを付けること。
 5. PR なしに main へのコードを反映しない
 6. `.env` ファイルを Git にコミットしない
 7. データベースのパスワードをコードに直書きしない
+8. **`terraform destroy` を本人の明示承認なしに実行しない**（特に auto-approve禁止）
+9. **`terraform apply -auto-approve` を本人の明示承認なしに実行しない**（破壊的変更が含まれる可能性）
+10. **`aws *delete*` `aws *terminate*` `aws s3 rb*` を本人の明示承認なしに実行しない**
+11. **本番データベース・バックアップを削除する操作は、AI 単独で完結させない**（必ず人間の承認をはさむ）
 
 ---
 
@@ -324,3 +328,96 @@ lsof -ti :5432 | xargs kill -9 2>/dev/null; true
 - ルールを変更したい場合は、必ず Issue を立ててから PR 経由で変更すること
 - 直接編集してコミットしない
 - 変更時のコミットメッセージ: `chore: CLAUDE.md のルールを更新 (#番号)`
+
+---
+
+## 12. AI 誤操作防止の多層防御ルール
+
+AWS / Terraform を扱う AI コーディングツールが本番環境を破壊する事故が業界で複数報告されているため、本リポジトリでは **多層防御** で予防する。
+
+### 12-1. 階層別の防御内容
+
+| 階層 | 仕組み | 場所 |
+|---|---|---|
+| 1. **Claude Code 設定** | `permissions.deny` で破壊的コマンドを拒否 | `~/.claude/settings.json`（本リポジトリ外） |
+| 2. **Terraform リソース保護** | `lifecycle { prevent_destroy = true }` | `infra/main.tf` の RDS 等 |
+| 3. **開発ルール** | 本ファイル（CLAUDE.md）の禁止事項 | `CLAUDE.md` セクション 6 |
+| 4. **コードレビュー** | PR ベースのワークフロー | GitHub PR |
+| 5. **AWS リソース保護**（将来） | `deletion_protection = true` / IAM 最小権限 / Backups | AWS Organizations / SCP |
+
+### 12-2. AI が単独で実行してはならない操作
+
+以下は **必ず人間の明示承認をはさむ** こと（CLAUDE.md セクション 6 の補足）：
+
+- `terraform destroy` 全般
+- `terraform apply -auto-approve`（明示承認なしの自動適用）
+- `terraform state rm` / `terraform workspace delete`
+- `aws rds delete-*` / `aws ec2 terminate-*` / `aws s3 rb`
+- `aws iam delete-*`（権限・ロール削除は復旧困難）
+- 本番データに対する手動 SQL（`DROP TABLE` / `TRUNCATE` 等）
+
+### 12-3. RDS の `lifecycle.prevent_destroy` 運用
+
+`infra/main.tf` の `aws_db_instance.main` に `prevent_destroy = true` を設定済み。
+**`terraform destroy` を実行するとエラーで止まる** ようになっている。
+
+正規の手順で削除する場合：
+
+1. `infra/main.tf` を編集して `prevent_destroy = false` に変更
+2. `terraform apply`（lifecycle 変更のみ反映、リソースは無変更）
+3. `terraform destroy` 実行
+4. 完了後、必要なら `prevent_destroy = true` に戻す
+
+→ **「ワンコマンドで destroy できない」状態をデフォルトにすることで、誤操作の窓を狭める**。
+
+### 12-4. デプロイ前監査チェックリスト
+
+PR で AWS / Terraform 変更が含まれる場合、レビュー時に必ず確認：
+
+- [ ] 平文の機密情報がコミットされていない（`grep -rE "(password|secret|api[_-]?key)"`）
+- [ ] 環境固有のハードコード（IP / endpoint / bucket 名）が外部化されている
+- [ ] 無料枠の範囲内（`describe-instance-types --filters free-tier-eligible=true` で確認）
+- [ ] Terraform Toolchain と EC2 上のランタイムバージョンが整合する
+- [ ] `terraform plan` の差分に **意図しない destroy** が含まれていない
+- [ ] `lifecycle.prevent_destroy` を外す変更があれば、その意図がコミットメッセージに明記されている
+
+これらは `~/.claude/skills/terraform-quality-check/` スキルで一括チェックできる。
+
+---
+
+## 13. 他組織での事故事例（教訓カード）
+
+業界で発生した実事例から学び、同じ過ちを繰り返さないために記録する。
+
+### 13-1. 2026年：Claude Code が Terraform で本番環境を全削除
+
+**概要：**
+SNS で報告された事例。Claude Code が Terraform 経由で本番環境のリソースを **バックアップを含めて全削除** したインシデント。
+
+**推測される原因（多層防御がすべて外れていた状態）：**
+- AI が `terraform destroy -auto-approve` を制限なく実行できた
+- dev / prod が同じ AWS アカウント・同じ tfstate で管理されていた
+- RDS / S3 等に `prevent_destroy` / `deletion_protection` が未設定
+- バックアップが同じアカウント内（クロスアカウント分離なし）
+- AI 用 IAM ロールに削除系の Deny ルールがなかった
+- PR-based ワークフローではなく、AI が直接 apply できる構成
+
+**本リポジトリでの予防策：**
+- セクション 12 の階層 1〜4 を適用済み
+- 階層 5（AWS Organizations / SCP / クロスアカウントバックアップ）は本格運用フェーズで実装予定
+
+**教訓：**
+- AI が「クリーンアップして」と言われたら destroy を実行する文脈がある（AI は文脈を慎重に解釈する責任がある）
+- **「便利さ」と「安全性」はトレードオフ**：auto-approve の便利さに対して、誤操作のリスクは取り返しがつかない
+- バックアップは **必ずクロスアカウント** で保管する（同一アカウント内のバックアップは「同じ削除コマンド」で消える）
+
+詳細は `task-board/docs/incidents/INDEX.md` の参照対象として登録。
+
+### 13-2. 教訓カードの追加方針
+
+新しい事故事例を学んだら、以下の形式で本セクションまたは `incidents/` に追加：
+
+- 概要（何が起きたか）
+- 推測される原因（多層防御の何が外れていたか）
+- 本リポジトリでの予防策（階層別に何が効くか）
+- 教訓（再発防止のために守るべきこと）

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -351,6 +351,28 @@ resource "aws_db_instance" "main" {
   # ログ・監視（学習用なので最小）
   performance_insights_enabled = false
 
+  # ---------------------------------------------------------------------
+  # 削除保護（AI 誤操作による本番DB破壊事故の予防）
+  # ---------------------------------------------------------------------
+  # SNS で「Claude Code が Terraform で本番DB(バックアップ含む)を全削除した
+  # 事案」が報告されたため、多層防御の一層として Terraform レベルで
+  # 削除を物理的にブロックする。
+  #
+  # 動作：terraform destroy を実行すると以下のエラーで停止する：
+  #   "Resource aws_db_instance.main has lifecycle.prevent_destroy set ..."
+  #
+  # 正規の手順で削除したい場合は以下：
+  #   1. このファイルで prevent_destroy = false に変更
+  #   2. terraform apply（lifecycle 変更のみ反映、リソースは触らない）
+  #   3. terraform destroy 実行
+  #   4. destroy 完了後、必要なら prevent_destroy を true に戻す
+  #
+  # 注意：prevent_destroy は変数（var.xxx）で制御できない（Terraform 仕様）
+  # ---------------------------------------------------------------------
+  lifecycle {
+    prevent_destroy = true
+  }
+
   tags = {
     Name = "${local.name_prefix}-db"
   }


### PR DESCRIPTION
## 関連 Issue

Closes #56

---

## 変更の概要

SNS で報告された **「Claude Code が Terraform で本番環境（バックアップ含む）を全削除した事案」** の予防策として、本リポジトリに **多層防御** を実装。

3層構成：
1. **Claude Code 設定**（リポジトリ外）- 破壊的コマンドの自動拒否
2. **Terraform リソース保護**（infra/main.tf）- RDS の物理削除阻止
3. **開発ルール文書化**（CLAUDE.md）- 行動規範の明文化

---

## 各対策の詳細

### 対策1：`~/.claude/settings.json` に破壊的コマンドの deny 追加（リポジトリ外）

> ⚠️ このファイルはユーザーごとのローカル設定でリポジトリにはコミットされません。本 PR ではコード変更なし、CLAUDE.md でルール文書化のみ。

`permissions.deny` 配列に18件追加（`update-config` スキル経由で実装）：

```
Terraform 系（5件）:
  - terraform destroy*
  - terraform apply -auto-approve*  /  apply --auto-approve*
  - terraform workspace delete*
  - terraform state rm*

AWS 系（10件）:
  - aws rds delete-db-instance / delete-db-cluster / delete-db-snapshot
  - aws ec2 terminate-instances / delete-vpc / delete-subnet / delete-security-group
  - aws s3 rb / aws s3 rm * --recursive / aws s3api delete-bucket
  - aws iam delete-user / delete-role / delete-policy
  - aws dynamodb delete-table

Git 系（追加3件）:
  - git push --force-with-lease*  （既存の --force / -f に追加）
```

### 対策2：`infra/main.tf` の RDS に `lifecycle { prevent_destroy = true }` 追加

```hcl
resource "aws_db_instance" "main" {
  # ... 既存設定 ...

  lifecycle {
    prevent_destroy = true   # ← 追加
  }
}
```

**動作：** `terraform destroy` 実行時に以下のエラーで停止する：
```
Error: Instance cannot be destroyed
Resource aws_db_instance.main has lifecycle.prevent_destroy set...
```

**正規の destroy 手順**（CLAUDE.md セクション 12-3 に文書化）：
1. `infra/main.tf` を編集して `prevent_destroy = false` に変更
2. `terraform apply`（lifecycle 変更のみ反映）
3. `terraform destroy` 実行
4. 完了後、必要なら `prevent_destroy = true` に戻す

### 対策3：CLAUDE.md に行動規範を追加

#### セクション 6（禁止事項）拡張：項目 8〜11 追加
- terraform destroy / apply -auto-approve / aws *delete* / aws *terminate* /
  aws s3 rb の AI 単独実行禁止
- 本番DB・バックアップ削除は AI 単独で完結させない

#### セクション 12（新規）：AI 誤操作防止の多層防御ルール
- 階層別防御（5層）の説明
- AI が単独で実行してはならない操作の明示
- RDS prevent_destroy の運用手順
- デプロイ前監査チェックリスト

#### セクション 13（新規）：他組織での事故事例（教訓カード）
- 2026年 Claude Code 本番削除事案の詳細記録
- 推測される原因と本リポジトリでの予防策
- 教訓カードの追加方針

---

## 品質チェック結果

`~/.claude/skills/terraform-quality-check/` スキルで全項目パス：

| 項目 | 結果 |
|---|---|
| terraform fmt | ✅ |
| terraform validate | ✅ Success |
| tflint | ✅ |
| tfsec | ✅ 0 critical/high/medium/low |
| shellcheck | ✅ |
| 機密情報スキャン | ✅ 検出ゼロ |
| Free Tier 確認 | ✅ t3.micro / db.t3.micro |
| ドリフト | ✅ なし（lifecycle はメタ引数のため plan に現れない仕様） |

---

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `infra/main.tf` | `aws_db_instance.main` に `lifecycle { prevent_destroy = true }` 追加（22行）|
| `CLAUDE.md` | 禁止事項拡張 + セクション 12, 13 新規追加（97行） |

> ※ `~/.claude/settings.json` はリポジトリ外のためコード変更ナシ。

---

## 変更の種別

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] style
- [ ] refactor
- [ ] test
- [x] chore（設定・ルール・安全対策の追加）

---

## 動作確認チェックリスト

- [x] `~/.claude/settings.json` の deny 数: 18件 → 36件
- [x] `infra/main.tf` の RDS に lifecycle.prevent_destroy 追加
- [x] CLAUDE.md セクション 6 に項目 8〜11 追加
- [x] CLAUDE.md セクション 12（多層防御）追加
- [x] CLAUDE.md セクション 13（事故事例）追加
- [x] terraform-quality-check スキル全項目パス
- [x] 平文機密情報の混入なし
- [x] `.env` / アクセスキー / シークレットをコミットしていない

---

## レビュー時に特に確認してほしい点

1. **deny ルールの網羅性**：他に防御すべき破壊的コマンドはないか
2. **prevent_destroy の運用手順**：CLAUDE.md セクション 12-3 の手順が明確か
3. **教訓カードの記述**：セクション 13 の事故事例が後日参照しやすい形か
4. **既存運用との整合性**：`deletion_protection = false` のままで OK か（lifecycle 側で防御するため）

---

## 後続対応（本 PR スコープ外）

- AWS Organizations / SCP による account 分離
- AWS Backup によるクロスアカウントバックアップ
- IAM ロールの最小権限化（読み取り専用ロール作成）
- gitleaks / detect-secrets の CI 化
- Terraform Cloud / Spacelift など PR-based apply 環境

これらは本格運用フェーズで実装予定。