### PR TITLE
feat: F-PROF 成長記録ページ（主役・集計）を実装

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/domain/evaluation/EvaluationRepository.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/evaluation/EvaluationRepository.java
@@ -12,4 +12,7 @@ public interface EvaluationRepository extends JpaRepository<Evaluation, Long> {
 
     /** 投稿の評価履歴（新しい順。母 S-4 履歴保持） */
     List<Evaluation> findByPostIdOrderByCreatedAtDesc(Long postId);
+
+    /** 成長記録（F-PROF-04）：複数投稿の最新評価をまとめて取得（合格バッジ判定・N+1回避） */
+    List<Evaluation> findByPostIdInAndLatestIsTrue(List<Long> postIds);
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/PostRepository.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/PostRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
@@ -13,4 +14,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     /** 単体取得も cohort 境界で絞る（他 cohort は不可視＝404 に倒す） */
     Optional<Post> findByIdAndCohortIdAndDeletedAtIsNull(Long id, Long cohortId);
+
+    /** 成長記録（F-PROF-01）：あるユーザーの投稿履歴（未削除・新しい順） */
+    List<Post> findByAuthorUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long authorUserId);
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/profile/ProfileController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/profile/ProfileController.java
@@ -1,0 +1,28 @@
+package com.reviewboard.domain.profile;
+
+import com.reviewboard.domain.auth.AuthPrincipal;
+import com.reviewboard.domain.profile.dto.ProfileResponse;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 成長記録ページ API（F-PROF・主役）。認証必須・同 cohort のメンバーのみ閲覧可。
+ */
+@RestController
+public class ProfileController {
+
+    private final ProfileService profileService;
+
+    public ProfileController(ProfileService profileService) {
+        this.profileService = profileService;
+    }
+
+    /** F-PROF 成長記録（投稿履歴・もらったレビュー・実績数・合格バッジ） */
+    @GetMapping("/api/users/{userId}/profile")
+    public ProfileResponse getProfile(@AuthenticationPrincipal AuthPrincipal principal,
+                                      @PathVariable Long userId) {
+        return profileService.getProfile(principal, userId);
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/profile/ProfileService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/profile/ProfileService.java
@@ -1,0 +1,90 @@
+package com.reviewboard.domain.profile;
+
+import com.reviewboard.common.ResourceNotFoundException;
+import com.reviewboard.domain.auth.AuthPrincipal;
+import com.reviewboard.domain.evaluation.Evaluation;
+import com.reviewboard.domain.evaluation.EvaluationRepository;
+import com.reviewboard.domain.evaluation.EvaluationResult;
+import com.reviewboard.domain.post.Post;
+import com.reviewboard.domain.post.PostRepository;
+import com.reviewboard.domain.profile.dto.ProfileResponse;
+import com.reviewboard.domain.review.Review;
+import com.reviewboard.domain.review.ReviewRepository;
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRepository;
+import com.reviewboard.domain.user.UserRole;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * 成長記録ページの集約（F-PROF・主役）。★S軸：閲覧対象は同 cohort のメンバーに限る（他 cohort は 404）。
+ * 投稿・評価・レビュー・reviewer をバッチで引いて N+1 を避ける（母 P-3）。
+ */
+@Service
+public class ProfileService {
+
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final ReviewRepository reviewRepository;
+    private final EvaluationRepository evaluationRepository;
+
+    public ProfileService(UserRepository userRepository, PostRepository postRepository,
+                         ReviewRepository reviewRepository, EvaluationRepository evaluationRepository) {
+        this.userRepository = userRepository;
+        this.postRepository = postRepository;
+        this.reviewRepository = reviewRepository;
+        this.evaluationRepository = evaluationRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public ProfileResponse getProfile(AuthPrincipal principal, Long userId) {
+        // cohort 境界：同 cohort のメンバーのみ可視（他 cohort は 404）
+        User target = userRepository.findByIdAndCohortId(userId, principal.cohortId())
+                .orElseThrow(() -> new ResourceNotFoundException("user not found: " + userId));
+
+        List<Post> posts = postRepository.findByAuthorUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(userId);
+        List<Long> postIds = posts.stream().map(Post::getId).toList();
+
+        Map<Long, EvaluationResult> latestByPost = postIds.isEmpty() ? Map.of()
+                : evaluationRepository.findByPostIdInAndLatestIsTrue(postIds).stream()
+                    .collect(Collectors.toMap(Evaluation::getPostId, Evaluation::getResult));
+
+        List<Review> reviews = postIds.isEmpty() ? List.of()
+                : reviewRepository.findByPostIdInAndDeletedAtIsNull(postIds);
+        Set<Long> reviewerIds = reviews.stream().map(Review::getReviewerUserId).collect(Collectors.toSet());
+        Map<Long, User> reviewers = reviewerIds.isEmpty() ? Map.of()
+                : userRepository.findAllById(reviewerIds).stream()
+                    .collect(Collectors.toMap(User::getId, Function.identity()));
+
+        List<ProfileResponse.PostEntry> postEntries = posts.stream().map(p -> {
+            EvaluationResult result = latestByPost.get(p.getId());
+            return new ProfileResponse.PostEntry(
+                    p.getId(), p.getTitle(), p.getRecruitStatus(), p.getReviewCount(),
+                    result == EvaluationResult.APPROVED, result, p.getCreatedAt());
+        }).toList();
+
+        List<ProfileResponse.ReceivedReview> received = reviews.stream().map(r -> {
+            User reviewer = reviewers.get(r.getReviewerUserId());
+            UserRole role = reviewer != null ? reviewer.getRole() : null;
+            return new ProfileResponse.ReceivedReview(
+                    r.getId(), r.getPostId(),
+                    reviewer != null ? reviewer.getDisplayName() : "(不明)",
+                    role, role == UserRole.TEACHER,
+                    r.getGood(), r.getImprovement(), r.getThanksCount(), r.getCreatedAt());
+        }).toList();
+
+        ProfileResponse.Stats stats = new ProfileResponse.Stats(
+                target.getReceivedReviewsCount(), target.getGivenReviewsCount(),
+                target.getThanksReceivedCount());
+
+        return new ProfileResponse(
+                target.getId(), target.getDisplayName(), target.getRole(), target.getBio(),
+                stats, postEntries, received);
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/profile/dto/ProfileResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/profile/dto/ProfileResponse.java
@@ -1,0 +1,50 @@
+package com.reviewboard.domain.profile.dto;
+
+import com.reviewboard.domain.evaluation.EvaluationResult;
+import com.reviewboard.domain.post.RecruitStatus;
+import com.reviewboard.domain.user.UserRole;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * 成長記録ページ（F-PROF・本アプリの主役）のレスポンス。
+ * 投稿履歴・もらったレビュー・実績数・合格バッジを1ユーザー視点で集約する。
+ */
+public record ProfileResponse(
+        Long userId,
+        String displayName,
+        UserRole role,
+        String bio,
+        Stats stats,
+        List<PostEntry> posts,
+        List<ReceivedReview> receivedReviews) {
+
+    /** F-PROF-03 実績数（非正規化カウンタ） */
+    public record Stats(int receivedReviewsCount, int givenReviewsCount, int thanksReceivedCount) {
+    }
+
+    /** F-PROF-01 投稿履歴 ＋ F-PROF-04 合格バッジ（approved） */
+    public record PostEntry(
+            Long postId,
+            String title,
+            RecruitStatus recruitStatus,
+            int reviewCount,
+            boolean approved,
+            EvaluationResult evaluationResult,
+            OffsetDateTime createdAt) {
+    }
+
+    /** F-PROF-02 もらったレビュー（reviewer の role で講師レビューを強調可能） */
+    public record ReceivedReview(
+            Long reviewId,
+            Long postId,
+            String reviewerDisplayName,
+            UserRole reviewerRole,
+            boolean teacherReview,
+            String good,
+            String improvement,
+            int thanksCount,
+            OffsetDateTime createdAt) {
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewRepository.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewRepository.java
@@ -13,6 +13,9 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     /** 単体取得（未削除のみ） */
     Optional<Review> findByIdAndDeletedAtIsNull(Long id);
 
+    /** 成長記録（F-PROF-02）：複数投稿に付いたレビューをまとめて取得（N+1回避） */
+    List<Review> findByPostIdInAndDeletedAtIsNull(List<Long> postIds);
+
     /** したレビュー実績（F-PROF-03） */
     List<Review> findByReviewerUserIdAndDeletedAtIsNull(Long reviewerUserId);
 }

--- a/review-board/backend/src/test/java/com/reviewboard/domain/profile/ProfileAuthorizationIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/profile/ProfileAuthorizationIntegrationTest.java
@@ -1,0 +1,216 @@
+package com.reviewboard.domain.profile;
+
+import com.reviewboard.domain.auth.AuthCookies;
+import com.reviewboard.domain.auth.RefreshTokenRepository;
+import com.reviewboard.domain.cohort.Cohort;
+import com.reviewboard.domain.cohort.CohortRepository;
+import com.reviewboard.domain.evaluation.EvaluationRepository;
+import com.reviewboard.domain.post.PostRepository;
+import com.reviewboard.domain.review.ReviewAxisCommentRepository;
+import com.reviewboard.domain.review.ReviewRepository;
+import com.reviewboard.domain.review.ThanksRepository;
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRepository;
+import com.reviewboard.domain.user.UserRole;
+import com.jayway.jsonpath.JsonPath;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * F-PROF 成長記録ページの認可・集約テスト（★S軸・テスト計画書 §6）。
+ * 投稿履歴/もらったレビュー(講師強調)/合格バッジ/したレビュー実績の集約と、
+ * cohort 境界（他 cohort は 404）・未認証を検証する。
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class ProfileAuthorizationIntegrationTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("app.jwt.secret", () -> "test-secret-please-change-32chars-minimum");
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired CohortRepository cohortRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired PostRepository postRepository;
+    @Autowired ReviewRepository reviewRepository;
+    @Autowired ReviewAxisCommentRepository axisCommentRepository;
+    @Autowired ThanksRepository thanksRepository;
+    @Autowired EvaluationRepository evaluationRepository;
+    @Autowired RefreshTokenRepository refreshTokenRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+
+    private static final String PW = "correct-horse-battery";
+
+    private long authorId;
+    private long reviewerId;
+    private String authorEmail;
+    private String reviewerEmail;
+    private String teacherEmail;
+    private String bEmail;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        thanksRepository.deleteAll();
+        axisCommentRepository.deleteAll();
+        evaluationRepository.deleteAll();
+        reviewRepository.deleteAll();
+        postRepository.deleteAll();
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        cohortRepository.deleteAll();
+
+        Cohort a = newCohort("A");
+        Cohort b = newCohort("B");
+        User author = newUser("author@example.com", UserRole.STUDENT, a.getId());
+        User reviewer = newUser("reviewer@example.com", UserRole.STUDENT, a.getId());
+        authorId = author.getId();
+        reviewerId = reviewer.getId();
+        authorEmail = author.getEmail();
+        reviewerEmail = reviewer.getEmail();
+        teacherEmail = newUser("teacher@example.com", UserRole.TEACHER, a.getId()).getEmail();
+        bEmail = newUser("b@example.com", UserRole.STUDENT, b.getId()).getEmail();
+
+        // author が投稿2件。post1 をレビュー(受講生+講師)・ありがとう・講師承認する
+        Cookie authorCookie = login(authorEmail);
+        long post1 = createPost(authorCookie, "作品1");
+        createPost(authorCookie, "作品2");
+
+        long studentReview = createReview(login(reviewerEmail), post1);
+        createReview(login(teacherEmail), post1);                 // 講師レビュー
+        thank(authorCookie, studentReview);                       // author が reviewer に感謝
+        evaluate(login(teacherEmail), post1, "APPROVED", "合格");  // 合格バッジ
+    }
+
+    @Test
+    void author_profile_aggregates_posts_received_reviews_and_badge() throws Exception {
+        mockMvc.perform(get("/api/users/" + authorId + "/profile").cookie(login(authorEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.posts.length()").value(2))
+                // 新しい順：作品2 が先頭、作品1 は合格バッジ付き
+                .andExpect(jsonPath("$.posts[?(@.title == '作品1')].approved").value(true))
+                // もらったレビューは2件（受講生＋講師）、講師レビューが強調対象
+                .andExpect(jsonPath("$.receivedReviews.length()").value(2))
+                .andExpect(jsonPath("$.receivedReviews[?(@.teacherReview == true)].reviewerRole").value("TEACHER"))
+                // F-PROF-03 もらったレビュー数（author 視点）
+                .andExpect(jsonPath("$.stats.receivedReviewsCount").value(2));
+    }
+
+    @Test
+    void reviewer_profile_shows_given_stats_and_thanks() throws Exception {
+        mockMvc.perform(get("/api/users/" + reviewerId + "/profile").cookie(login(reviewerEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.stats.givenReviewsCount").value(1))
+                .andExpect(jsonPath("$.stats.thanksReceivedCount").value(1))
+                .andExpect(jsonPath("$.posts.length()").value(0));
+    }
+
+    @Test
+    void same_cohort_member_can_view_others_profile() throws Exception {
+        mockMvc.perform(get("/api/users/" + authorId + "/profile").cookie(login(reviewerEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value((int) authorId));
+    }
+
+    @Test
+    void other_cohort_cannot_view_profile_returns404() throws Exception {
+        mockMvc.perform(get("/api/users/" + authorId + "/profile").cookie(login(bEmail)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void unauthenticated_is_rejected() throws Exception {
+        mockMvc.perform(get("/api/users/" + authorId + "/profile"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ---- helpers ----
+
+    private long createPost(Cookie cookie, String title) throws Exception {
+        MvcResult res = mockMvc.perform(post("/api/posts").cookie(cookie)
+                        .contentType("application/json")
+                        .content("{\"title\":\"" + title + "\",\"description\":\"説明\"}"))
+                .andExpect(status().isCreated()).andReturn();
+        return readId(res);
+    }
+
+    private long createReview(Cookie cookie, long postId) throws Exception {
+        MvcResult res = mockMvc.perform(post("/api/posts/" + postId + "/reviews").cookie(cookie)
+                        .contentType("application/json")
+                        .content("{\"good\":\"よい\",\"improvement\":\"改善\"}"))
+                .andExpect(status().isCreated()).andReturn();
+        return readId(res);
+    }
+
+    private void thank(Cookie cookie, long reviewId) throws Exception {
+        mockMvc.perform(post("/api/reviews/" + reviewId + "/thanks").cookie(cookie))
+                .andExpect(status().isNoContent());
+    }
+
+    private void evaluate(Cookie cookie, long postId, String result, String comment) throws Exception {
+        mockMvc.perform(post("/api/posts/" + postId + "/evaluation").cookie(cookie)
+                        .contentType("application/json")
+                        .content("{\"result\":\"" + result + "\",\"comment\":\"" + comment + "\"}"))
+                .andExpect(status().isOk());
+    }
+
+    private long readId(MvcResult res) throws Exception {
+        return JsonPath.parse(res.getResponse().getContentAsString()).read("$.id", Integer.class).longValue();
+    }
+
+    private Cookie login(String email) throws Exception {
+        MvcResult res = mockMvc.perform(post("/api/auth/login")
+                        .contentType("application/json")
+                        .content("{\"email\":\"" + email + "\",\"password\":\"" + PW + "\"}"))
+                .andExpect(status().isOk()).andReturn();
+        Cookie access = res.getResponse().getCookie(AuthCookies.ACCESS);
+        assertThat(access).isNotNull();
+        return access;
+    }
+
+    private Cohort newCohort(String name) {
+        Cohort c = new Cohort();
+        c.setName(name);
+        c.setCreatedAt(OffsetDateTime.now());
+        return cohortRepository.save(c);
+    }
+
+    private User newUser(String email, UserRole role, Long cohortId) {
+        OffsetDateTime now = OffsetDateTime.now();
+        User u = new User();
+        u.setEmail(email);
+        u.setPasswordHash(passwordEncoder.encode(PW));
+        u.setDisplayName(email);
+        u.setRole(role);
+        u.setCohortId(cohortId);
+        u.setCreatedAt(now);
+        u.setUpdatedAt(now);
+        return userRepository.save(u);
+    }
+}


### PR DESCRIPTION
## 関連 Issue

Closes #97

---

## 変更の概要

Phase 1 MVP §3-1 の最後 **F-PROF（成長記録ページ＝本アプリの主役）** を実装。これで「投稿 → レビュー → 成長記録」の最小一周が揃う。

- GET /api/users/{userId}/profile（同 cohort のメンバーのみ閲覧可）
- **F-PROF-01** 投稿した成果物の履歴（新しい順）
- **F-PROF-02** もらったレビュー一覧（reviewer の role を含め講師レビューを強調可能に・`teacherReview`）
- **F-PROF-03** したレビューの実績（件数・もらった「ありがとう」数＝非正規化カウンタ）
- **F-PROF-04** 講師に承認された成果物の合格バッジ（最新評価が APPROVED → `approved`）

### 認可（★重点軸）
- プロフィール閲覧は **同 cohort のみ**（他 cohort は **404**・`findByIdAndCohortId`）
- 未ログイン **401**
- posts / 評価 / レビュー / reviewer をバッチ取得し N+1 を回避（P-3）

## 変更の種別

- [x] feat（新機能の追加）
- [x] test（テストの追加・修正）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（`./gradlew test` グリーン・**全27件**）
- [x] 既存の機能が壊れていないことを確認した
- [x] `.env` ファイルやパスワードをコミットしていない（テスト用ダミー値のみ）

### 認可・集約テスト（Testcontainers PostgreSQL 16）— 5件 green
投稿+レビュー+合格バッジの集約 / したレビュー実績+ありがとう数 / 同 cohort 他者は閲覧可 / 他 cohort 404 / 未ログイン401

---

## レビュー時に特に確認してほしい点

- 集約のバッチ取得（投稿IDで評価・レビューをまとめ引き）が N+1 を避けられているか
- 合格バッジ（F-PROF-04）の判定が「最新評価＝APPROVED」になっているか

> これで Phase1 §3-1（F-AUTH #90 / F-POST #92 / F-REV #94 / F-EVAL #96 / F-PROF 本PR）が完了。次は React/Vite フロント雛形・付録A A/重点判定表が候補。

🤖 Generated with [Claude Code](https://claude.com/claude-code)