### PR TITLE
feat: F-POST 成果物の投稿 CRUD（cohort境界・所有者認可）を実装

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/common/GlobalExceptionHandler.java
+++ b/review-board/backend/src/main/java/com/reviewboard/common/GlobalExceptionHandler.java
@@ -29,6 +29,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity.badRequest().body(ApiError.of("VALIDATION_ERROR", msg));
     }
 
+    /** リソース無し/他 cohort/他人の資源/削除済み（404・存在を漏らさず IDOR 遮断） */
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ApiError> handleNotFound(ResourceNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiError.of("NOT_FOUND", "対象が見つかりません"));
+    }
+
     /** 認可不可（403）：ロール不足など */
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<ApiError> handleAccessDenied(AccessDeniedException ex) {

--- a/review-board/backend/src/main/java/com/reviewboard/common/ResourceNotFoundException.java
+++ b/review-board/backend/src/main/java/com/reviewboard/common/ResourceNotFoundException.java
@@ -1,0 +1,15 @@
+package com.reviewboard.common;
+
+/**
+ * リソースが存在しない・所有者/cohort が一致しない・論理削除済みのときに投げる（404）。
+ *
+ * <p>★S軸：他人/他 cohort の資源は「存在しない」と同じ 404 に倒し、存在を漏らさず IDOR を遮断する
+ * （要件定義書 §3-2、母 SEC-2・SEC-3）。「権限がない（403）」と区別しないのは意図的で、
+ * リソース ID の有無を列挙させないため。
+ */
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/PostController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/PostController.java
@@ -1,0 +1,70 @@
+package com.reviewboard.domain.post;
+
+import com.reviewboard.domain.auth.AuthPrincipal;
+import com.reviewboard.domain.post.dto.PostCreateRequest;
+import com.reviewboard.domain.post.dto.PostResponse;
+import com.reviewboard.domain.post.dto.PostSummaryResponse;
+import com.reviewboard.domain.post.dto.PostUpdateRequest;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+/**
+ * 投稿 API（F-POST）。すべて認証必須（SecurityConfig の anyRequest().authenticated()）。
+ * cohort 境界・所有者の判定は {@link PostService} に集約する（★S軸・認可の一元化）。
+ */
+@RestController
+@RequestMapping("/api/posts")
+public class PostController {
+
+    private final PostService postService;
+
+    public PostController(PostService postService) {
+        this.postService = postService;
+    }
+
+    /** F-POST-01 作成 */
+    @PostMapping
+    public ResponseEntity<PostResponse> create(@AuthenticationPrincipal AuthPrincipal principal,
+                                               @Valid @RequestBody PostCreateRequest request) {
+        Post post = postService.create(principal, request);
+        return ResponseEntity.created(URI.create("/api/posts/" + post.getId()))
+                .body(PostResponse.from(post));
+    }
+
+    /** F-POST-03 一覧（同 cohort・未削除・ページネーション） */
+    @GetMapping
+    public Slice<PostSummaryResponse> list(@AuthenticationPrincipal AuthPrincipal principal,
+                                           @PageableDefault(size = 20) Pageable pageable) {
+        return postService.listForCohort(principal, pageable).map(PostSummaryResponse::from);
+    }
+
+    /** F-POST-03 単体取得 */
+    @GetMapping("/{id}")
+    public PostResponse get(@AuthenticationPrincipal AuthPrincipal principal,
+                            @PathVariable Long id) {
+        return PostResponse.from(postService.get(principal, id));
+    }
+
+    /** F-POST-02 編集（所有者のみ） */
+    @PutMapping("/{id}")
+    public PostResponse update(@AuthenticationPrincipal AuthPrincipal principal,
+                               @PathVariable Long id,
+                               @Valid @RequestBody PostUpdateRequest request) {
+        return PostResponse.from(postService.update(principal, id, request));
+    }
+
+    /** F-POST-02 論理削除（所有者のみ） */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@AuthenticationPrincipal AuthPrincipal principal,
+                                       @PathVariable Long id) {
+        postService.delete(principal, id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/PostService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/PostService.java
@@ -1,0 +1,92 @@
+package com.reviewboard.domain.post;
+
+import com.reviewboard.common.ResourceNotFoundException;
+import com.reviewboard.domain.auth.AuthPrincipal;
+import com.reviewboard.domain.post.dto.PostCreateRequest;
+import com.reviewboard.domain.post.dto.PostUpdateRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 投稿のユースケース（F-POST）。★S軸の中核：cohort 境界と所有者を必ずバックエンドで検証する。
+ *
+ * <p>取得・一覧は principal.cohortId で絞り、編集・削除は所有者（authorUserId == userId）に限定する。
+ * 境界外・他人・削除済みは存在を漏らさず {@link ResourceNotFoundException}（404）に倒す（IDOR 遮断）。
+ */
+@Service
+public class PostService {
+
+    private final PostRepository postRepository;
+
+    public PostService(PostRepository postRepository) {
+        this.postRepository = postRepository;
+    }
+
+    /** F-POST-01 作成。cohort と author は principal（検証済み）から導出する。 */
+    @Transactional
+    public Post create(AuthPrincipal principal, PostCreateRequest req) {
+        OffsetDateTime now = OffsetDateTime.now();
+        Post post = new Post();
+        post.setAuthorUserId(principal.userId());
+        post.setCohortId(principal.cohortId());
+        post.setTitle(req.title());
+        post.setDescription(req.description());
+        post.setRepoUrl(req.repoUrl());
+        post.setDemoUrl(req.demoUrl());
+        post.setScreenshotKey(req.screenshotKey());
+        post.setRecruitStatus(RecruitStatus.OPEN);
+        post.setCreatedAt(now);
+        post.setUpdatedAt(now);
+        return postRepository.save(post);
+    }
+
+    /** F-POST-03 単体取得。自 cohort かつ未削除のみ可視（他は 404）。 */
+    @Transactional(readOnly = true)
+    public Post get(AuthPrincipal principal, Long postId) {
+        return postRepository.findByIdAndCohortIdAndDeletedAtIsNull(postId, principal.cohortId())
+                .orElseThrow(() -> new ResourceNotFoundException("post not found: " + postId));
+    }
+
+    /** F-POST-03 一覧。自 cohort かつ未削除のみ。ページネーション（母 P-2）。 */
+    @Transactional(readOnly = true)
+    public Slice<Post> listForCohort(AuthPrincipal principal, Pageable pageable) {
+        return postRepository.findByCohortIdAndDeletedAtIsNull(principal.cohortId(), pageable);
+    }
+
+    /** F-POST-02 編集。所有者のみ（不一致・他 cohort・削除済みは 404）。 */
+    @Transactional
+    public Post update(AuthPrincipal principal, Long postId, PostUpdateRequest req) {
+        Post post = loadOwned(principal, postId);
+        post.setTitle(req.title());
+        post.setDescription(req.description());
+        post.setRepoUrl(req.repoUrl());
+        post.setDemoUrl(req.demoUrl());
+        post.setScreenshotKey(req.screenshotKey());
+        post.setUpdatedAt(OffsetDateTime.now());
+        return post;
+    }
+
+    /** F-POST-02 論理削除（母 S-4）。所有者のみ（不一致は 404）。 */
+    @Transactional
+    public void delete(AuthPrincipal principal, Long postId) {
+        Post post = loadOwned(principal, postId);
+        post.setDeletedAt(OffsetDateTime.now());
+    }
+
+    /**
+     * 自 cohort・未削除の投稿を取得し、所有者でなければ 404。
+     * 「他人のもの」を 403 ではなく 404 にするのは存在を漏らさないため（★S軸・IDOR）。
+     */
+    private Post loadOwned(AuthPrincipal principal, Long postId) {
+        Post post = postRepository.findByIdAndCohortIdAndDeletedAtIsNull(postId, principal.cohortId())
+                .orElseThrow(() -> new ResourceNotFoundException("post not found: " + postId));
+        if (!post.getAuthorUserId().equals(principal.userId())) {
+            throw new ResourceNotFoundException("not the owner: " + postId);
+        }
+        return post;
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostCreateRequest.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostCreateRequest.java
@@ -1,0 +1,16 @@
+package com.reviewboard.domain.post.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 投稿作成リクエスト（F-POST-01）。タイトルと説明は必須、URL/スクショキーは任意。
+ * cohort_id・author は principal（検証済み JWT）から導出し、クライアント入力は信用しない（★S軸）。
+ */
+public record PostCreateRequest(
+        @NotBlank @Size(max = 100) String title,
+        @NotBlank String description,
+        @Size(max = 512) String repoUrl,
+        @Size(max = 512) String demoUrl,
+        @Size(max = 512) String screenshotKey) {
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostResponse.java
@@ -1,0 +1,32 @@
+package com.reviewboard.domain.post.dto;
+
+import com.reviewboard.domain.post.Post;
+import com.reviewboard.domain.post.RecruitStatus;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 投稿の詳細レスポンス（F-POST-03 単体取得）。
+ */
+public record PostResponse(
+        Long id,
+        Long authorUserId,
+        Long cohortId,
+        String title,
+        String description,
+        String repoUrl,
+        String demoUrl,
+        String screenshotKey,
+        RecruitStatus recruitStatus,
+        int reviewCount,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt) {
+
+    public static PostResponse from(Post p) {
+        return new PostResponse(
+                p.getId(), p.getAuthorUserId(), p.getCohortId(),
+                p.getTitle(), p.getDescription(), p.getRepoUrl(), p.getDemoUrl(),
+                p.getScreenshotKey(), p.getRecruitStatus(), p.getReviewCount(),
+                p.getCreatedAt(), p.getUpdatedAt());
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostSummaryResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostSummaryResponse.java
@@ -1,0 +1,24 @@
+package com.reviewboard.domain.post.dto;
+
+import com.reviewboard.domain.post.Post;
+import com.reviewboard.domain.post.RecruitStatus;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 一覧用の軽量レスポンス（F-POST-03）。本文（description）は載せず転送量を抑える（母 P-2）。
+ */
+public record PostSummaryResponse(
+        Long id,
+        Long authorUserId,
+        String title,
+        RecruitStatus recruitStatus,
+        int reviewCount,
+        OffsetDateTime createdAt) {
+
+    public static PostSummaryResponse from(Post p) {
+        return new PostSummaryResponse(
+                p.getId(), p.getAuthorUserId(), p.getTitle(),
+                p.getRecruitStatus(), p.getReviewCount(), p.getCreatedAt());
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostUpdateRequest.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.reviewboard.domain.post.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 投稿更新リクエスト（F-POST-02）。所有者のみ実行可（Service で検証、不一致は 404）。
+ */
+public record PostUpdateRequest(
+        @NotBlank @Size(max = 100) String title,
+        @NotBlank String description,
+        @Size(max = 512) String repoUrl,
+        @Size(max = 512) String demoUrl,
+        @Size(max = 512) String screenshotKey) {
+}

--- a/review-board/backend/src/test/java/com/reviewboard/domain/post/PostAuthorizationIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/post/PostAuthorizationIntegrationTest.java
@@ -1,0 +1,215 @@
+package com.reviewboard.domain.post;
+
+import com.reviewboard.domain.auth.AuthCookies;
+import com.reviewboard.domain.auth.RefreshTokenRepository;
+import com.reviewboard.domain.cohort.Cohort;
+import com.reviewboard.domain.cohort.CohortRepository;
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRepository;
+import com.reviewboard.domain.user.UserRole;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * F-POST の認可テスト（★S軸の中核。テスト計画書 §6 認可マトリクスの投稿部分）。
+ *
+ * <p>cohort A（所有者 a1・同 cohort の a2）と cohort B（b1）を用意し、
+ * 所有者境界・cohort 境界・未認証を網羅する。他人/他 cohort は存在を漏らさず 404（IDOR 遮断）。
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class PostAuthorizationIntegrationTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("app.jwt.secret", () -> "test-secret-please-change-32chars-minimum");
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired CohortRepository cohortRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired PostRepository postRepository;
+    @Autowired RefreshTokenRepository refreshTokenRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+
+    private static final String PASSWORD = "correct-horse-battery";
+
+    private String a1Email;  // cohort A・投稿の所有者
+    private String a2Email;  // cohort A・別の受講生（非所有者）
+    private String b1Email;  // cohort B・別 cohort
+
+    @BeforeEach
+    void setUp() {
+        // FK 依存順に削除：posts/refresh_tokens(→users) を user より先に消す（テスト間分離）。
+        postRepository.deleteAll();
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        cohortRepository.deleteAll();
+
+        Cohort a = newCohort("cohort A");
+        Cohort b = newCohort("cohort B");
+        a1Email = newUser("a1@example.com", UserRole.STUDENT, a.getId()).getEmail();
+        a2Email = newUser("a2@example.com", UserRole.STUDENT, a.getId()).getEmail();
+        b1Email = newUser("b1@example.com", UserRole.STUDENT, b.getId()).getEmail();
+    }
+
+    @Test
+    void create_then_owner_can_get() throws Exception {
+        Cookie a1 = login(a1Email);
+        long id = createPost(a1, "私の成果物");
+
+        mockMvc.perform(get("/api/posts/" + id).cookie(a1))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("私の成果物"));
+    }
+
+    @Test
+    void sameCohort_other_can_view_but_cannot_edit_or_delete() throws Exception {
+        Cookie a1 = login(a1Email);
+        long id = createPost(a1, "a1 の投稿");
+
+        Cookie a2 = login(a2Email);
+        // 同 cohort なので閲覧はできる
+        mockMvc.perform(get("/api/posts/" + id).cookie(a2))
+                .andExpect(status().isOk());
+        // しかし他人の投稿は編集・削除不可（所有者でない → 404）
+        mockMvc.perform(put("/api/posts/" + id).cookie(a2)
+                        .contentType("application/json")
+                        .content(body("乗っ取り編集")))
+                .andExpect(status().isNotFound());
+        mockMvc.perform(delete("/api/posts/" + id).cookie(a2))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void otherCohort_cannot_view_edit_or_delete() throws Exception {
+        Cookie a1 = login(a1Email);
+        long id = createPost(a1, "cohort A の投稿");
+
+        Cookie b1 = login(b1Email);
+        mockMvc.perform(get("/api/posts/" + id).cookie(b1))
+                .andExpect(status().isNotFound());
+        mockMvc.perform(put("/api/posts/" + id).cookie(b1)
+                        .contentType("application/json")
+                        .content(body("他 cohort 編集")))
+                .andExpect(status().isNotFound());
+        mockMvc.perform(delete("/api/posts/" + id).cookie(b1))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void list_returns_only_same_cohort() throws Exception {
+        Cookie a1 = login(a1Email);
+        createPost(a1, "A の投稿");
+
+        // b1（cohort B）の一覧には A の投稿は出ない
+        mockMvc.perform(get("/api/posts").cookie(login(b1Email)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(0));
+
+        // a2（cohort A）の一覧には出る
+        mockMvc.perform(get("/api/posts").cookie(login(a2Email)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(1));
+    }
+
+    @Test
+    void owner_can_update_and_logical_delete() throws Exception {
+        Cookie a1 = login(a1Email);
+        long id = createPost(a1, "編集前");
+
+        mockMvc.perform(put("/api/posts/" + id).cookie(a1)
+                        .contentType("application/json")
+                        .content(body("編集後")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("編集後"));
+
+        mockMvc.perform(delete("/api/posts/" + id).cookie(a1))
+                .andExpect(status().isNoContent());
+        // 論理削除後は本人でも取得不可（404）
+        mockMvc.perform(get("/api/posts/" + id).cookie(a1))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void unauthenticated_is_rejected() throws Exception {
+        mockMvc.perform(post("/api/posts")
+                        .contentType("application/json")
+                        .content(body("未ログイン投稿")))
+                .andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/posts"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ---- helpers ----
+
+    private long createPost(Cookie cookie, String title) throws Exception {
+        MvcResult res = mockMvc.perform(post("/api/posts").cookie(cookie)
+                        .contentType("application/json")
+                        .content(body(title)))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return com.jayway.jsonpath.JsonPath.parse(res.getResponse().getContentAsString())
+                .read("$.id", Integer.class).longValue();
+    }
+
+    private String body(String title) {
+        return "{\"title\":\"" + title + "\",\"description\":\"説明文です\"}";
+    }
+
+    private Cookie login(String email) throws Exception {
+        MvcResult res = mockMvc.perform(post("/api/auth/login")
+                        .contentType("application/json")
+                        .content("{\"email\":\"" + email + "\",\"password\":\"" + PASSWORD + "\"}"))
+                .andExpect(status().isOk())
+                .andReturn();
+        Cookie access = res.getResponse().getCookie(AuthCookies.ACCESS);
+        assertThat(access).isNotNull();
+        return access;
+    }
+
+    private Cohort newCohort(String name) {
+        Cohort c = new Cohort();
+        c.setName(name);
+        c.setCreatedAt(OffsetDateTime.now());
+        return cohortRepository.save(c);
+    }
+
+    private User newUser(String email, UserRole role, Long cohortId) {
+        OffsetDateTime now = OffsetDateTime.now();
+        User u = new User();
+        u.setEmail(email);
+        u.setPasswordHash(passwordEncoder.encode(PASSWORD));
+        u.setDisplayName(email);
+        u.setRole(role);
+        u.setCohortId(cohortId);
+        u.setCreatedAt(now);
+        u.setUpdatedAt(now);
+        return userRepository.save(u);
+    }
+}


### PR DESCRIPTION
## 関連 Issue

Closes #91

---

## 変更の概要

Phase 1 MVP §3-1 の2番目 **F-POST（成果物の投稿）** を実装。重点軸の本丸として cohort 境界・所有者認可を全エンドポイントに敷いた。

- **F-POST-01** 作成（POST /api/posts）：cohort_id・author は principal（検証済み JWT）から導出。クライアント入力は信用しない
- **F-POST-02** 編集（PUT /api/posts/{id}）・論理削除（DELETE /api/posts/{id}、S-4）：所有者のみ
- **F-POST-03** 一覧（GET /api/posts、Slice ページネーション・P-2）＋ 単体取得（GET /api/posts/{id}）：同 cohort・未削除のみ
- `ResourceNotFoundException`(404) を common に追加し GlobalExceptionHandler にマッピング

### 認可（★重点軸）
- 取得・一覧は **principal.cohortId 境界**で絞る（他 cohort は不可視）
- 編集・削除は **所有者（authorUserId == principal.userId）のみ**。不一致・他 cohort・削除済みは存在を漏らさず **404**（403 と区別しないのは ID 列挙を防ぐため）

## 変更の種別

- [x] feat（新機能の追加）
- [x] test（テストの追加・修正）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（`./gradlew test` グリーン・全9件）
- [x] 既存の機能が壊れていないことを確認した（F-AUTH テスト含め green）
- [x] `.env` ファイルやパスワードをコミットしていない（テスト用ダミー値のみ）

### 認可テスト（Testcontainers PostgreSQL 16）— 6件 green
1. 所有者が作成 → 取得できる
2. 同 cohort の他者：閲覧は可・編集/削除は **404**
3. 他 cohort：取得/編集/削除すべて **404**
4. 一覧は自 cohort の投稿のみ返す
5. 所有者の編集・論理削除（削除後は本人も 404）
6. 未ログインは **401**

---

## レビュー時に特に確認してほしい点

- 「他人の投稿」を **403 ではなく 404** に倒す設計（存在を漏らさず IDOR を遮断）が要件 §3-2 と整合しているか
- 所有者・cohort の判定を Service(`loadOwned`)に一元化している点（認可ロジックの散在防止・M-3）

> 既知の follow-up：テスト間の FK クリーンアップ（refresh_tokens/posts を user より先に削除）が AuthIntegrationTest と本テストで重複。共通テスト基底クラス化は別 PR で検討予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)