### PR TITLE
feat: F-REV レビュー（観点別コメント・ありがとう）を実装

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/common/GlobalExceptionHandler.java
+++ b/review-board/backend/src/main/java/com/reviewboard/common/GlobalExceptionHandler.java
@@ -29,6 +29,12 @@ public class GlobalExceptionHandler {
         return ResponseEntity.badRequest().body(ApiError.of("VALIDATION_ERROR", msg));
     }
 
+    /** ビジネスルール違反（400）：自己レビュー・観点重複など */
+    @ExceptionHandler(InvalidRequestException.class)
+    public ResponseEntity<ApiError> handleInvalidRequest(InvalidRequestException ex) {
+        return ResponseEntity.badRequest().body(ApiError.of("INVALID_REQUEST", ex.getMessage()));
+    }
+
     /** リソース無し/他 cohort/他人の資源/削除済み（404・存在を漏らさず IDOR 遮断） */
     @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<ApiError> handleNotFound(ResourceNotFoundException ex) {

--- a/review-board/backend/src/main/java/com/reviewboard/common/InvalidRequestException.java
+++ b/review-board/backend/src/main/java/com/reviewboard/common/InvalidRequestException.java
@@ -1,0 +1,12 @@
+package com.reviewboard.common;
+
+/**
+ * ビジネスルール違反（400）。バリデーション（@Valid）では表現しきれない不正リクエスト用。
+ * 例：自分の投稿への自己レビュー、同じ観点軸の重複コメント。
+ */
+public class InvalidRequestException extends RuntimeException {
+
+    public InvalidRequestException(String message) {
+        super(message);
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewAxis.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewAxis.java
@@ -1,0 +1,12 @@
+package com.reviewboard.domain.review;
+
+/**
+ * 観点別コメントの軸（F-REV-01）。母の品質4軸に対応（①動作・正しさ ②可読性・保守性
+ * ③セキュリティ ④性能・UX）。各軸は任意入力。
+ */
+public enum ReviewAxis {
+    CORRECTNESS,
+    MAINTAINABILITY,
+    SECURITY,
+    PERFORMANCE
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewAxisComment.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewAxisComment.java
@@ -1,0 +1,31 @@
+package com.reviewboard.domain.review;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * レビューの観点別コメント（F-REV-01・任意）。1 レビューにつき 1 軸 1 行（ER図 uq_review_axis）。
+ */
+@Entity
+@Table(name = "review_axis_comments")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReviewAxisComment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "review_id", nullable = false)
+    private Long reviewId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ReviewAxis axis;
+
+    @Column(nullable = false, columnDefinition = "text")
+    private String comment;
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewAxisCommentRepository.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewAxisCommentRepository.java
@@ -1,0 +1,12 @@
+package com.reviewboard.domain.review;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReviewAxisCommentRepository extends JpaRepository<ReviewAxisComment, Long> {
+
+    List<ReviewAxisComment> findByReviewId(Long reviewId);
+
+    List<ReviewAxisComment> findByReviewIdIn(List<Long> reviewIds);
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewController.java
@@ -1,0 +1,66 @@
+package com.reviewboard.domain.review;
+
+import com.reviewboard.domain.auth.AuthPrincipal;
+import com.reviewboard.domain.review.dto.ReviewCreateRequest;
+import com.reviewboard.domain.review.dto.ReviewResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+/**
+ * レビュー API（F-REV）。すべて認証必須。cohort 境界・自己レビュー禁止・所有者・ありがとう権限の
+ * 判定は {@link ReviewService} に集約する（★S軸・認可の一元化）。
+ */
+@RestController
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    public ReviewController(ReviewService reviewService) {
+        this.reviewService = reviewService;
+    }
+
+    /** F-REV-01 作成（同 cohort の投稿のみ・自己レビュー禁止） */
+    @PostMapping("/api/posts/{postId}/reviews")
+    public ResponseEntity<ReviewResponse> create(@AuthenticationPrincipal AuthPrincipal principal,
+                                                 @PathVariable Long postId,
+                                                 @Valid @RequestBody ReviewCreateRequest request) {
+        ReviewResponse res = reviewService.create(principal, postId, request);
+        return ResponseEntity.created(URI.create("/api/reviews/" + res.id())).body(res);
+    }
+
+    /** F-REV-01/02 一覧（reviewer の role を含む＝講師の特別表示が可能） */
+    @GetMapping("/api/posts/{postId}/reviews")
+    public List<ReviewResponse> list(@AuthenticationPrincipal AuthPrincipal principal,
+                                     @PathVariable Long postId) {
+        return reviewService.listForPost(principal, postId);
+    }
+
+    /** F-REV 編集（所有者のみ） */
+    @PutMapping("/api/reviews/{id}")
+    public ReviewResponse update(@AuthenticationPrincipal AuthPrincipal principal,
+                                 @PathVariable Long id,
+                                 @Valid @RequestBody ReviewCreateRequest request) {
+        return reviewService.update(principal, id, request);
+    }
+
+    /** F-REV 論理削除（所有者のみ） */
+    @DeleteMapping("/api/reviews/{id}")
+    public ResponseEntity<Void> delete(@AuthenticationPrincipal AuthPrincipal principal,
+                                       @PathVariable Long id) {
+        reviewService.delete(principal, id);
+        return ResponseEntity.noContent().build();
+    }
+
+    /** F-REV-03 ありがとう（投稿者のみ・冪等） */
+    @PostMapping("/api/reviews/{id}/thanks")
+    public ResponseEntity<Void> thank(@AuthenticationPrincipal AuthPrincipal principal,
+                                      @PathVariable Long id) {
+        reviewService.thank(principal, id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewRepository.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewRepository.java
@@ -3,11 +3,15 @@ package com.reviewboard.domain.review;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     /** ある投稿のレビュー一覧（未削除） */
     List<Review> findByPostIdAndDeletedAtIsNull(Long postId);
+
+    /** 単体取得（未削除のみ） */
+    Optional<Review> findByIdAndDeletedAtIsNull(Long id);
 
     /** したレビュー実績（F-PROF-03） */
     List<Review> findByReviewerUserIdAndDeletedAtIsNull(Long reviewerUserId);

--- a/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewService.java
@@ -1,0 +1,204 @@
+package com.reviewboard.domain.review;
+
+import com.reviewboard.common.InvalidRequestException;
+import com.reviewboard.common.ResourceNotFoundException;
+import com.reviewboard.domain.auth.AuthPrincipal;
+import com.reviewboard.domain.post.Post;
+import com.reviewboard.domain.post.PostRepository;
+import com.reviewboard.domain.review.dto.ReviewCreateRequest;
+import com.reviewboard.domain.review.dto.ReviewResponse;
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRepository;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * レビューのユースケース（F-REV）。★S軸：cohort 境界・自己レビュー禁止・所有者・ありがとう権限を
+ * すべてバックエンドで検証する。可視性外は存在を漏らさず 404（IDOR 遮断）。
+ */
+@Service
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final ReviewAxisCommentRepository axisCommentRepository;
+    private final ThanksRepository thanksRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    public ReviewService(ReviewRepository reviewRepository,
+                         ReviewAxisCommentRepository axisCommentRepository,
+                         ThanksRepository thanksRepository,
+                         PostRepository postRepository,
+                         UserRepository userRepository) {
+        this.reviewRepository = reviewRepository;
+        this.axisCommentRepository = axisCommentRepository;
+        this.thanksRepository = thanksRepository;
+        this.postRepository = postRepository;
+        this.userRepository = userRepository;
+    }
+
+    /** F-REV-01 作成。同 cohort の投稿のみ・自己レビュー禁止。 */
+    @Transactional
+    public ReviewResponse create(AuthPrincipal principal, Long postId, ReviewCreateRequest req) {
+        Post post = visiblePost(principal, postId);
+        if (post.getAuthorUserId().equals(principal.userId())) {
+            throw new InvalidRequestException("自分の投稿にはレビューできません");
+        }
+        OffsetDateTime now = OffsetDateTime.now();
+        Review review = new Review();
+        review.setPostId(postId);
+        review.setReviewerUserId(principal.userId());
+        review.setGood(req.good());
+        review.setImprovement(req.improvement());
+        review.setCreatedAt(now);
+        review.setUpdatedAt(now);
+        reviewRepository.save(review);
+
+        List<ReviewAxisComment> axisComments = saveAxisComments(review.getId(), req.axisComments());
+
+        // 非正規化カウンタ更新（母 S-3。ズレは将来の定期再計算で補正）
+        post.setReviewCount(post.getReviewCount() + 1);
+        adjustCount(principal.userId(), 0, +1);            // reviewer の「したレビュー」
+        adjustCount(post.getAuthorUserId(), +1, 0);        // author の「もらったレビュー」
+
+        User reviewer = userRepository.findById(principal.userId()).orElseThrow();
+        return ReviewResponse.from(review, reviewer.getDisplayName(), reviewer.getRole(), axisComments);
+    }
+
+    /** F-REV-01/02 一覧。投稿が可視（同 cohort）でなければ 404。reviewer の role を含める。 */
+    @Transactional(readOnly = true)
+    public List<ReviewResponse> listForPost(AuthPrincipal principal, Long postId) {
+        visiblePost(principal, postId);
+        List<Review> reviews = reviewRepository.findByPostIdAndDeletedAtIsNull(postId);
+        if (reviews.isEmpty()) {
+            return List.of();
+        }
+        // N+1 回避：axis コメントと reviewer をまとめて引く（母 P-3）
+        List<Long> reviewIds = reviews.stream().map(Review::getId).toList();
+        Map<Long, List<ReviewAxisComment>> axisByReview = axisCommentRepository.findByReviewIdIn(reviewIds)
+                .stream().collect(Collectors.groupingBy(ReviewAxisComment::getReviewId));
+        Set<Long> reviewerIds = reviews.stream().map(Review::getReviewerUserId).collect(Collectors.toSet());
+        Map<Long, User> reviewers = userRepository.findAllById(reviewerIds).stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+
+        return reviews.stream().map(r -> {
+            User reviewer = reviewers.get(r.getReviewerUserId());
+            return ReviewResponse.from(r,
+                    reviewer != null ? reviewer.getDisplayName() : "(不明)",
+                    reviewer != null ? reviewer.getRole() : null,
+                    axisByReview.getOrDefault(r.getId(), List.of()));
+        }).toList();
+    }
+
+    /** F-REV 編集（所有者のみ・不一致は 404）。観点別コメントは入れ替える。 */
+    @Transactional
+    public ReviewResponse update(AuthPrincipal principal, Long reviewId, ReviewCreateRequest req) {
+        Review review = ownedReview(principal, reviewId);
+        review.setGood(req.good());
+        review.setImprovement(req.improvement());
+        review.setUpdatedAt(OffsetDateTime.now());
+
+        axisCommentRepository.deleteAll(axisCommentRepository.findByReviewId(reviewId));
+        List<ReviewAxisComment> axisComments = saveAxisComments(reviewId, req.axisComments());
+
+        User reviewer = userRepository.findById(principal.userId()).orElseThrow();
+        return ReviewResponse.from(review, reviewer.getDisplayName(), reviewer.getRole(), axisComments);
+    }
+
+    /** F-REV 論理削除（所有者のみ）。カウンタも戻す。 */
+    @Transactional
+    public void delete(AuthPrincipal principal, Long reviewId) {
+        Review review = ownedReview(principal, reviewId);
+        review.setDeletedAt(OffsetDateTime.now());
+        review.setUpdatedAt(OffsetDateTime.now());
+
+        postRepository.findById(review.getPostId()).ifPresent(p -> {
+            p.setReviewCount(Math.max(0, p.getReviewCount() - 1));
+            adjustCount(p.getAuthorUserId(), -1, 0);
+        });
+        adjustCount(principal.userId(), 0, -1);
+    }
+
+    /** F-REV-03 ありがとう（投稿者のみ・冪等）。reviewer の実績に反映。 */
+    @Transactional
+    public void thank(AuthPrincipal principal, Long reviewId) {
+        Review review = reviewRepository.findByIdAndDeletedAtIsNull(reviewId)
+                .orElseThrow(() -> new ResourceNotFoundException("review not found: " + reviewId));
+        // レビュー先の投稿が自 cohort かつ未削除であること（可視性）
+        Post post = visiblePost(principal, review.getPostId());
+        // ありがとうを返せるのは投稿者のみ（F-REV-03）
+        if (!post.getAuthorUserId().equals(principal.userId())) {
+            throw new AccessDeniedException("ありがとうは投稿者のみ送れます");
+        }
+        // 冪等：既に送っていれば何もしない（uq_thanks）
+        if (thanksRepository.existsByReviewIdAndFromUserId(reviewId, principal.userId())) {
+            return;
+        }
+        Thanks thanks = new Thanks();
+        thanks.setReviewId(reviewId);
+        thanks.setFromUserId(principal.userId());
+        thanks.setCreatedAt(OffsetDateTime.now());
+        thanksRepository.save(thanks);
+
+        review.setThanksCount(review.getThanksCount() + 1);
+        adjustThanksReceived(review.getReviewerUserId(), +1);
+    }
+
+    // ---- helpers ----
+
+    /** 自 cohort・未削除の投稿を返す。可視性外は 404（IDOR 遮断）。 */
+    private Post visiblePost(AuthPrincipal principal, Long postId) {
+        return postRepository.findByIdAndCohortIdAndDeletedAtIsNull(postId, principal.cohortId())
+                .orElseThrow(() -> new ResourceNotFoundException("post not found: " + postId));
+    }
+
+    /** 未削除かつ自分が書いたレビューを返す。他人/未存在は 404。 */
+    private Review ownedReview(AuthPrincipal principal, Long reviewId) {
+        Review review = reviewRepository.findByIdAndDeletedAtIsNull(reviewId)
+                .orElseThrow(() -> new ResourceNotFoundException("review not found: " + reviewId));
+        if (!review.getReviewerUserId().equals(principal.userId())) {
+            throw new ResourceNotFoundException("not the owner: " + reviewId);
+        }
+        return review;
+    }
+
+    private List<ReviewAxisComment> saveAxisComments(Long reviewId,
+                                                     List<ReviewCreateRequest.AxisCommentInput> inputs) {
+        if (inputs == null || inputs.isEmpty()) {
+            return List.of();
+        }
+        Set<ReviewAxis> seen = new HashSet<>();
+        List<ReviewAxisComment> entities = inputs.stream().map(in -> {
+            if (!seen.add(in.axis())) {
+                throw new InvalidRequestException("同じ観点軸のコメントは1つまでです: " + in.axis());
+            }
+            ReviewAxisComment c = new ReviewAxisComment();
+            c.setReviewId(reviewId);
+            c.setAxis(in.axis());
+            c.setComment(in.comment());
+            return c;
+        }).toList();
+        return axisCommentRepository.saveAll(entities);
+    }
+
+    private void adjustCount(Long userId, int receivedDelta, int givenDelta) {
+        userRepository.findById(userId).ifPresent(u -> {
+            u.setReceivedReviewsCount(Math.max(0, u.getReceivedReviewsCount() + receivedDelta));
+            u.setGivenReviewsCount(Math.max(0, u.getGivenReviewsCount() + givenDelta));
+        });
+    }
+
+    private void adjustThanksReceived(Long userId, int delta) {
+        userRepository.findById(userId).ifPresent(u ->
+                u.setThanksReceivedCount(Math.max(0, u.getThanksReceivedCount() + delta)));
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/review/Thanks.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/review/Thanks.java
@@ -1,0 +1,32 @@
+package com.reviewboard.domain.review;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+
+/**
+ * ありがとう（F-REV-03）。1 レビューに 1 ユーザー 1 回（ER図 uq_thanks で冪等を担保）。
+ */
+@Entity
+@Table(name = "thanks")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Thanks {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "review_id", nullable = false)
+    private Long reviewId;
+
+    @Column(name = "from_user_id", nullable = false)
+    private Long fromUserId;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/review/ThanksRepository.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/review/ThanksRepository.java
@@ -1,0 +1,8 @@
+package com.reviewboard.domain.review;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ThanksRepository extends JpaRepository<Thanks, Long> {
+
+    boolean existsByReviewIdAndFromUserId(Long reviewId, Long fromUserId);
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/review/dto/ReviewCreateRequest.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/review/dto/ReviewCreateRequest.java
@@ -1,0 +1,24 @@
+package com.reviewboard.domain.review.dto;
+
+import com.reviewboard.domain.review.ReviewAxis;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+/**
+ * レビュー作成リクエスト（F-REV-01）。
+ * 「良かった点」「改善提案」は必須、観点別コメントは任意（初心者が全軸埋めなくてよい）。
+ */
+public record ReviewCreateRequest(
+        @NotBlank String good,
+        @NotBlank String improvement,
+        @Valid List<AxisCommentInput> axisComments) {
+
+    /** 観点別コメント1件。同じ軸は1回まで（Service で重複を弾く）。 */
+    public record AxisCommentInput(
+            @NotNull ReviewAxis axis,
+            @NotBlank String comment) {
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/review/dto/ReviewResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/review/dto/ReviewResponse.java
@@ -1,0 +1,43 @@
+package com.reviewboard.domain.review.dto;
+
+import com.reviewboard.domain.review.Review;
+import com.reviewboard.domain.review.ReviewAxis;
+import com.reviewboard.domain.review.ReviewAxisComment;
+import com.reviewboard.domain.user.UserRole;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * レビューのレスポンス。reviewer の role/displayName を含め、講師レビューの特別表示
+ * （F-REV-02）をフロントで可能にする。teacherReview フラグは利便のため導出。
+ */
+public record ReviewResponse(
+        Long id,
+        Long postId,
+        Long reviewerUserId,
+        String reviewerDisplayName,
+        UserRole reviewerRole,
+        boolean teacherReview,
+        String good,
+        String improvement,
+        int thanksCount,
+        List<AxisComment> axisComments,
+        OffsetDateTime createdAt) {
+
+    public record AxisComment(ReviewAxis axis, String comment) {
+        static AxisComment from(ReviewAxisComment c) {
+            return new AxisComment(c.getAxis(), c.getComment());
+        }
+    }
+
+    public static ReviewResponse from(Review r, String reviewerDisplayName, UserRole reviewerRole,
+                                      List<ReviewAxisComment> axisComments) {
+        return new ReviewResponse(
+                r.getId(), r.getPostId(), r.getReviewerUserId(),
+                reviewerDisplayName, reviewerRole, reviewerRole == UserRole.TEACHER,
+                r.getGood(), r.getImprovement(), r.getThanksCount(),
+                axisComments.stream().map(AxisComment::from).toList(),
+                r.getCreatedAt());
+    }
+}

--- a/review-board/backend/src/test/java/com/reviewboard/domain/review/ReviewAuthorizationIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/review/ReviewAuthorizationIntegrationTest.java
@@ -1,0 +1,240 @@
+package com.reviewboard.domain.review;
+
+import com.reviewboard.domain.auth.AuthCookies;
+import com.reviewboard.domain.auth.RefreshTokenRepository;
+import com.reviewboard.domain.cohort.Cohort;
+import com.reviewboard.domain.cohort.CohortRepository;
+import com.reviewboard.domain.post.PostRepository;
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRepository;
+import com.reviewboard.domain.user.UserRole;
+import com.jayway.jsonpath.JsonPath;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * F-REV の認可テスト（★S軸・テスト計画書 §6）。
+ * cohort 境界・自己レビュー禁止・所有者・ありがとう権限（投稿者のみ・冪等）を網羅する。
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class ReviewAuthorizationIntegrationTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("app.jwt.secret", () -> "test-secret-please-change-32chars-minimum");
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired CohortRepository cohortRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired PostRepository postRepository;
+    @Autowired ReviewRepository reviewRepository;
+    @Autowired ReviewAxisCommentRepository axisCommentRepository;
+    @Autowired ThanksRepository thanksRepository;
+    @Autowired RefreshTokenRepository refreshTokenRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+
+    private static final String PW = "correct-horse-battery";
+
+    private String authorEmail;   // cohort A・投稿の所有者
+    private String reviewerEmail; // cohort A・レビュアー
+    private String otherEmail;    // cohort A・第三者
+    private String teacherEmail;  // cohort A・講師
+    private String bEmail;        // cohort B
+    private long postId;          // author の投稿
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // FK 依存順に削除
+        thanksRepository.deleteAll();
+        axisCommentRepository.deleteAll();
+        reviewRepository.deleteAll();
+        postRepository.deleteAll();
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        cohortRepository.deleteAll();
+
+        Cohort a = newCohort("A");
+        Cohort b = newCohort("B");
+        authorEmail = newUser("author@example.com", UserRole.STUDENT, a.getId());
+        reviewerEmail = newUser("reviewer@example.com", UserRole.STUDENT, a.getId());
+        otherEmail = newUser("other@example.com", UserRole.STUDENT, a.getId());
+        teacherEmail = newUser("teacher@example.com", UserRole.TEACHER, a.getId());
+        bEmail = newUser("b@example.com", UserRole.STUDENT, b.getId());
+
+        // author が投稿を1件作る
+        MvcResult res = mockMvc.perform(post("/api/posts").cookie(login(authorEmail))
+                        .contentType("application/json")
+                        .content("{\"title\":\"作品\",\"description\":\"説明\"}"))
+                .andExpect(status().isCreated()).andReturn();
+        postId = readId(res);
+    }
+
+    @Test
+    void reviewer_can_create_and_list_shows_it() throws Exception {
+        mockMvc.perform(post("/api/posts/" + postId + "/reviews").cookie(login(reviewerEmail))
+                        .contentType("application/json")
+                        .content(reviewBody()))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.good").value("よい"));
+
+        mockMvc.perform(get("/api/posts/" + postId + "/reviews").cookie(login(reviewerEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].axisComments.length()").value(1));
+    }
+
+    @Test
+    void self_review_is_rejected() throws Exception {
+        mockMvc.perform(post("/api/posts/" + postId + "/reviews").cookie(login(authorEmail))
+                        .contentType("application/json")
+                        .content(reviewBody()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void other_cohort_cannot_review_or_list() throws Exception {
+        Cookie b = login(bEmail);
+        mockMvc.perform(post("/api/posts/" + postId + "/reviews").cookie(b)
+                        .contentType("application/json")
+                        .content(reviewBody()))
+                .andExpect(status().isNotFound());
+        mockMvc.perform(get("/api/posts/" + postId + "/reviews").cookie(b))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void teacher_review_is_flagged() throws Exception {
+        mockMvc.perform(post("/api/posts/" + postId + "/reviews").cookie(login(teacherEmail))
+                        .contentType("application/json")
+                        .content(reviewBody()))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.reviewerRole").value("TEACHER"))
+                .andExpect(jsonPath("$.teacherReview").value(true));
+    }
+
+    @Test
+    void non_owner_cannot_edit_or_delete_review() throws Exception {
+        long reviewId = createReview(reviewerEmail);
+        Cookie other = login(otherEmail);
+        mockMvc.perform(put("/api/reviews/" + reviewId).cookie(other)
+                        .contentType("application/json").content(reviewBody()))
+                .andExpect(status().isNotFound());
+        mockMvc.perform(delete("/api/reviews/" + reviewId).cookie(other))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void owner_can_edit_and_delete_review() throws Exception {
+        long reviewId = createReview(reviewerEmail);
+        Cookie reviewer = login(reviewerEmail);
+        mockMvc.perform(put("/api/reviews/" + reviewId).cookie(reviewer)
+                        .contentType("application/json")
+                        .content("{\"good\":\"更新\",\"improvement\":\"改善\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.good").value("更新"));
+        mockMvc.perform(delete("/api/reviews/" + reviewId).cookie(reviewer))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void thanks_only_by_post_author_and_idempotent() throws Exception {
+        long reviewId = createReview(reviewerEmail);
+
+        // 第三者は不可（投稿者でない）→ 403
+        mockMvc.perform(post("/api/reviews/" + reviewId + "/thanks").cookie(login(otherEmail)))
+                .andExpect(status().isForbidden());
+
+        // 投稿者は可、2回送っても冪等（thanksCount は 1）
+        Cookie author = login(authorEmail);
+        mockMvc.perform(post("/api/reviews/" + reviewId + "/thanks").cookie(author))
+                .andExpect(status().isNoContent());
+        mockMvc.perform(post("/api/reviews/" + reviewId + "/thanks").cookie(author))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/posts/" + postId + "/reviews").cookie(author))
+                .andExpect(jsonPath("$[0].thanksCount").value(1));
+    }
+
+    @Test
+    void unauthenticated_is_rejected() throws Exception {
+        mockMvc.perform(post("/api/posts/" + postId + "/reviews")
+                        .contentType("application/json").content(reviewBody()))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ---- helpers ----
+
+    private long createReview(String email) throws Exception {
+        MvcResult res = mockMvc.perform(post("/api/posts/" + postId + "/reviews").cookie(login(email))
+                        .contentType("application/json").content(reviewBody()))
+                .andExpect(status().isCreated()).andReturn();
+        return readId(res);
+    }
+
+    private String reviewBody() {
+        return "{\"good\":\"よい\",\"improvement\":\"改善案\","
+                + "\"axisComments\":[{\"axis\":\"SECURITY\",\"comment\":\"認可OK\"}]}";
+    }
+
+    private long readId(MvcResult res) throws Exception {
+        return JsonPath.parse(res.getResponse().getContentAsString())
+                .read("$.id", Integer.class).longValue();
+    }
+
+    private Cookie login(String email) throws Exception {
+        MvcResult res = mockMvc.perform(post("/api/auth/login")
+                        .contentType("application/json")
+                        .content("{\"email\":\"" + email + "\",\"password\":\"" + PW + "\"}"))
+                .andExpect(status().isOk()).andReturn();
+        Cookie access = res.getResponse().getCookie(AuthCookies.ACCESS);
+        assertThat(access).isNotNull();
+        return access;
+    }
+
+    private Cohort newCohort(String name) {
+        Cohort c = new Cohort();
+        c.setName(name);
+        c.setCreatedAt(OffsetDateTime.now());
+        return cohortRepository.save(c);
+    }
+
+    private String newUser(String email, UserRole role, Long cohortId) {
+        OffsetDateTime now = OffsetDateTime.now();
+        User u = new User();
+        u.setEmail(email);
+        u.setPasswordHash(passwordEncoder.encode(PW));
+        u.setDisplayName(email);
+        u.setRole(role);
+        u.setCohortId(cohortId);
+        u.setCreatedAt(now);
+        u.setUpdatedAt(now);
+        return userRepository.save(u).getEmail();
+    }
+}


### PR DESCRIPTION
## 関連 Issue

Closes #93

---

## 変更の概要

Phase 1 MVP §3-1 の3番目 **F-REV（レビュー）** を実装。

- **F-REV-01** レビュー作成（POST /api/posts/{postId}/reviews）：良かった点・改善提案は必須、観点別コメント（①動作 ②可読性 ③セキュリティ ④性能、各任意）。同 cohort の投稿のみ・**自己レビュー禁止**
- **F-REV-02** 一覧（GET /api/posts/{postId}/reviews）に reviewer の role/displayName を載せ、講師レビューの特別表示（`teacherReview` フラグ）を可能に
- レビューの編集・論理削除（PUT/DELETE /api/reviews/{id}）：所有者のみ
- **F-REV-03** ありがとう（POST /api/reviews/{id}/thanks）：**投稿者のみ**・冪等（uq_thanks）。reviewer の実績に反映

### 認可（★重点軸）
- 投稿が自 cohort でなければ作成・一覧とも **404**（IDOR 遮断）
- 自分の投稿への自己レビューは **400**
- 編集・削除は所有者のみ（不一致 **404**）
- ありがとうは対象投稿の所有者のみ（他者 **403**）、二重送信は冪等
- 非正規化カウンタ（review_count / given / received / thanks_received）を更新（S-3、ズレは将来の定期再計算で補正）

## 変更の種別

- [x] feat（新機能の追加）
- [x] test（テストの追加・修正）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（`./gradlew test` グリーン・全17件）
- [x] 既存の機能が壊れていないことを確認した（F-AUTH/F-POST 含め green）
- [x] `.env` ファイルやパスワードをコミットしていない（テスト用ダミー値のみ）

### 認可テスト（Testcontainers PostgreSQL 16）— 8件 green
作成+一覧 / 自己レビュー400 / 他 cohort 404 / 講師フラグ / 非所有者の編集削除404 / 所有者の編集削除 / ありがとうは投稿者のみ403+冪等 / 未ログイン401

---

## レビュー時に特に確認してほしい点

- 一覧の N+1 回避（axis コメント・reviewer をバッチ取得）が意図通りか（P-3）
- ありがとうの権限を **403**（投稿者でない）とした判断（リソースは可視なので存在隠蔽の 404 ではなく操作禁止の 403）

> follow-up（既知）：観点別コメントの編集は「全削除→再作成」方式。テスト間 FK クリーンアップの共通基底クラス化は別 PR で検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)