### PR TITLE
feat: RDS auto-stop workflow 追加（F3 解体・#60）

### DIFF
--- a/.github/workflows/rds-auto-stop.yml
+++ b/.github/workflows/rds-auto-stop.yml
@@ -1,0 +1,79 @@
+name: RDS Auto Stop (F3 解体)
+
+# ============================================
+# scout-drone-protocol v3.3 F3 解体: RDS 7 日自動再起動の阻止
+# ============================================
+# 目的:
+#   AWS の仕様 = stopped RDS は 7 日後に自動再起動する。
+#   これを阻止するため、5 日ごとに自動的に stop し直す。
+#
+# 関連:
+#   - hideharu-AI#60: 本 workflow の Issue
+#   - recipe-board#75: scout-drone-protocol v3.3
+#   - F3 達成 Level: L3（解体）
+#   - L4 化（destroy/recreate 運用）は別 Issue で持ち越し
+#
+# 安全策:
+#   - 専用 IAM user `github-actions-rds-stop`（最小権限）
+#   - rds:StopDBInstance は task-board-dev-db に限定
+#   - 冪等: 既に stopped なら no-op
+#   - workflow_dispatch で手動テスト可能
+# ============================================
+
+on:
+  schedule:
+    # 5 日ごと 09:00 JST = 0:00 UTC
+    # 最大ギャップ 5〜6 日 < AWS 7 日自動再起動。安全マージン 1〜2 日。
+    - cron: '0 0 */5 * *'
+  workflow_dispatch:
+    # 手動テスト / 緊急時用
+
+permissions:
+  contents: read
+
+jobs:
+  stop-rds:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-1
+
+      - name: Check current RDS state
+        id: check
+        shell: bash
+        run: |
+          set -euo pipefail
+          STATUS=$(aws rds describe-db-instances \
+            --db-instance-identifier task-board-dev-db \
+            --query 'DBInstances[0].DBInstanceStatus' \
+            --output text)
+          echo "Current status: $STATUS"
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+
+      - name: Stop RDS if running
+        if: steps.check.outputs.status == 'available'
+        shell: bash
+        run: |
+          echo "🛑 RDS is running (available) — issuing stop"
+          aws rds stop-db-instance \
+            --db-instance-identifier task-board-dev-db
+          echo "✅ Stop requested"
+
+      - name: Skip (already not running)
+        if: steps.check.outputs.status != 'available'
+        shell: bash
+        env:
+          STATUS: ${{ steps.check.outputs.status }}
+        run: |
+          echo "✅ RDS state = '$STATUS' (not running) — no action needed"
+          echo "::notice::F3 解体: RDS already stopped/stopping. Idempotent no-op."
+
+      - name: Heartbeat log
+        shell: bash
+        run: |
+          echo "::notice::🟢 RDS Auto Stop workflow completed at $(date -u)"
+          echo "Next run: every 5 days via cron '0 0 */5 * *'"


### PR DESCRIPTION
## 関連 Issue

Closes #60

## 変更の概要

scout-drone-protocol v3.3（recipe-board#75）で識別された **F3（RDS 7 日自動再起動）**の整備作業。
GitHub Actions で 5 日ごとに自動 stop することで、AWS の 7 日自動再起動仕様を阻止する。

## 達成 Level（v3.3 Phase 4 適用）

| Finding | 種類 | 達成 Level | 整備の中身 |
|---|---|---|---|
| F3: RDS 7 日自動再起動 | 外部仕様 | **L3（解体）** | 5 日ごと自動 stop で再起動を阻止 |

→ **L4 化**（destroy / recreate 運用）は別 follow-up Issue で持ち越し（destructive 操作のため別承認）

## 仕組み

| 項目 | 内容 |
|---|---|
| 配置 | `.github/workflows/rds-auto-stop.yml` |
| トリガー | 5 日ごと（cron `0 0 */5 * *`）+ workflow_dispatch |
| 動作 | describe → stopped/stopping なら no-op、available なら stop |
| 冪等性 | ✅ 何度実行しても安全 |

## 安全策（最小権限の原則）

| 項目 | 内容 |
|---|---|
| IAM user | `github-actions-rds-stop`（新規・専用）|
| 権限スコープ | `rds:StopDBInstance` を task-board-dev-db のみ |
| 過剰権限回避 | `tesuto`（AdministratorAccess）の流用なし |

## ユーザー側の必須操作: GitHub Secrets 登録

私（Claude）が IAM user とアクセスキーを準備済み。**user は以下を実施してください：**

### 手順

1. ローカルで Secret を確認（権限 600 ファイル・私の chat には出さない）：
   ```bash
   cat /tmp/aws-rds-stop-key-1778331801.json
   ```

2. GitHub Secrets ページを開く：
   https://github.com/80-cloud/hideharu-AI/settings/secrets/actions

3. **New repository secret** で以下を 2 件登録：
   | Secret 名 | 値 |
   |---|---|
   | `AWS_ACCESS_KEY_ID` | `AKIAVSNQBQFTN67N4Z53` |
   | `AWS_SECRET_ACCESS_KEY` | `/tmp/aws-rds-stop-key-1778331801.json` の `SecretAccessKey` 値 |

4. 登録完了後、ファイル削除（推奨）：
   ```bash
   shred -u /tmp/aws-rds-stop-key-1778331801.json 2>/dev/null || rm /tmp/aws-rds-stop-key-1778331801.json
   ```

## 動作確認手順（マージ後）

1. GitHub Actions タブで **RDS Auto Stop (F3 解体)** workflow を確認
2. **Run workflow** ボタン（workflow_dispatch）で手動実行
3. 実行ログで以下を確認：
   - 現状 RDS は stopped → "✅ RDS state = 'stopped' (not running) — no action needed" 表示期待
   - エラーなく完了

## 動作確認チェックリスト

- [x] YAML 構文 OK
- [x] 主要キー存在確認
- [x] IAM user `github-actions-rds-stop` 作成済み
- [x] IAM policy `github-actions-rds-stop-policy` 作成済み + attach 済み
- [x] アクセスキー発行済み（一時ファイルに保管）
- [ ] **GitHub Secrets 登録**（user 操作必須）
- [ ] **workflow_dispatch で実環境テスト**（user 操作・Secrets 登録後）

## scout-drone-protocol v3.3 Phase 4/5 適用

- 達成 Level: **L3** ✅
- 残置 🔴: 1 件（L4 化の follow-up Issue を別途起票予定）
- 形骸化防止: workflow_dispatch + Actions タブ可視化 + idempotent 設計