### PR TITLE
feat: F-AUTH 認証フロー（JWT in HttpOnly Cookie）を実装

### DIFF
--- a/review-board/backend/build.gradle
+++ b/review-board/backend/build.gradle
@@ -56,13 +56,22 @@ tasks.named('test') {
 	useJUnitPlatform()
 	// env-var 駆動の application.yml（${DATABASE_PASSWORD} 等、fail-fast）を test fork に継承。
 	// 必要な key のみ allow-list で渡し、機密が test heap に乗らないようにする。
+	// DOCKER_API_VERSION: Testcontainers(docker-java) が daemon の対応上限を超える API
+	// バージョンを要求して 400 になる環境向けの安全弁（設定時のみ伝播。未設定なら無影響）。
 	['DATABASE_URL', 'DATABASE_USERNAME', 'DATABASE_PASSWORD',
-	 'JWT_SECRET', 'JWT_COOKIE_SECURE', 'SPRING_PROFILES_ACTIVE'].each { key ->
+	 'JWT_SECRET', 'JWT_COOKIE_SECURE', 'SPRING_PROFILES_ACTIVE',
+	 'DOCKER_API_VERSION'].each { key ->
 		def value = System.getenv(key)
 		if (value != null) {
 			environment key, value
 		}
 	}
+	// Testcontainers(docker-java) は新しめの API バージョンを要求し、Docker Desktop の対応上限を
+	// 超えると /info が 400 になって "Could not find a valid Docker environment" で失敗する。
+	// docker-java が直接読む system property `api.version` で保守的な版に固定して回避する。
+	// 既定 1.44 は daemon 最小要件(1.40)以上で広く互換。新しい daemon に合わせたい場合は
+	// DOCKER_API_VERSION env で上書き可能。
+	systemProperty 'api.version', System.getenv('DOCKER_API_VERSION') ?: '1.44'
 	finalizedBy jacocoTestReport
 }
 

--- a/review-board/backend/src/main/java/com/reviewboard/ReviewBoardApplication.java
+++ b/review-board/backend/src/main/java/com/reviewboard/ReviewBoardApplication.java
@@ -2,12 +2,14 @@ package com.reviewboard;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 /**
  * review-board バックエンドのエントリポイント。
  * 成長支援型レビューコミュニティ（クローズド・cohort 境界・S軸＝認可）。
  */
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class ReviewBoardApplication {
 
     public static void main(String[] args) {

--- a/review-board/backend/src/main/java/com/reviewboard/common/GlobalExceptionHandler.java
+++ b/review-board/backend/src/main/java/com/reviewboard/common/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.reviewboard.common;
 
+import com.reviewboard.domain.auth.BadCredentialsException;
+import com.reviewboard.domain.auth.InvalidRefreshTokenException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -39,5 +41,19 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiError> handleUnauthenticated(AuthenticationCredentialsNotFoundException ex) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(ApiError.of("UNAUTHORIZED", "ログインが必要です"));
+    }
+
+    /** ログイン認証失敗（401・存在を漏らさない汎用メッセージ） */
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<ApiError> handleBadCredentials(BadCredentialsException ex) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ApiError.of("BAD_CREDENTIALS", ex.getMessage()));
+    }
+
+    /** refresh トークン無効（401・未知/期限切れ/reuse 検知） */
+    @ExceptionHandler(InvalidRefreshTokenException.class)
+    public ResponseEntity<ApiError> handleInvalidRefresh(InvalidRefreshTokenException ex) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ApiError.of("INVALID_REFRESH_TOKEN", "再ログインが必要です"));
     }
 }

--- a/review-board/backend/src/main/java/com/reviewboard/config/DevDataSeeder.java
+++ b/review-board/backend/src/main/java/com/reviewboard/config/DevDataSeeder.java
@@ -1,0 +1,75 @@
+package com.reviewboard.config;
+
+import com.reviewboard.domain.cohort.Cohort;
+import com.reviewboard.domain.cohort.CohortRepository;
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRepository;
+import com.reviewboard.domain.user.UserRole;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 開発環境専用のシードデータ（dev プロファイルのみ）。
+ * users が空のときだけ cohort + 講師1 + 受講生1 を作成する。
+ * パスワードは {@code SEED_PASSWORD} 環境変数から取得（未設定なら何もしない＝機密ハードコード禁止）。
+ */
+@Component
+@Profile("dev")
+public class DevDataSeeder implements CommandLineRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(DevDataSeeder.class);
+
+    private final CohortRepository cohortRepository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final String seedPassword;
+
+    public DevDataSeeder(CohortRepository cohortRepository, UserRepository userRepository,
+                         PasswordEncoder passwordEncoder,
+                         @Value("${SEED_PASSWORD:}") String seedPassword) {
+        this.cohortRepository = cohortRepository;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.seedPassword = seedPassword;
+    }
+
+    @Override
+    public void run(String... args) {
+        if (userRepository.count() > 0) {
+            return;
+        }
+        if (seedPassword == null || seedPassword.isBlank()) {
+            log.warn("[dev seed] SEED_PASSWORD 未設定のためシードをスキップしました");
+            return;
+        }
+
+        OffsetDateTime now = OffsetDateTime.now();
+        Cohort cohort = new Cohort();
+        cohort.setName("2026 期 A");
+        cohort.setCreatedAt(now);
+        cohort = cohortRepository.save(cohort);
+
+        userRepository.save(newUser("teacher@example.com", "講師ティーチャー", UserRole.TEACHER, cohort.getId(), now));
+        userRepository.save(newUser("student@example.com", "受講生スチューデント", UserRole.STUDENT, cohort.getId(), now));
+        log.info("[dev seed] cohort + 講師/受講生 を作成しました（cohortId={}）", cohort.getId());
+    }
+
+    private User newUser(String email, String displayName, UserRole role, Long cohortId, OffsetDateTime now) {
+        User user = new User();
+        user.setEmail(email);
+        user.setPasswordHash(passwordEncoder.encode(seedPassword));
+        user.setDisplayName(displayName);
+        user.setRole(role);
+        user.setCohortId(cohortId);
+        user.setCreatedAt(now);
+        user.setUpdatedAt(now);
+        return user;
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/config/JwtProperties.java
+++ b/review-board/backend/src/main/java/com/reviewboard/config/JwtProperties.java
@@ -1,0 +1,19 @@
+package com.reviewboard.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * JWT 設定（application.yml の app.jwt.*。env 駆動）。
+ *
+ * @param secret           HS256 署名鍵（32 文字以上＝256bit 以上必須。env で注入）
+ * @param accessTtlSeconds access トークン寿命（短命）
+ * @param refreshTtlSeconds refresh トークン寿命
+ * @param cookieSecure     Cookie の Secure 属性（本番は true、ローカルは false）
+ */
+@ConfigurationProperties(prefix = "app.jwt")
+public record JwtProperties(
+        String secret,
+        long accessTtlSeconds,
+        long refreshTtlSeconds,
+        boolean cookieSecure) {
+}

--- a/review-board/backend/src/main/java/com/reviewboard/config/SecurityConfig.java
+++ b/review-board/backend/src/main/java/com/reviewboard/config/SecurityConfig.java
@@ -1,44 +1,69 @@
 package com.reviewboard.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.reviewboard.common.ApiError;
+import com.reviewboard.domain.auth.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 /**
- * ★S軸の中核。RBAC + ステートレス認可の土台。
+ * ★S軸の中核。RBAC + ステートレス認可。
  *
- * <p>方針（要件定義書 §3-2・テスト計画書 §6）：
  * <ul>
- *   <li>セッションは持たない（STATELESS）。認証は JWT in HttpOnly Cookie（後続 PR で JWT フィルタを追加）。</li>
- *   <li>ロール別の細かい認可はメソッドレベル（{@code @PreAuthorize}）で行うため EnableMethodSecurity。</li>
- *   <li>{@code /actuator/health} と将来のログインのみ公開、それ以外は認証必須。</li>
+ *   <li>セッションは持たない（STATELESS）。認証は JWT in HttpOnly Cookie（{@link JwtAuthenticationFilter}）。</li>
+ *   <li>ロール別の細かい認可はメソッドレベル（{@code @PreAuthorize}）で行う。</li>
+ *   <li>未認証は 401・認可不可は 403 を JSON で返す（機能一覧.md §共通仕様）。</li>
  * </ul>
  */
 @Configuration
 @EnableMethodSecurity
 public class SecurityConfig {
 
+    private final ObjectMapper objectMapper;
+
+    public SecurityConfig(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http, JwtAuthenticationFilter jwtFilter) throws Exception {
         http
-            // CorsConfigurationSource Bean（CorsConfig）を使う
             .cors(Customizer.withDefaults())
-            // TODO(Phase1 認証PR): JWT in HttpOnly Cookie のため、CSRF は SameSite Cookie +
-            // 同期トークン方式で別途対策する（テスト計画書 §7）。雛形段階では一旦無効化。
+            // JWT in HttpOnly Cookie + SameSite=Strict 方式。CSRF は SameSite で緩和する
+            // （ステートレス API のため CSRF トークンは持たない。テスト計画書 §7）。
             .csrf(csrf -> csrf.disable())
             .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/actuator/health", "/api/auth/login").permitAll()
+                .requestMatchers("/actuator/health",
+                        "/api/auth/login", "/api/auth/refresh", "/api/auth/logout").permitAll()
                 .anyRequest().authenticated())
+            .exceptionHandling(ex -> ex
+                .authenticationEntryPoint((req, res, e) ->
+                        writeError(res, HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "ログインが必要です"))
+                .accessDeniedHandler((req, res, e) ->
+                        writeError(res, HttpStatus.FORBIDDEN, "FORBIDDEN", "この操作を行う権限がありません")))
             .httpBasic(basic -> basic.disable())
-            .formLogin(form -> form.disable());
+            .formLogin(form -> form.disable())
+            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
+    }
+
+    private void writeError(jakarta.servlet.http.HttpServletResponse res, HttpStatus status,
+                            String code, String message) throws java.io.IOException {
+        res.setStatus(status.value());
+        res.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        res.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(res.getWriter(), ApiError.of(code, message));
     }
 
     /** パスワードは bcrypt でハッシュ化（ER図 §3-1）。 */

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/AuthController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/AuthController.java
@@ -1,0 +1,73 @@
+package com.reviewboard.domain.auth;
+
+import com.reviewboard.domain.auth.dto.LoginRequest;
+import com.reviewboard.domain.auth.dto.UserResponse;
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRepository;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 認証 API（F-AUTH）。トークンは HttpOnly Cookie で受け渡し、レスポンス body には載せない。
+ */
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+    private final AuthCookies cookies;
+    private final UserRepository userRepository;
+
+    public AuthController(AuthService authService, AuthCookies cookies, UserRepository userRepository) {
+        this.authService = authService;
+        this.cookies = cookies;
+        this.userRepository = userRepository;
+    }
+
+    /** F-AUTH-01 ログイン */
+    @PostMapping("/login")
+    public ResponseEntity<UserResponse> login(@Valid @RequestBody LoginRequest request) {
+        AuthService.LoginResult result = authService.login(request.email(), request.password());
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookies.access(result.accessToken()).toString())
+                .header(HttpHeaders.SET_COOKIE, cookies.refresh(result.refreshToken()).toString())
+                .body(UserResponse.from(result.user()));
+    }
+
+    /** F-AUTH-(extra) リフレッシュ（access 再発行 + refresh rotation） */
+    @PostMapping("/refresh")
+    public ResponseEntity<Void> refresh(
+            @CookieValue(name = AuthCookies.REFRESH, required = false) String refreshToken) {
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw new InvalidRefreshTokenException("missing refresh token");
+        }
+        AuthService.RefreshResult result = authService.refresh(refreshToken);
+        return ResponseEntity.noContent()
+                .header(HttpHeaders.SET_COOKIE, cookies.access(result.accessToken()).toString())
+                .header(HttpHeaders.SET_COOKIE, cookies.refresh(result.refreshToken()).toString())
+                .build();
+    }
+
+    /** F-AUTH-03 ログアウト（refresh 失効 + Cookie 削除） */
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(
+            @CookieValue(name = AuthCookies.REFRESH, required = false) String refreshToken) {
+        authService.logout(refreshToken);
+        return ResponseEntity.noContent()
+                .header(HttpHeaders.SET_COOKIE, cookies.clearAccess().toString())
+                .header(HttpHeaders.SET_COOKIE, cookies.clearRefresh().toString())
+                .build();
+    }
+
+    /** 認証確認（現在のログインユーザー）。未認証なら SecurityConfig が 401 を返す。 */
+    @GetMapping("/me")
+    public UserResponse me(@AuthenticationPrincipal AuthPrincipal principal) {
+        User user = userRepository.findById(principal.userId())
+                .orElseThrow(() -> new IllegalStateException("authenticated user not found"));
+        return UserResponse.from(user);
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/AuthCookies.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/AuthCookies.java
@@ -1,0 +1,50 @@
+package com.reviewboard.domain.auth;
+
+import com.reviewboard.config.JwtProperties;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+/**
+ * 認証 Cookie（HttpOnly + Secure + SameSite=Strict）の組み立て。
+ * SameSite=Strict で CSRF を緩和する（テスト計画書 §7）。
+ */
+@Component
+public class AuthCookies {
+
+    public static final String ACCESS = "access_token";
+    public static final String REFRESH = "refresh_token";
+    /** refresh は認証エンドポイントにのみ送られれば十分（露出面を狭める） */
+    private static final String REFRESH_PATH = "/api/auth";
+
+    private final JwtProperties props;
+
+    public AuthCookies(JwtProperties props) {
+        this.props = props;
+    }
+
+    public ResponseCookie access(String token) {
+        return base(ACCESS, token, "/", props.accessTtlSeconds());
+    }
+
+    public ResponseCookie refresh(String token) {
+        return base(REFRESH, token, REFRESH_PATH, props.refreshTtlSeconds());
+    }
+
+    public ResponseCookie clearAccess() {
+        return base(ACCESS, "", "/", 0);
+    }
+
+    public ResponseCookie clearRefresh() {
+        return base(REFRESH, "", REFRESH_PATH, 0);
+    }
+
+    private ResponseCookie base(String name, String value, String path, long maxAgeSeconds) {
+        return ResponseCookie.from(name, value)
+                .httpOnly(true)
+                .secure(props.cookieSecure())
+                .sameSite("Strict")
+                .path(path)
+                .maxAge(maxAgeSeconds)
+                .build();
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/AuthPrincipal.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/AuthPrincipal.java
@@ -1,0 +1,11 @@
+package com.reviewboard.domain.auth;
+
+import com.reviewboard.domain.user.UserRole;
+
+/**
+ * 認証済みユーザーの最小情報。SecurityContext の principal として保持し、
+ * 各サービスが cohort 境界・所有者・ロールを判定するために使う（★S軸）。
+ * クライアント入力ではなく、検証済み access トークンから導出する。
+ */
+public record AuthPrincipal(Long userId, Long cohortId, UserRole role) {
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/AuthService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/AuthService.java
@@ -1,0 +1,64 @@
+package com.reviewboard.domain.auth;
+
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 認証フローのオーケストレーション（F-AUTH）。
+ * トークンの生成・rotation は専用サービスに委譲し、ここは「誰を認証したか」を担う。
+ */
+@Service
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtService jwtService;
+    private final RefreshTokenService refreshTokenService;
+
+    public AuthService(UserRepository userRepository, PasswordEncoder passwordEncoder,
+                       JwtService jwtService, RefreshTokenService refreshTokenService) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtService = jwtService;
+        this.refreshTokenService = refreshTokenService;
+    }
+
+    /** F-AUTH-01 ログイン。失敗は存在を漏らさない汎用エラー（BadCredentials）。 */
+    @Transactional
+    public LoginResult login(String email, String rawPassword) {
+        User user = userRepository.findByEmail(email).orElseThrow(BadCredentialsException::new);
+        if (!passwordEncoder.matches(rawPassword, user.getPasswordHash())) {
+            throw new BadCredentialsException();
+        }
+        String access = jwtService.issueAccessToken(user.getId(), user.getRole(), user.getCohortId());
+        String refresh = refreshTokenService.issue(user.getId());
+        return new LoginResult(user, access, refresh);
+    }
+
+    /** F-AUTH-(extra) リフレッシュ。rotation + reuse 検知は RefreshTokenService が担う。 */
+    @Transactional
+    public RefreshResult refresh(String rawRefreshToken) {
+        RefreshTokenService.RotationResult rotation = refreshTokenService.rotate(rawRefreshToken);
+        User user = userRepository.findById(rotation.userId())
+                .orElseThrow(() -> new InvalidRefreshTokenException("user not found"));
+        String access = jwtService.issueAccessToken(user.getId(), user.getRole(), user.getCohortId());
+        return new RefreshResult(access, rotation.newRawToken());
+    }
+
+    /** F-AUTH-03 ログアウト。 */
+    @Transactional
+    public void logout(String rawRefreshToken) {
+        if (rawRefreshToken != null && !rawRefreshToken.isBlank()) {
+            refreshTokenService.revoke(rawRefreshToken);
+        }
+    }
+
+    public record LoginResult(User user, String accessToken, String refreshToken) {
+    }
+
+    public record RefreshResult(String accessToken, String refreshToken) {
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/BadCredentialsException.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/BadCredentialsException.java
@@ -1,0 +1,11 @@
+package com.reviewboard.domain.auth;
+
+/**
+ * ログイン認証失敗。ユーザー存在を漏らさない汎用エラー（列挙攻撃対策・画面設計書 S-01）。
+ * 401 に倒す。
+ */
+public class BadCredentialsException extends RuntimeException {
+    public BadCredentialsException() {
+        super("メールアドレスまたはパスワードが正しくありません");
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/InvalidRefreshTokenException.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/InvalidRefreshTokenException.java
@@ -1,0 +1,8 @@
+package com.reviewboard.domain.auth;
+
+/** refresh トークンが無効（未知・期限切れ・reuse 検知）。401 に倒す。 */
+public class InvalidRefreshTokenException extends RuntimeException {
+    public InvalidRefreshTokenException(String message) {
+        super(message);
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/JwtAuthenticationFilter.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,64 @@
+package com.reviewboard.domain.auth;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * access トークン（HttpOnly Cookie）を検証して SecurityContext を確立する。
+ * トークンが無い/不正なら認証を設定しないだけ（認可は後段で 401/403 を返す）。
+ * ロールは {@code ROLE_STUDENT} / {@code ROLE_TEACHER} の権限に写す（RBAC）。
+ */
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+
+    public JwtAuthenticationFilter(JwtService jwtService) {
+        this.jwtService = jwtService;
+    }
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain)
+            throws ServletException, IOException {
+        String token = readAccessCookie(request);
+        if (token != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            try {
+                AuthPrincipal principal = jwtService.parse(token);
+                var authority = new SimpleGrantedAuthority("ROLE_" + principal.role().name());
+                var authentication = new UsernamePasswordAuthenticationToken(
+                        principal, null, List.of(authority));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (Exception ignored) {
+                // 署名不正・期限切れ等は未認証扱い（SecurityContext を設定しない）
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String readAccessCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return null;
+        }
+        for (Cookie c : cookies) {
+            if (AuthCookies.ACCESS.equals(c.getName())) {
+                return c.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/JwtService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/JwtService.java
@@ -1,0 +1,64 @@
+package com.reviewboard.domain.auth;
+
+import com.reviewboard.config.JwtProperties;
+import com.reviewboard.domain.user.UserRole;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+
+/**
+ * access トークン（JWT・HS256）の発行と検証。
+ * 認可に必要な userId / role / cohortId をクレームに載せる（クライアント入力を信用しない）。
+ */
+@Service
+public class JwtService {
+
+    private final SecretKey key;
+    private final long accessTtlSeconds;
+
+    public JwtService(JwtProperties props) {
+        byte[] secretBytes = props.secret().getBytes(StandardCharsets.UTF_8);
+        if (secretBytes.length < 32) {
+            // HS256 は 256bit 以上必須。短い秘密は起動時に弾く（fail-fast）。
+            throw new IllegalStateException("app.jwt.secret は 32 文字（256bit）以上にしてください");
+        }
+        this.key = Keys.hmacShaKeyFor(secretBytes);
+        this.accessTtlSeconds = props.accessTtlSeconds();
+    }
+
+    /** access トークンを発行する。 */
+    public String issueAccessToken(Long userId, UserRole role, Long cohortId) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim("role", role.name())
+                .claim("cohortId", cohortId)
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plusSeconds(accessTtlSeconds)))
+                .signWith(key)
+                .compact();
+    }
+
+    /**
+     * access トークンを検証して principal を取り出す。
+     * 署名不正・期限切れ等は {@link JwtException} 系で失敗（呼び出し側で握って未認証扱い）。
+     */
+    public AuthPrincipal parse(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+        Long userId = Long.valueOf(claims.getSubject());
+        UserRole role = UserRole.valueOf(claims.get("role", String.class));
+        Long cohortId = claims.get("cohortId", Number.class).longValue();
+        return new AuthPrincipal(userId, cohortId, role);
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/RefreshTokenRepository.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/RefreshTokenRepository.java
@@ -1,10 +1,19 @@
 package com.reviewboard.domain.auth;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.OffsetDateTime;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
     Optional<RefreshToken> findByTokenHash(String tokenHash);
+
+    /** reuse 検知時：当該ユーザーの未失効トークンを一括失効（盗用への防御・母 SEC-7） */
+    @Modifying
+    @Query("UPDATE RefreshToken r SET r.revokedAt = :now WHERE r.userId = :userId AND r.revokedAt IS NULL")
+    int revokeAllActiveByUserId(@Param("userId") Long userId, @Param("now") OffsetDateTime now);
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/RefreshTokenService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/RefreshTokenService.java
@@ -1,0 +1,102 @@
+package com.reviewboard.domain.auth;
+
+import com.reviewboard.config.JwtProperties;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.time.OffsetDateTime;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.Optional;
+
+/**
+ * refresh トークンの発行・rotation・revoke・reuse 検知（母 SEC-7）。
+ *
+ * <p>平文は保存せず SHA-256 ハッシュのみ DB に持つ。refresh のたびに使い捨て rotation。
+ * 既に失効済みのトークンが再提示されたら「盗用（reuse）」とみなし、当該ユーザーの
+ * 全トークンを失効させる。
+ */
+@Service
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository repository;
+    private final long refreshTtlSeconds;
+    private final SecureRandom random = new SecureRandom();
+
+    public RefreshTokenService(RefreshTokenRepository repository, JwtProperties props) {
+        this.repository = repository;
+        this.refreshTtlSeconds = props.refreshTtlSeconds();
+    }
+
+    /** 新規 refresh トークンを発行し、生トークン（Cookie 用）を返す。DB にはハッシュを保存。 */
+    @Transactional
+    public String issue(Long userId) {
+        String raw = randomToken();
+        RefreshToken token = new RefreshToken();
+        token.setUserId(userId);
+        token.setTokenHash(sha256(raw));
+        OffsetDateTime now = OffsetDateTime.now();
+        token.setCreatedAt(now);
+        token.setExpiresAt(now.plusSeconds(refreshTtlSeconds));
+        repository.save(token);
+        return raw;
+    }
+
+    /**
+     * rotation：生トークンを検証し、有効なら失効させて新トークンを発行する。
+     *
+     * @return 新しい生 refresh トークン
+     * @throws InvalidRefreshTokenException 未知/期限切れ、または reuse 検知時
+     */
+    @Transactional
+    public RotationResult rotate(String rawToken) {
+        RefreshToken stored = repository.findByTokenHash(sha256(rawToken))
+                .orElseThrow(() -> new InvalidRefreshTokenException("unknown refresh token"));
+
+        if (stored.getRevokedAt() != null) {
+            // 失効済みトークンの再提示 ＝ 盗用の疑い。当該ユーザーの全トークンを失効。
+            repository.revokeAllActiveByUserId(stored.getUserId(), OffsetDateTime.now());
+            throw new InvalidRefreshTokenException("refresh token reuse detected");
+        }
+        if (stored.getExpiresAt().isBefore(OffsetDateTime.now())) {
+            throw new InvalidRefreshTokenException("refresh token expired");
+        }
+
+        stored.setRevokedAt(OffsetDateTime.now());
+        String newRaw = issue(stored.getUserId());
+        return new RotationResult(stored.getUserId(), newRaw);
+    }
+
+    /** ログアウト：当該トークンを失効（未知でも黙って成功＝列挙を防ぐ）。 */
+    @Transactional
+    public void revoke(String rawToken) {
+        Optional<RefreshToken> stored = repository.findByTokenHash(sha256(rawToken));
+        stored.ifPresent(t -> {
+            if (t.getRevokedAt() == null) {
+                t.setRevokedAt(OffsetDateTime.now());
+            }
+        });
+    }
+
+    public record RotationResult(Long userId, String newRawToken) {
+    }
+
+    private String randomToken() {
+        byte[] bytes = new byte[32];
+        random.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private String sha256(String value) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] hash = md.digest(value.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash); // 64 文字 hex（refresh_tokens.token_hash CHAR(64)）
+        } catch (Exception e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/dto/LoginRequest.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/dto/LoginRequest.java
@@ -1,0 +1,9 @@
+package com.reviewboard.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank @Email String email,
+        @NotBlank String password) {
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/dto/UserResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/dto/UserResponse.java
@@ -1,0 +1,12 @@
+package com.reviewboard.domain.auth.dto;
+
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRole;
+
+/** 認証後にフロントへ返す最小ユーザー情報（パスワード等は含めない）。 */
+public record UserResponse(Long id, String displayName, UserRole role, Long cohortId) {
+
+    public static UserResponse from(User user) {
+        return new UserResponse(user.getId(), user.getDisplayName(), user.getRole(), user.getCohortId());
+    }
+}

--- a/review-board/backend/src/test/java/com/reviewboard/domain/auth/AuthIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/auth/AuthIntegrationTest.java
@@ -1,0 +1,114 @@
+package com.reviewboard.domain.auth;
+
+import com.reviewboard.domain.cohort.Cohort;
+import com.reviewboard.domain.cohort.CohortRepository;
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRepository;
+import com.reviewboard.domain.user.UserRole;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * F-AUTH の認可テスト（テスト計画書 §6 マトリクスの認証部分）。
+ * Testcontainers PostgreSQL で本番同等の DB に対して検証する。
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class AuthIntegrationTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("app.jwt.secret", () -> "test-secret-please-change-32chars-minimum");
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired CohortRepository cohortRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired RefreshTokenRepository refreshTokenRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+
+    private static final String PASSWORD = "correct-horse-battery";
+
+    @BeforeEach
+    void setUp() {
+        // refresh_tokens は users への FK を持つため、user より先に消す（テスト間の分離）。
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        cohortRepository.deleteAll();
+        OffsetDateTime now = OffsetDateTime.now();
+        Cohort cohort = new Cohort();
+        cohort.setName("test cohort");
+        cohort.setCreatedAt(now);
+        cohort = cohortRepository.save(cohort);
+
+        User student = new User();
+        student.setEmail("student@example.com");
+        student.setPasswordHash(passwordEncoder.encode(PASSWORD));
+        student.setDisplayName("受講生");
+        student.setRole(UserRole.STUDENT);
+        student.setCohortId(cohort.getId());
+        student.setCreatedAt(now);
+        student.setUpdatedAt(now);
+        userRepository.save(student);
+    }
+
+    @Test
+    void login_success_setsCookie_andMeReturnsUser() throws Exception {
+        // 正常系：ログイン成功 → access_token Cookie 発行
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType("application/json")
+                        .content("{\"email\":\"student@example.com\",\"password\":\"" + PASSWORD + "\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.role").value("STUDENT"))
+                .andReturn();
+
+        Cookie access = result.getResponse().getCookie(AuthCookies.ACCESS);
+        assertThat(access).isNotNull();
+        assertThat(access.isHttpOnly()).isTrue();
+
+        // その Cookie で /me が通る（認証済み）
+        mockMvc.perform(get("/api/auth/me").cookie(access))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.role").value("STUDENT"));
+    }
+
+    @Test
+    void login_wrongPassword_returns401() throws Exception {
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType("application/json")
+                        .content("{\"email\":\"student@example.com\",\"password\":\"wrong\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void me_withoutCookie_returns401() throws Exception {
+        mockMvc.perform(get("/api/auth/me"))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## 関連 Issue

Closes #89

---

## 変更の概要

Phase 1 MVP の起点となる **F-AUTH（認証・ロール）** を実装。要件定義書 §3-2・SEC-7 準拠。

- **F-AUTH-01** ログイン（email+password → JWT in HttpOnly Cookie / access 短命）
- **F-AUTH-03** ログアウト（refresh を DB revoke + Cookie 削除）/ 全ページ認証必須（401 JSON）
- **リフレッシュ**：access 再発行 + refresh **使い捨て rotation** + **reuse 検知**（盗用時は当該ユーザー全失効）
- **JWT 認証フィルタ**：access cookie 検証 → SecurityContext に principal(userId/role/cohortId)
- **GET /api/auth/me**：認証確認
- **dev シーダー**：cohort + 講師/受講生（パスワードは `SEED_PASSWORD` env、未設定ならスキップ）

### セキュリティ（★重点軸）
- Cookie：HttpOnly + Secure(env) + **SameSite=Strict**（CSRF 緩和）。refresh は `/api/auth` パス限定で露出面を縮小
- refresh は平文非保存（**SHA-256 ハッシュ**で DB 保持）
- 未認証 401 / 認可不可 403 を JSON で返すハンドラ
- 機密の平文ハードコードなし（JWT secret / DB / seed すべて env 駆動・fail-fast）

## 変更の種別

- [x] feat（新機能の追加）
- [x] test（テストの追加・修正）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（`./gradlew test` グリーン）
- [x] 既存の機能が壊れていないことを確認した
- [x] `.env` ファイルやパスワードをコミットしていない（テスト用ダミー値のみ）

### テスト（Testcontainers PostgreSQL 16）
`AuthIntegrationTest` 3件 green：
1. ログイン成功 → access_token Cookie 発行 + `/me` 疎通
2. 誤パスワード → 401
3. Cookie なし `/me` → 401

---

## レビュー時に特に確認してほしい点

検証中に判明したローカル環境/テストの問題2点を本PRで併せて修正しています:

1. **build.gradle**：Testcontainers(docker-java) が Docker daemon の対応 API 上限を超える版を要求し `/info` が 400 →「Could not find a valid Docker environment」で失敗する事象。`api.version`（既定 1.44・`DOCKER_API_VERSION` env で上書き可）で回避。
2. **AuthIntegrationTest**：`refresh_tokens` の FK 制約を考慮し `@BeforeEach` で user より先に削除（テスト間分離）。

> reuse 検知のロジック（rotate 時の失効済みトークン再提示で全失効）と、IDOR の起点になる principal の cohortId 導出が信頼できる経路（クライアント入力ではなく検証済み JWT）かを重点的に見ていただけると助かります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)