### PR TITLE
feat: F-EVAL 講師による最終評価・承認（講師ロール限定）を実装

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/domain/evaluation/EvaluationController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/evaluation/EvaluationController.java
@@ -1,0 +1,43 @@
+package com.reviewboard.domain.evaluation;
+
+import com.reviewboard.domain.auth.AuthPrincipal;
+import com.reviewboard.domain.evaluation.dto.EvaluationRequest;
+import com.reviewboard.domain.evaluation.dto.EvaluationResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 講師の最終評価 API（F-EVAL-01・★S軸）。
+ * 評価作成は {@code @PreAuthorize("hasRole('TEACHER')")} で講師に限定し、受講生の権限昇格を 403 で弾く。
+ * 取得は同 cohort のメンバーなら可（成長記録の合格バッジ表示に使う）。
+ */
+@RestController
+@RequestMapping("/api/posts/{postId}/evaluation")
+public class EvaluationController {
+
+    private final EvaluationService evaluationService;
+
+    public EvaluationController(EvaluationService evaluationService) {
+        this.evaluationService = evaluationService;
+    }
+
+    /** F-EVAL-01 評価を付ける（講師ロール限定） */
+    @PreAuthorize("hasRole('TEACHER')")
+    @PostMapping
+    public ResponseEntity<EvaluationResponse> evaluate(@AuthenticationPrincipal AuthPrincipal principal,
+                                                       @PathVariable Long postId,
+                                                       @Valid @RequestBody EvaluationRequest request) {
+        Evaluation eval = evaluationService.evaluate(principal, postId, request);
+        return ResponseEntity.ok(EvaluationResponse.from(eval));
+    }
+
+    /** 最新評価の取得（同 cohort 可視・未評価は 404） */
+    @GetMapping
+    public EvaluationResponse getLatest(@AuthenticationPrincipal AuthPrincipal principal,
+                                        @PathVariable Long postId) {
+        return EvaluationResponse.from(evaluationService.getLatest(principal, postId));
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/evaluation/EvaluationRepository.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/evaluation/EvaluationRepository.java
@@ -2,10 +2,14 @@ package com.reviewboard.domain.evaluation;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface EvaluationRepository extends JpaRepository<Evaluation, Long> {
 
     /** 投稿の最新評価（合格バッジ判定・F-PROF-04） */
     Optional<Evaluation> findByPostIdAndLatestIsTrue(Long postId);
+
+    /** 投稿の評価履歴（新しい順。母 S-4 履歴保持） */
+    List<Evaluation> findByPostIdOrderByCreatedAtDesc(Long postId);
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/evaluation/EvaluationService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/evaluation/EvaluationService.java
@@ -1,0 +1,61 @@
+package com.reviewboard.domain.evaluation;
+
+import com.reviewboard.common.ResourceNotFoundException;
+import com.reviewboard.domain.auth.AuthPrincipal;
+import com.reviewboard.domain.evaluation.dto.EvaluationRequest;
+import com.reviewboard.domain.post.Post;
+import com.reviewboard.domain.post.PostRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 講師の最終評価のユースケース（F-EVAL-01・★S軸の重点）。
+ *
+ * <p>ロール制御（講師限定）は Controller の {@code @PreAuthorize} で担保する。本サービスは
+ * cohort 境界（他 cohort の投稿は 404）と「最新1件＋履歴」の整合を担う。
+ */
+@Service
+public class EvaluationService {
+
+    private final EvaluationRepository evaluationRepository;
+    private final PostRepository postRepository;
+
+    public EvaluationService(EvaluationRepository evaluationRepository, PostRepository postRepository) {
+        this.evaluationRepository = evaluationRepository;
+        this.postRepository = postRepository;
+    }
+
+    /**
+     * F-EVAL-01 評価を付ける。旧 latest を倒し、新規を is_latest=true で積む（履歴保持・母 S-4）。
+     * 投稿は評価者（講師）の cohort 内のものに限る（他 cohort は 404）。
+     */
+    @Transactional
+    public Evaluation evaluate(AuthPrincipal principal, Long postId, EvaluationRequest req) {
+        Post post = postRepository.findByIdAndCohortIdAndDeletedAtIsNull(postId, principal.cohortId())
+                .orElseThrow(() -> new ResourceNotFoundException("post not found: " + postId));
+
+        evaluationRepository.findByPostIdAndLatestIsTrue(post.getId())
+                .ifPresent(prev -> prev.setLatest(false));
+
+        Evaluation eval = new Evaluation();
+        eval.setPostId(post.getId());
+        eval.setTeacherUserId(principal.userId());
+        eval.setResult(req.result());
+        eval.setComment(req.comment());
+        eval.setLatest(true);
+        eval.setCreatedAt(OffsetDateTime.now());
+        return evaluationRepository.save(eval);
+    }
+
+    /** 最新評価の取得（同 cohort のみ可視）。未評価は 404。 */
+    @Transactional(readOnly = true)
+    public Evaluation getLatest(AuthPrincipal principal, Long postId) {
+        // 投稿の可視性（cohort 境界）を先に確認
+        postRepository.findByIdAndCohortIdAndDeletedAtIsNull(postId, principal.cohortId())
+                .orElseThrow(() -> new ResourceNotFoundException("post not found: " + postId));
+        return evaluationRepository.findByPostIdAndLatestIsTrue(postId)
+                .orElseThrow(() -> new ResourceNotFoundException("evaluation not found for post: " + postId));
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/evaluation/dto/EvaluationRequest.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/evaluation/dto/EvaluationRequest.java
@@ -1,0 +1,13 @@
+package com.reviewboard.domain.evaluation.dto;
+
+import com.reviewboard.domain.evaluation.EvaluationResult;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 講師の最終評価リクエスト（F-EVAL-01）。result と評価コメントは必須。
+ */
+public record EvaluationRequest(
+        @NotNull EvaluationResult result,
+        @NotBlank String comment) {
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/evaluation/dto/EvaluationResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/evaluation/dto/EvaluationResponse.java
@@ -1,0 +1,27 @@
+package com.reviewboard.domain.evaluation.dto;
+
+import com.reviewboard.domain.evaluation.Evaluation;
+import com.reviewboard.domain.evaluation.EvaluationResult;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 講師の最終評価レスポンス（F-EVAL-01 / F-PROF-04 合格バッジ）。
+ * approved=true は成長記録の「合格バッジ」に対応する。
+ */
+public record EvaluationResponse(
+        Long id,
+        Long postId,
+        Long teacherUserId,
+        EvaluationResult result,
+        boolean approved,
+        String comment,
+        OffsetDateTime createdAt) {
+
+    public static EvaluationResponse from(Evaluation e) {
+        return new EvaluationResponse(
+                e.getId(), e.getPostId(), e.getTeacherUserId(),
+                e.getResult(), e.getResult() == EvaluationResult.APPROVED,
+                e.getComment(), e.getCreatedAt());
+    }
+}

--- a/review-board/backend/src/test/java/com/reviewboard/domain/evaluation/EvaluationAuthorizationIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/evaluation/EvaluationAuthorizationIntegrationTest.java
@@ -1,0 +1,182 @@
+package com.reviewboard.domain.evaluation;
+
+import com.reviewboard.domain.auth.AuthCookies;
+import com.reviewboard.domain.auth.RefreshTokenRepository;
+import com.reviewboard.domain.cohort.Cohort;
+import com.reviewboard.domain.cohort.CohortRepository;
+import com.reviewboard.domain.post.PostRepository;
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRepository;
+import com.reviewboard.domain.user.UserRole;
+import com.jayway.jsonpath.JsonPath;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * F-EVAL の認可テスト（★S軸の重点＝権限昇格防止）。
+ * 受講生が講師限定の評価操作を呼べないこと（403）を中心に、cohort 境界・最新後勝ち＋履歴を検証する。
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class EvaluationAuthorizationIntegrationTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("app.jwt.secret", () -> "test-secret-please-change-32chars-minimum");
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired CohortRepository cohortRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired PostRepository postRepository;
+    @Autowired EvaluationRepository evaluationRepository;
+    @Autowired RefreshTokenRepository refreshTokenRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+
+    private static final String PW = "correct-horse-battery";
+
+    private String authorEmail;    // cohort A・受講生・投稿者
+    private String teacherEmail;   // cohort A・講師
+    private String teacherBEmail;  // cohort B・講師
+    private long postId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        evaluationRepository.deleteAll();
+        postRepository.deleteAll();
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        cohortRepository.deleteAll();
+
+        Cohort a = newCohort("A");
+        Cohort b = newCohort("B");
+        authorEmail = newUser("author@example.com", UserRole.STUDENT, a.getId());
+        teacherEmail = newUser("teacher@example.com", UserRole.TEACHER, a.getId());
+        teacherBEmail = newUser("teacherB@example.com", UserRole.TEACHER, b.getId());
+
+        MvcResult res = mockMvc.perform(post("/api/posts").cookie(login(authorEmail))
+                        .contentType("application/json")
+                        .content("{\"title\":\"作品\",\"description\":\"説明\"}"))
+                .andExpect(status().isCreated()).andReturn();
+        postId = JsonPath.parse(res.getResponse().getContentAsString()).read("$.id", Integer.class);
+    }
+
+    @Test
+    void teacher_can_evaluate_and_fetch_latest() throws Exception {
+        mockMvc.perform(post("/api/posts/" + postId + "/evaluation").cookie(login(teacherEmail))
+                        .contentType("application/json")
+                        .content("{\"result\":\"APPROVED\",\"comment\":\"合格です\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.approved").value(true));
+
+        mockMvc.perform(get("/api/posts/" + postId + "/evaluation").cookie(login(authorEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value("APPROVED"));
+    }
+
+    /** ★最重要：受講生は講師限定の評価操作を呼べない（権限昇格防止）。 */
+    @Test
+    void student_cannot_evaluate_returns403() throws Exception {
+        mockMvc.perform(post("/api/posts/" + postId + "/evaluation").cookie(login(authorEmail))
+                        .contentType("application/json")
+                        .content("{\"result\":\"APPROVED\",\"comment\":\"自己承認の試み\"}"))
+                .andExpect(status().isForbidden());
+
+        // 評価は1件も作られていない
+        assertThat(evaluationRepository.findByPostIdOrderByCreatedAtDesc(postId)).isEmpty();
+    }
+
+    @Test
+    void new_evaluation_supersedes_and_keeps_history() throws Exception {
+        Cookie teacher = login(teacherEmail);
+        evaluate(teacher, "RETURNED", "差し戻し");
+        evaluate(teacher, "APPROVED", "再提出を承認");
+
+        // 最新は APPROVED（後勝ち）
+        mockMvc.perform(get("/api/posts/" + postId + "/evaluation").cookie(teacher))
+                .andExpect(jsonPath("$.result").value("APPROVED"));
+        // 履歴は2件残る（母 S-4）
+        assertThat(evaluationRepository.findByPostIdOrderByCreatedAtDesc(postId)).hasSize(2);
+        assertThat(evaluationRepository.findByPostIdAndLatestIsTrue(postId)).isPresent();
+    }
+
+    @Test
+    void teacher_of_other_cohort_cannot_evaluate_returns404() throws Exception {
+        mockMvc.perform(post("/api/posts/" + postId + "/evaluation").cookie(login(teacherBEmail))
+                        .contentType("application/json")
+                        .content("{\"result\":\"APPROVED\",\"comment\":\"他cohortから\"}"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void unauthenticated_is_rejected() throws Exception {
+        mockMvc.perform(post("/api/posts/" + postId + "/evaluation")
+                        .contentType("application/json")
+                        .content("{\"result\":\"APPROVED\",\"comment\":\"x\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ---- helpers ----
+
+    private void evaluate(Cookie teacher, String result, String comment) throws Exception {
+        mockMvc.perform(post("/api/posts/" + postId + "/evaluation").cookie(teacher)
+                        .contentType("application/json")
+                        .content("{\"result\":\"" + result + "\",\"comment\":\"" + comment + "\"}"))
+                .andExpect(status().isOk());
+    }
+
+    private Cookie login(String email) throws Exception {
+        MvcResult res = mockMvc.perform(post("/api/auth/login")
+                        .contentType("application/json")
+                        .content("{\"email\":\"" + email + "\",\"password\":\"" + PW + "\"}"))
+                .andExpect(status().isOk()).andReturn();
+        Cookie access = res.getResponse().getCookie(AuthCookies.ACCESS);
+        assertThat(access).isNotNull();
+        return access;
+    }
+
+    private Cohort newCohort(String name) {
+        Cohort c = new Cohort();
+        c.setName(name);
+        c.setCreatedAt(OffsetDateTime.now());
+        return cohortRepository.save(c);
+    }
+
+    private String newUser(String email, UserRole role, Long cohortId) {
+        OffsetDateTime now = OffsetDateTime.now();
+        User u = new User();
+        u.setEmail(email);
+        u.setPasswordHash(passwordEncoder.encode(PW));
+        u.setDisplayName(email);
+        u.setRole(role);
+        u.setCohortId(cohortId);
+        u.setCreatedAt(now);
+        u.setUpdatedAt(now);
+        return userRepository.save(u).getEmail();
+    }
+}


### PR DESCRIPTION
## 関連 Issue

Closes #95

---

## 変更の概要

Phase 1 MVP §3-1 の4番目 **F-EVAL（講師の最終評価・承認）** を実装。要件 §3-2 で講師ロール限定＝重点軸の権限昇格防止の重点。

- 評価作成（POST /api/posts/{postId}/evaluation）：`result`（APPROVED=合格 / RETURNED=差し戻し）+ コメント。**講師ロール限定**
- 最新評価の取得（GET /api/posts/{postId}/evaluation）：同 cohort 可視・未評価は 404
- 1 投稿につき最新1件（is_latest）＋ 過去は履歴として保持（S-4）
- `approved` フラグは F-PROF-04 合格バッジの判定材料

### 認可（★重点軸 — 重点）
- 作成は `@PreAuthorize("hasRole('TEACHER')")` で受講生を **403**（権限昇格防止）
- 投稿が自 cohort でなければ **404**（他 cohort 講師も不可）
- 未ログイン **401**

## 変更の種別

- [x] feat（新機能の追加）
- [x] test（テストの追加・修正）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（`./gradlew test` グリーン・全22件）
- [x] 既存の機能が壊れていないことを確認した
- [x] `.env` ファイルやパスワードをコミットしていない（テスト用ダミー値のみ）

### 認可テスト（Testcontainers PostgreSQL 16）— 5件 green
講師は評価+最新取得 / **★受講生は403（権限昇格防止）** / 後勝ち+履歴2件 / 他 cohort 講師404 / 未ログイン401

---

## レビュー時に特に確認してほしい点

- ロール制御を `@PreAuthorize` のメソッドセキュリティで担保した点（`EnableMethodSecurity` 既設）。受講生の評価呼び出しが 403 になることをテストで固定
- 「最新1件＋履歴」の整合：新規評価時に旧 latest を false にしてから積む

> 補足：本 PR の検証中、`build/` 配下に iCloud 同期由来の `com.reviewboard 2` 重複コンパイル済みクラスが混入しテストランナーが落ちる事象があり、`./gradlew clean` で解消（src は無傷・生成物のみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)