### PR TITLE
docs: review-board 技術スタック.md を作成（Java 25 + Spring Boot 3.5.5）

### DIFF
--- a/review-board/docs/技術スタック.md
+++ b/review-board/docs/技術スタック.md
@@ -1,0 +1,264 @@
+# review-board 技術スタック
+
+**プロジェクト名:** review-board (成長支援型レビューコミュニティ)
+**作成日:** 2026-05-22
+**バージョン:** 1.0
+**作成者:** hideharu-AI
+
+> 本ドキュメントは [要件定義書](./要件定義書.md) §2-3 から技術選定に関する内容を分離・詳細化したもの。
+> **基本スタックは slack-board / sns-board と揃える**（学習資産の継承）。review-board 固有の差分は
+> ① 言語ランタイムを **Java 25 (LTS)** へ先行採用（要件定義書 §1-6「やったことがないことをするのが
+> エンジニアの仕事」）、② S軸（セキュリティ・認可）の強化（RBAC / IDOR / 依存脆弱性スキャン）である。
+> WebSocket・動画処理は本アプリの対象外（要件定義書 §5）なので採用しない。
+
+---
+
+## 目次
+
+1. [フルスタック構成の全体像](#1-フルスタック構成の全体像)
+2. [バックエンドの採用技術](#2-バックエンドの採用技術)
+3. [フロントエンドの採用技術](#3-フロントエンドの採用技術)
+4. [インフラ・環境設定](#4-インフラ環境設定)
+5. [採用技術一覧（まとめ）](#5-採用技術一覧まとめ)
+6. [不採用技術とその理由](#6-不採用技術とその理由)
+7. [外部ライブラリ・依存関係](#7-外部ライブラリ依存関係)
+8. [M-14：Toolchain と実行ランタイムの整合（最重要）](#8-m-14toolchain-と実行ランタイムの整合最重要)
+
+---
+
+## 1. フルスタック構成の全体像
+
+### アプリ全体の構造
+
+```
+┌─────────────────────────────────────────────┐
+│        ブラウザ (受講生 / 講師の画面)         │
+│                                             │
+│   React + Tailwind CSS                      │
+│   ・成長記録ページ (主役) / 投稿 / レビュー    │
+│   ・ログイン必須 (未ログインはアクセス不可)    │
+│   ・通知は Phase 2 でポーリング (WebSocket なし)│
+└────────────────┬────────────────────────────┘
+                 │  HTTPS (Axios)
+                 ▼
+┌─────────────────────────────────────────────┐
+│         ALB (HTTPS 終端、Phase 3 デプロイ時)  │
+│   ・ACM 証明書 / /api/* → REST API           │
+└────────────────┬────────────────────────────┘
+                 │
+                 ▼
+┌─────────────────────────────────────────────┐
+│   EC2 (Spring Boot + Nginx、Phase 3)         │
+│                                             │
+│   ・REST API (/api/*)                        │
+│   ・Spring Security による RBAC + 所有者/cohort 検証 (★S軸)│
+│   ・SPA 配信 (/)                             │
+│   ・成果物スクショの S3 アップロード仲介        │
+└────┬──────────────────────────────────┬─────┘
+     │  JPA                              │  AWS SDK / S3 互換
+     ▼                                   ▼
+┌────────────────────────┐    ┌────────────────────┐
+│ RDS / PostgreSQL       │    │ MinIO(ローカル)/S3  │
+│  ・users (role)        │    │ 成果物スクリーンショット│
+│  ・cohorts             │    │                    │
+│  ・refresh_tokens      │    └────────────────────┘
+│  ・posts (成果物)       │
+│  ・reviews             │
+│  ・review_axis_comments│  ← 品質4軸の観点別コメント
+│  ・thanks (ありがとう)  │
+│  ・evaluations (講師評価)│
+│  ・audit_logs (★S軸)   │
+└────────────────────────┘
+```
+
+> テーブル名・列は ER図.md 起こし時に確定する。ここでは構成把握のための概略。
+
+### API エンドポイント設計（方針）
+
+詳細は [機能一覧.md](./機能一覧.md)（後日作成）参照。本アプリは S軸（認可）が突出点のため、
+**全エンドポイントで「ログイン必須 → ロール判定（RBAC）→ 所有者 / cohort 一致の検証」を必ず通す**
+（要件定義書 §3-2、母 SEC-2/3/4）。不一致は 404 を返し IDOR を遮断する。
+
+---
+
+## 2. バックエンドの採用技術
+
+### 2-1. Java 25（プログラミング言語）
+
+**バージョン:** **25（LTS）** — slack-board / sns-board（21）からの **先行採用（本アプリ固有の差分）**。
+ディストリビューションは **Amazon Corretto 25**（EC2 の標準・無料・LTS）。
+要件定義書 §1-6「やったことがないことをするのがエンジニアの仕事」に沿った学習上の挑戦。
+
+### 2-2. Spring Boot 3.5.5（Web フレームワーク）
+
+**バージョン:** **3.5.5** — family（3.5.0）からの **パッチ上げ（継承重視）**。
+Spring Boot 3.5.5 は **Java 25 をサポート**する（3.5.0 では未対応のため必ず 3.5.5 以上を使う）。
+メジャーを 4.0 に上げず 3.5 系に留めることで、slack-board / sns-board の書式・設定・参考資料を最大限流用する。
+
+- Spring Web（REST API）
+- **Spring Security**（★S軸の中核）：RBAC（受講生 / 講師）・認可フィルタ・メソッドレベル認可（`@PreAuthorize`）
+- Spring Data JPA + Hibernate（ORM）
+- Flyway（DB マイグレーション）
+- Spring Boot Actuator（ヘルスチェック・メトリクス）
+
+### 2-3. Gradle 9.1.0（ビルドツール）
+
+**バージョン:** **9.1.0 以上** — family（8.14.4）からの **メジャー上げ（Java 25 対応のため必須）**。
+JDK 25 上で Gradle daemon を動かすには **Gradle 9.1.0 以降**が必要（8.14.4 / 9.0.0 は JDK 25 非対応）。
+`id 'jacoco'` plugin で coverage を取得（Phase 1 はゲートなし・レポート出力のみ）。
+
+### 2-4. 認証・認可（★S軸）
+
+- **Spring Security + JWT（jjwt）** — sns-board / slack-board と同方針
+  - アルゴリズム: **HS256**（HMAC-SHA256）
+  - **JWT in HttpOnly Cookie**（access 短命 + refresh DB rotation + reuse detection、母 SEC-7）
+  - **DB rotation**: `refresh_tokens` テーブルに SHA-256 hash を保存、refresh ごとに使い捨て rotation
+- **RBAC**：ロール（受講生 / 講師）をロールベースで一元判定（母 SEC-4）。最終評価・承認（`F-EVAL-01`）は講師ロール限定
+- **IDOR 対策**：所有者 / cohort 一致をバックエンドで必ず検証、不一致は 404（母 SEC-2/3）
+- **監査ログ**：`audit_logs` に「誰が・いつ・誰の資源に・何をしたか」を記録（S基準）
+
+### 2-5. 依存脆弱性スキャン（★S軸・CI 常設）
+
+- バックエンド: **OWASP dependency-check**（Gradle plugin）で High/Critical 0 件を維持
+- フロントエンド: **`npm audit`** を CI に常設
+- 要件定義書 §4-1 の S基準（High/Critical 0 件維持）に対応
+
+### 2-6. ストレージ（成果物スクリーンショット）
+
+- ローカル: **MinIO**（S3 互換、Docker）。API 9002 / Console 9003（要件定義書 ローカルポート表）
+- 本番: **AWS S3**（Phase 3）
+- 連携: **AWS SDK for Java v2**（`software.amazon.awssdk:s3`、2.x）
+- 画像は外部ストレージに保存し DB 肥大化を回避（母 P-10・SEC-8）
+
+### 2-7. API ドキュメント・ログ
+
+- **SpringDoc OpenAPI**（2.x）— family 同一
+- **構造化ログ**：Spring Boot 3.5 ネイティブ ECS フォーマット（`logging.structured.format.console=ecs`）
+
+---
+
+## 3. フロントエンドの採用技術
+
+> **全面的に slack-board / sns-board と同一**（WebSocket / 動画 / Slack 固有要素を除く）。
+
+- **React 19.2.5** + **React Router 7.x**
+- **Vite 8.0.10**（ビルド・dev サーバー、ポート 5175）
+- **Tailwind CSS 4.2.4**（`@tailwindcss/vite` プラグイン経由）
+- **Axios 1.15.2**（HTTP 通信。Vite プロキシで `/api` → `http://localhost:8082`）
+- **Lucide React**（アイコン）
+- **DOMPurify**（★UGC の XSS 対策）：レビュー本文・説明文など利用者入力をサニタイズ（要件定義書 §1-2）
+- **TanStack Query**（5.x、Phase 2+ のデータフェッチ・キャッシュ）
+- カバレッジ: **Vitest** + `@vitest/coverage-v8`（Phase 1 はゲートなし・レポートのみ）
+
+---
+
+## 4. インフラ・環境設定
+
+### ローカル開発ポート（要件定義書 準拠 / task-board・sns-board と分離）
+
+| サービス | コマンド | ポート |
+|---|---|---|
+| Backend (Spring Boot) | `./gradlew bootRun` | **8082** |
+| Frontend (Vite) | `npm run dev` | **5175** |
+| PostgreSQL | `docker-compose up` | **5434** |
+| MinIO API | （Docker） | 9002 |
+| MinIO Console | （Docker） | 9003 |
+
+> CORS（許可 origin）・Vite プロキシ（転送先）は上記ポートで固定。別ポート起動は禁止（CLAUDE.md §10）。
+
+### EC2 デプロイ（Phase 3）
+
+EC2 起動時に **Java 25（Amazon Corretto LTS）/ Node.js 22 / Docker / Docker Compose / Git** を
+セットアップ + リポジトリ clone。**Java バージョンは §2-1 / §5 / §8 と完全一致させる**（M-14）。
+無料枠の範囲内で運用（要件定義書 §2-2、月 $0.50 以下）。CloudFront / WAF は学習簡素化のため対象外。
+
+---
+
+## 5. 採用技術一覧（まとめ）
+
+> **凡例:** `✅ 同一` = family（slack-board / sns-board）とバージョン一致。`🔼 差分` = 本アプリ固有で変更。`➕ 追加` = family に無い採用。`➖ 不採用` = family にあるが本アプリでは外す。
+
+| カテゴリ | 採用ツール | バージョン | family との関係 |
+|---|---|---|---|
+| **バックエンド** | | | |
+| 言語 | Java | **25**（LTS, Corretto）| 🔼 差分（family 21・先行採用） |
+| フレームワーク | Spring Boot | **3.5.5** | 🔼 差分（family 3.5.0・Java 25 対応） |
+| ビルドツール | Gradle | **9.1.0+** | 🔼 差分（family 8.14.4・JDK 25 対応） |
+| ORM | Spring Data JPA + Hibernate | Spring Boot 内蔵 | ✅ 同一 |
+| 認証 | Spring Security + JWT (jjwt) | Spring Boot 内蔵 + jjwt 最新 | ✅ 同一 |
+| **認可 (RBAC/IDOR)** | Spring Security `@PreAuthorize` + 所有者/cohort 検証 | Spring Boot 内蔵 | ➕ 追加（★S軸の中核） |
+| DB マイグレーション | Flyway | Spring Boot 内蔵 | ✅ 同一 |
+| 依存脆弱性スキャン | OWASP dependency-check | Gradle plugin | ➕ 追加（★S軸・CI 常設） |
+| ストレージ連携 | AWS SDK for Java v2 (s3) | 2.x | ✅ 同一 |
+| API ドキュメント | SpringDoc OpenAPI | 2.x | ✅ 同一 |
+| 構造化ログ | Spring Boot 3.5 ネイティブ ECS | Spring Boot 内蔵 | ✅ 同一 |
+| カバレッジ | JaCoCo | Gradle plugin | ✅ 同一 |
+| WebSocket / STOMP | — | — | ➖ 不採用（リアルタイム対象外・§5） |
+| 動画検証 (jave-core) | — | — | ➖ 不採用（成果物は URL+スクショ） |
+| **フロントエンド** | | | |
+| 言語 | JavaScript | ES2022 相当 | ✅ 同一 |
+| UI ライブラリ | React | **19.2.5** | ✅ 同一 |
+| ルーター | React Router | 7.x | ✅ 同一 |
+| ビルドツール | Vite | **8.0.10** | ✅ 同一 |
+| CSS | Tailwind CSS | **4.2.4** | ✅ 同一 |
+| HTTP 通信 | Axios | **1.15.2** | ✅ 同一 |
+| サニタイズ | DOMPurify | 最新 | ➕ 追加（UGC の XSS 対策） |
+| データフェッチ | TanStack Query (Phase 2+) | 5.x | ✅ 同一 |
+| アイコン | Lucide React | 最新 | ✅ 同一 |
+| カバレッジ | Vitest + coverage-v8 | 最新 | ✅ 同一 |
+| **インフラ** | | | |
+| DB | PostgreSQL (Docker) | 16 | ✅ 同一 |
+| ストレージ | MinIO(ローカル) / S3(本番) | — | ✅ 同一 |
+
+---
+
+## 6. 不採用技術とその理由
+
+| 技術 | 不採用の理由 |
+|---|---|
+| Spring Boot 4.0.x | Java 25 ファーストクラス対応で魅力的だが、family（3.5 系）から乖離が大きく学習資産・参考資料の流用が減る。継承重視で 3.5.5 を選択（差分最小） |
+| WebSocket / STOMP / SockJS | リアルタイム通信は対象外（要件定義書 §5）。通知は Phase 2 でポーリング/簡易方式から検討 |
+| 動画処理 (FFmpeg / jave-core) | 成果物は「URL + スクショ + 説明 + タイトル」の1形式（`F-POST-01`）。動画は扱わない |
+| marked（Markdown レンダリング） | Phase 1 のレビュー本文は構造化フォーム + 自由記述で足り、Markdown 描画は不要。導入時は DOMPurify と必ずセット（XSS） |
+| CloudFront / WAF | 学習目的のインフラ簡素化（要件定義書 §2-2・§5）。簡素化の事実として明記 |
+
+---
+
+## 7. 外部ライブラリ・依存関係
+
+- バックエンドは原則 **Spring Boot 管理下のバージョン**に従う（BOM 準拠）。`jjwt` のみ最新を明示指定
+- フロントエンドの正確なバージョンは `package.json` 起こし時に固定（family の lockfile を起点に）
+- すべての依存は §2-5 の脆弱性スキャン対象。High/Critical は 0 件を維持（★S軸）
+
+---
+
+## 8. M-14：Toolchain と実行ランタイムの整合（最重要）
+
+> 母 M-14。**「ビルド時に使う Java」と「本番 EC2 で動かす Java」を完全一致**させる。
+> 不一致は「ローカルでは通るが本番で落ちる」級の事故源。
+
+### 整合ルール（review-board）
+
+| 箇所 | 値 | 確認方法 |
+|---|---|---|
+| Gradle toolchain（`build.gradle` の `languageVersion`）| **Java 25** | ビルド設定で固定 |
+| Gradle 本体 | **9.1.0+** | `./gradlew --version`（JDK 25 で daemon 起動可） |
+| Spring Boot | **3.5.5** | `dependencies` で固定 |
+| EC2 ランタイム（user_data）| **Amazon Corretto 25** | EC2 上で `java -version` |
+
+### 教訓（family の失敗を踏まない）
+
+sns-board は技術スタック §2-1 で「Java 21」と宣言しながら、EC2 user_data では「Java 25」で起動しており、
+**宣言と実行ランタイムが食い違っている**（M-14 が警戒する典型）。review-board では本表のとおり
+**全箇所を Java 25 に統一**し、ドキュメント・ビルド設定・EC2 起動スクリプトの三者が一致することを
+デプロイ前に必ず確認する（要件定義書 §7 監査チェックリストに追加）。
+
+---
+
+## 関連ドキュメント
+
+- [要件定義書](./要件定義書.md) — §2-3 技術スタック・§1-6 指導理念
+- [機能一覧.md](./機能一覧.md) — API エンドポイント詳細（後日作成）
+- [ER図.md](./ER図.md) — テーブル定義（後日作成）
+- [画面設計書.md](./画面設計書.md) — 画面一覧・遷移図（後日作成）
+- [母要件定義書](../../母要件定義書.md) — M-14・SEC・P 各要件の原典


### PR DESCRIPTION
## 概要
review-board の技術スタック.md を作成。slack-board / sns-board を雛形に特化させた。

## 確定スタック（事実確認済み）
| 項目 | review-board | family | 差分理由 |
|---|---|---|---|
| Java | **25 (LTS, Corretto)** | 21 | 学習の先行採用（§1-6） |
| Spring Boot | **3.5.5** | 3.5.0 | Java 25 対応の最小パッチ上げ |
| Gradle | **9.1.0+** | 8.14.4 | JDK 25 で動く最小版 |
| React/Vite/Tailwind/JWT/Flyway 等 | 同一 | 同一 | 継承 |

## review-board 固有
- **重点軸（セキュリティ・認可）の強化**：Spring Security RBAC + 所有者/cohort 検証（IDOR）、OWASP dependency-check、DOMPurify、監査ログ
- **WebSocket / 動画は不採用**（リアルタイム・動画は対象外）
- **§8 M-14**：toolchain と EC2 ランタイムを Java 25 に統一。sns-board の「宣言21/実行25」矛盾を踏まないことを教訓化

## 確認事項
- [x] Spring Boot 3.5.5 / Gradle 9.1.0+ の Java 25 対応を一次情報で確認
- [x] family との差分・理由を §5/§6 に明記

Closes #75