### PR TITLE
feat: 監査ログ（audit_logs）の記録と閲覧を実装

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/domain/audit/AuditAction.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/audit/AuditAction.java
@@ -1,0 +1,16 @@
+package com.reviewboard.domain.audit;
+
+/**
+ * 監査対象のアクション（★S軸・要件 §4-1）。「誰が・何をしたか」の「何を」。
+ * 名前は audit_logs.action(VARCHAR(50)) に格納する。
+ */
+public enum AuditAction {
+    POST_CREATED,
+    POST_UPDATED,
+    POST_DELETED,
+    REVIEW_CREATED,
+    REVIEW_DELETED,
+    THANKS_SENT,
+    EVALUATION_APPROVED,
+    EVALUATION_RETURNED
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/audit/AuditController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/audit/AuditController.java
@@ -1,0 +1,34 @@
+package com.reviewboard.domain.audit;
+
+import com.reviewboard.domain.audit.dto.AuditLogResponse;
+import com.reviewboard.domain.auth.AuthPrincipal;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 監査ログ閲覧 API（★S軸）。監査情報は機微なため講師ロール限定・自 cohort のみ。
+ */
+@RestController
+@RequestMapping("/api/audit-logs")
+public class AuditController {
+
+    private final AuditService auditService;
+
+    public AuditController(AuditService auditService) {
+        this.auditService = auditService;
+    }
+
+    /** 監査ログ一覧（講師限定・自 cohort・新しい順） */
+    @PreAuthorize("hasRole('TEACHER')")
+    @GetMapping
+    public Page<AuditLogResponse> list(@AuthenticationPrincipal AuthPrincipal principal,
+                                       @PageableDefault(size = 50) Pageable pageable) {
+        return auditService.listForCohort(principal, pageable).map(AuditLogResponse::from);
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/audit/AuditLog.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/audit/AuditLog.java
@@ -1,0 +1,44 @@
+package com.reviewboard.domain.audit;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 監査ログ（★S軸・要件 §4-1）。「誰が(actor)・いつ(createdAt)・誰の資源に(targetType/targetId)・
+ * 何を(action)」を追跡する。cohort_id を持ち、閲覧の cohort 境界に使う。
+ */
+@Entity
+@Table(name = "audit_logs")
+@Getter
+@Setter
+@NoArgsConstructor
+public class AuditLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "actor_user_id", nullable = false)
+    private Long actorUserId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private AuditAction action;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_type", nullable = false, length = 30)
+    private AuditTargetType targetType;
+
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
+
+    @Column(name = "cohort_id", nullable = false)
+    private Long cohortId;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/audit/AuditLogRepository.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/audit/AuditLogRepository.java
@@ -1,0 +1,11 @@
+package com.reviewboard.domain.audit;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuditLogRepository extends JpaRepository<AuditLog, Long> {
+
+    /** 閲覧（★S軸）：自 cohort の監査ログのみ・新しい順。他 cohort は返さない。 */
+    Page<AuditLog> findByCohortIdOrderByCreatedAtDesc(Long cohortId, Pageable pageable);
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/audit/AuditService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/audit/AuditService.java
@@ -1,0 +1,45 @@
+package com.reviewboard.domain.audit;
+
+import com.reviewboard.domain.auth.AuthPrincipal;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 監査ログの記録と閲覧（★S軸・要件 §4-1）。
+ *
+ * <p>記録は呼び出し元の {@code @Transactional} に参加する（{@code MANDATORY}）。これにより
+ * 「操作がコミットされたときだけ監査行も残る」を保証し、ログだけ残る/操作だけ残るを防ぐ。
+ * actor・cohort は principal（検証済み JWT）から導出し、クライアント入力を信用しない。
+ */
+@Service
+public class AuditService {
+
+    private final AuditLogRepository repository;
+
+    public AuditService(AuditLogRepository repository) {
+        this.repository = repository;
+    }
+
+    /** 監査行を記録する。認可チェックを通過した操作の後で呼ぶこと。 */
+    @Transactional(propagation = org.springframework.transaction.annotation.Propagation.MANDATORY)
+    public void record(AuthPrincipal actor, AuditAction action, AuditTargetType targetType, Long targetId) {
+        AuditLog log = new AuditLog();
+        log.setActorUserId(actor.userId());
+        log.setAction(action);
+        log.setTargetType(targetType);
+        log.setTargetId(targetId);
+        log.setCohortId(actor.cohortId());
+        log.setCreatedAt(OffsetDateTime.now());
+        repository.save(log);
+    }
+
+    /** 閲覧（講師限定は Controller の @PreAuthorize で担保）。自 cohort のログのみ。 */
+    @Transactional(readOnly = true)
+    public Page<AuditLog> listForCohort(AuthPrincipal principal, Pageable pageable) {
+        return repository.findByCohortIdOrderByCreatedAtDesc(principal.cohortId(), pageable);
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/audit/AuditTargetType.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/audit/AuditTargetType.java
@@ -1,0 +1,11 @@
+package com.reviewboard.domain.audit;
+
+/**
+ * 監査対象の資源種別（★S軸）。「誰の資源に」の資源の型。
+ * 名前は audit_logs.target_type(VARCHAR(30)) に格納する。
+ */
+public enum AuditTargetType {
+    POST,
+    REVIEW,
+    EVALUATION
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/audit/dto/AuditLogResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/audit/dto/AuditLogResponse.java
@@ -1,0 +1,26 @@
+package com.reviewboard.domain.audit.dto;
+
+import com.reviewboard.domain.audit.AuditAction;
+import com.reviewboard.domain.audit.AuditLog;
+import com.reviewboard.domain.audit.AuditTargetType;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 監査ログの閲覧レスポンス（★S軸）。誰が(actorUserId)・いつ(createdAt)・
+ * 誰の資源に(targetType/targetId)・何を(action)。
+ */
+public record AuditLogResponse(
+        Long id,
+        Long actorUserId,
+        AuditAction action,
+        AuditTargetType targetType,
+        Long targetId,
+        OffsetDateTime createdAt) {
+
+    public static AuditLogResponse from(AuditLog log) {
+        return new AuditLogResponse(
+                log.getId(), log.getActorUserId(), log.getAction(),
+                log.getTargetType(), log.getTargetId(), log.getCreatedAt());
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/evaluation/EvaluationService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/evaluation/EvaluationService.java
@@ -1,6 +1,9 @@
 package com.reviewboard.domain.evaluation;
 
 import com.reviewboard.common.ResourceNotFoundException;
+import com.reviewboard.domain.audit.AuditAction;
+import com.reviewboard.domain.audit.AuditService;
+import com.reviewboard.domain.audit.AuditTargetType;
 import com.reviewboard.domain.auth.AuthPrincipal;
 import com.reviewboard.domain.evaluation.dto.EvaluationRequest;
 import com.reviewboard.domain.post.Post;
@@ -21,10 +24,13 @@ public class EvaluationService {
 
     private final EvaluationRepository evaluationRepository;
     private final PostRepository postRepository;
+    private final AuditService auditService;
 
-    public EvaluationService(EvaluationRepository evaluationRepository, PostRepository postRepository) {
+    public EvaluationService(EvaluationRepository evaluationRepository, PostRepository postRepository,
+                             AuditService auditService) {
         this.evaluationRepository = evaluationRepository;
         this.postRepository = postRepository;
+        this.auditService = auditService;
     }
 
     /**
@@ -46,7 +52,12 @@ public class EvaluationService {
         eval.setComment(req.comment());
         eval.setLatest(true);
         eval.setCreatedAt(OffsetDateTime.now());
-        return evaluationRepository.save(eval);
+        evaluationRepository.save(eval);
+
+        AuditAction action = req.result() == EvaluationResult.APPROVED
+                ? AuditAction.EVALUATION_APPROVED : AuditAction.EVALUATION_RETURNED;
+        auditService.record(principal, action, AuditTargetType.EVALUATION, eval.getId());
+        return eval;
     }
 
     /** 最新評価の取得（同 cohort のみ可視）。未評価は 404。 */

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/PostService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/PostService.java
@@ -1,6 +1,9 @@
 package com.reviewboard.domain.post;
 
 import com.reviewboard.common.ResourceNotFoundException;
+import com.reviewboard.domain.audit.AuditAction;
+import com.reviewboard.domain.audit.AuditService;
+import com.reviewboard.domain.audit.AuditTargetType;
 import com.reviewboard.domain.auth.AuthPrincipal;
 import com.reviewboard.domain.post.dto.PostCreateRequest;
 import com.reviewboard.domain.post.dto.PostUpdateRequest;
@@ -21,9 +24,11 @@ import java.time.OffsetDateTime;
 public class PostService {
 
     private final PostRepository postRepository;
+    private final AuditService auditService;
 
-    public PostService(PostRepository postRepository) {
+    public PostService(PostRepository postRepository, AuditService auditService) {
         this.postRepository = postRepository;
+        this.auditService = auditService;
     }
 
     /** F-POST-01 作成。cohort と author は principal（検証済み）から導出する。 */
@@ -41,7 +46,9 @@ public class PostService {
         post.setRecruitStatus(RecruitStatus.OPEN);
         post.setCreatedAt(now);
         post.setUpdatedAt(now);
-        return postRepository.save(post);
+        postRepository.save(post);
+        auditService.record(principal, AuditAction.POST_CREATED, AuditTargetType.POST, post.getId());
+        return post;
     }
 
     /** F-POST-03 単体取得。自 cohort かつ未削除のみ可視（他は 404）。 */
@@ -67,6 +74,7 @@ public class PostService {
         post.setDemoUrl(req.demoUrl());
         post.setScreenshotKey(req.screenshotKey());
         post.setUpdatedAt(OffsetDateTime.now());
+        auditService.record(principal, AuditAction.POST_UPDATED, AuditTargetType.POST, postId);
         return post;
     }
 
@@ -75,6 +83,7 @@ public class PostService {
     public void delete(AuthPrincipal principal, Long postId) {
         Post post = loadOwned(principal, postId);
         post.setDeletedAt(OffsetDateTime.now());
+        auditService.record(principal, AuditAction.POST_DELETED, AuditTargetType.POST, postId);
     }
 
     /**

--- a/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewService.java
@@ -2,6 +2,9 @@ package com.reviewboard.domain.review;
 
 import com.reviewboard.common.InvalidRequestException;
 import com.reviewboard.common.ResourceNotFoundException;
+import com.reviewboard.domain.audit.AuditAction;
+import com.reviewboard.domain.audit.AuditService;
+import com.reviewboard.domain.audit.AuditTargetType;
 import com.reviewboard.domain.auth.AuthPrincipal;
 import com.reviewboard.domain.post.Post;
 import com.reviewboard.domain.post.PostRepository;
@@ -33,17 +36,20 @@ public class ReviewService {
     private final ThanksRepository thanksRepository;
     private final PostRepository postRepository;
     private final UserRepository userRepository;
+    private final AuditService auditService;
 
     public ReviewService(ReviewRepository reviewRepository,
                          ReviewAxisCommentRepository axisCommentRepository,
                          ThanksRepository thanksRepository,
                          PostRepository postRepository,
-                         UserRepository userRepository) {
+                         UserRepository userRepository,
+                         AuditService auditService) {
         this.reviewRepository = reviewRepository;
         this.axisCommentRepository = axisCommentRepository;
         this.thanksRepository = thanksRepository;
         this.postRepository = postRepository;
         this.userRepository = userRepository;
+        this.auditService = auditService;
     }
 
     /** F-REV-01 作成。同 cohort の投稿のみ・自己レビュー禁止。 */
@@ -69,6 +75,8 @@ public class ReviewService {
         post.setReviewCount(post.getReviewCount() + 1);
         adjustCount(principal.userId(), 0, +1);            // reviewer の「したレビュー」
         adjustCount(post.getAuthorUserId(), +1, 0);        // author の「もらったレビュー」
+
+        auditService.record(principal, AuditAction.REVIEW_CREATED, AuditTargetType.REVIEW, review.getId());
 
         User reviewer = userRepository.findById(principal.userId()).orElseThrow();
         return ReviewResponse.from(review, reviewer.getDisplayName(), reviewer.getRole(), axisComments);
@@ -126,6 +134,7 @@ public class ReviewService {
             adjustCount(p.getAuthorUserId(), -1, 0);
         });
         adjustCount(principal.userId(), 0, -1);
+        auditService.record(principal, AuditAction.REVIEW_DELETED, AuditTargetType.REVIEW, reviewId);
     }
 
     /** F-REV-03 ありがとう（投稿者のみ・冪等）。reviewer の実績に反映。 */
@@ -151,6 +160,7 @@ public class ReviewService {
 
         review.setThanksCount(review.getThanksCount() + 1);
         adjustThanksReceived(review.getReviewerUserId(), +1);
+        auditService.record(principal, AuditAction.THANKS_SENT, AuditTargetType.REVIEW, reviewId);
     }
 
     // ---- helpers ----

--- a/review-board/backend/src/test/java/com/reviewboard/domain/audit/AuditAuthorizationIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/audit/AuditAuthorizationIntegrationTest.java
@@ -1,0 +1,79 @@
+package com.reviewboard.domain.audit;
+
+import com.reviewboard.domain.user.UserRole;
+import com.reviewboard.support.AbstractIntegrationTest;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * S軸 監査ログの認可・記録テスト（要件 §4-1）。
+ * 操作が監査行として残ること、閲覧が講師限定・自 cohort のみであることを検証する。
+ */
+class AuditAuthorizationIntegrationTest extends AbstractIntegrationTest {
+
+    private String authorEmail;
+    private String teacherEmail;
+    private String teacherBEmail;
+
+    @BeforeEach
+    void seed() throws Exception {
+        var a = newCohort("A");
+        var b = newCohort("B");
+        authorEmail = newUser("author@example.com", UserRole.STUDENT, a.getId()).getEmail();
+        teacherEmail = newUser("teacher@example.com", UserRole.TEACHER, a.getId()).getEmail();
+        teacherBEmail = newUser("teacherB@example.com", UserRole.TEACHER, b.getId()).getEmail();
+
+        // cohort A で活動：投稿作成 → 講師承認（監査行が2件残るはず）
+        long postId = createPost(login(authorEmail), "作品");
+        mockMvc.perform(post("/api/posts/" + postId + "/evaluation").cookie(login(teacherEmail))
+                        .contentType("application/json")
+                        .content("{\"result\":\"APPROVED\",\"comment\":\"合格\"}"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void actions_are_recorded_and_visible_to_teacher() throws Exception {
+        mockMvc.perform(get("/api/audit-logs").cookie(login(teacherEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(2))
+                .andExpect(jsonPath("$.content[?(@.action == 'POST_CREATED')]").exists())
+                .andExpect(jsonPath("$.content[?(@.action == 'EVALUATION_APPROVED')]").exists());
+    }
+
+    /** ★監査情報は機微：受講生は閲覧できない（403）。 */
+    @Test
+    void student_cannot_view_audit_logs_returns403() throws Exception {
+        mockMvc.perform(get("/api/audit-logs").cookie(login(authorEmail)))
+                .andExpect(status().isForbidden());
+    }
+
+    /** cohort 分離：他 cohort の講師には cohort A のログが見えない。 */
+    @Test
+    void teacher_sees_only_own_cohort_logs() throws Exception {
+        mockMvc.perform(get("/api/audit-logs").cookie(login(teacherBEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(0));
+        assertThat(auditLogRepository.count()).isEqualTo(2);
+    }
+
+    @Test
+    void unauthenticated_is_rejected() throws Exception {
+        mockMvc.perform(get("/api/audit-logs"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    private long createPost(Cookie cookie, String title) throws Exception {
+        MvcResult res = mockMvc.perform(post("/api/posts").cookie(cookie)
+                        .contentType("application/json")
+                        .content("{\"title\":\"" + title + "\",\"description\":\"説明\"}"))
+                .andExpect(status().isCreated()).andReturn();
+        return readId(res);
+    }
+}

--- a/review-board/backend/src/test/java/com/reviewboard/domain/auth/AuthIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/auth/AuthIntegrationTest.java
@@ -1,26 +1,12 @@
 package com.reviewboard.domain.auth;
 
 import com.reviewboard.domain.cohort.Cohort;
-import com.reviewboard.domain.cohort.CohortRepository;
-import com.reviewboard.domain.user.User;
-import com.reviewboard.domain.user.UserRepository;
 import com.reviewboard.domain.user.UserRole;
+import com.reviewboard.support.AbstractIntegrationTest;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-
-import java.time.OffsetDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -31,56 +17,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * F-AUTH の認可テスト（テスト計画書 §6 マトリクスの認証部分）。
  * Testcontainers PostgreSQL で本番同等の DB に対して検証する。
  */
-@SpringBootTest
-@AutoConfigureMockMvc
-@Testcontainers
-class AuthIntegrationTest {
-
-    @Container
-    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", postgres::getJdbcUrl);
-        registry.add("spring.datasource.username", postgres::getUsername);
-        registry.add("spring.datasource.password", postgres::getPassword);
-        registry.add("app.jwt.secret", () -> "test-secret-please-change-32chars-minimum");
-    }
-
-    @Autowired MockMvc mockMvc;
-    @Autowired CohortRepository cohortRepository;
-    @Autowired UserRepository userRepository;
-    @Autowired RefreshTokenRepository refreshTokenRepository;
-    @Autowired PasswordEncoder passwordEncoder;
-
-    private static final String PASSWORD = "correct-horse-battery";
+class AuthIntegrationTest extends AbstractIntegrationTest {
 
     @BeforeEach
-    void setUp() {
-        // refresh_tokens は users への FK を持つため、user より先に消す（テスト間の分離）。
-        refreshTokenRepository.deleteAll();
-        userRepository.deleteAll();
-        cohortRepository.deleteAll();
-        OffsetDateTime now = OffsetDateTime.now();
-        Cohort cohort = new Cohort();
-        cohort.setName("test cohort");
-        cohort.setCreatedAt(now);
-        cohort = cohortRepository.save(cohort);
-
-        User student = new User();
-        student.setEmail("student@example.com");
-        student.setPasswordHash(passwordEncoder.encode(PASSWORD));
-        student.setDisplayName("受講生");
-        student.setRole(UserRole.STUDENT);
-        student.setCohortId(cohort.getId());
-        student.setCreatedAt(now);
-        student.setUpdatedAt(now);
-        userRepository.save(student);
+    void seed() {
+        Cohort cohort = newCohort("test cohort");
+        newUser("student@example.com", UserRole.STUDENT, cohort.getId());
     }
 
     @Test
     void login_success_setsCookie_andMeReturnsUser() throws Exception {
-        // 正常系：ログイン成功 → access_token Cookie 発行
         MvcResult result = mockMvc.perform(post("/api/auth/login")
                         .contentType("application/json")
                         .content("{\"email\":\"student@example.com\",\"password\":\"" + PASSWORD + "\"}"))
@@ -92,7 +38,6 @@ class AuthIntegrationTest {
         assertThat(access).isNotNull();
         assertThat(access.isHttpOnly()).isTrue();
 
-        // その Cookie で /me が通る（認証済み）
         mockMvc.perform(get("/api/auth/me").cookie(access))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.role").value("STUDENT"));

--- a/review-board/backend/src/test/java/com/reviewboard/domain/evaluation/EvaluationAuthorizationIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/evaluation/EvaluationAuthorizationIntegrationTest.java
@@ -1,30 +1,13 @@
 package com.reviewboard.domain.evaluation;
 
-import com.reviewboard.domain.auth.AuthCookies;
-import com.reviewboard.domain.auth.RefreshTokenRepository;
 import com.reviewboard.domain.cohort.Cohort;
-import com.reviewboard.domain.cohort.CohortRepository;
-import com.reviewboard.domain.post.PostRepository;
-import com.reviewboard.domain.user.User;
-import com.reviewboard.domain.user.UserRepository;
 import com.reviewboard.domain.user.UserRole;
+import com.reviewboard.support.AbstractIntegrationTest;
 import com.jayway.jsonpath.JsonPath;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-
-import java.time.OffsetDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -34,31 +17,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * F-EVAL の認可テスト（★S軸の重点＝権限昇格防止）。
  * 受講生が講師限定の評価操作を呼べないこと（403）を中心に、cohort 境界・最新後勝ち＋履歴を検証する。
  */
-@SpringBootTest
-@AutoConfigureMockMvc
-@Testcontainers
-class EvaluationAuthorizationIntegrationTest {
-
-    @Container
-    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", postgres::getJdbcUrl);
-        registry.add("spring.datasource.username", postgres::getUsername);
-        registry.add("spring.datasource.password", postgres::getPassword);
-        registry.add("app.jwt.secret", () -> "test-secret-please-change-32chars-minimum");
-    }
-
-    @Autowired MockMvc mockMvc;
-    @Autowired CohortRepository cohortRepository;
-    @Autowired UserRepository userRepository;
-    @Autowired PostRepository postRepository;
-    @Autowired EvaluationRepository evaluationRepository;
-    @Autowired RefreshTokenRepository refreshTokenRepository;
-    @Autowired PasswordEncoder passwordEncoder;
-
-    private static final String PW = "correct-horse-battery";
+class EvaluationAuthorizationIntegrationTest extends AbstractIntegrationTest {
 
     private String authorEmail;    // cohort A・受講生・投稿者
     private String teacherEmail;   // cohort A・講師
@@ -66,18 +25,12 @@ class EvaluationAuthorizationIntegrationTest {
     private long postId;
 
     @BeforeEach
-    void setUp() throws Exception {
-        evaluationRepository.deleteAll();
-        postRepository.deleteAll();
-        refreshTokenRepository.deleteAll();
-        userRepository.deleteAll();
-        cohortRepository.deleteAll();
-
+    void seed() throws Exception {
         Cohort a = newCohort("A");
         Cohort b = newCohort("B");
-        authorEmail = newUser("author@example.com", UserRole.STUDENT, a.getId());
-        teacherEmail = newUser("teacher@example.com", UserRole.TEACHER, a.getId());
-        teacherBEmail = newUser("teacherB@example.com", UserRole.TEACHER, b.getId());
+        authorEmail = newUser("author@example.com", UserRole.STUDENT, a.getId()).getEmail();
+        teacherEmail = newUser("teacher@example.com", UserRole.TEACHER, a.getId()).getEmail();
+        teacherBEmail = newUser("teacherB@example.com", UserRole.TEACHER, b.getId()).getEmail();
 
         MvcResult res = mockMvc.perform(post("/api/posts").cookie(login(authorEmail))
                         .contentType("application/json")
@@ -107,7 +60,6 @@ class EvaluationAuthorizationIntegrationTest {
                         .content("{\"result\":\"APPROVED\",\"comment\":\"自己承認の試み\"}"))
                 .andExpect(status().isForbidden());
 
-        // 評価は1件も作られていない
         assertThat(evaluationRepository.findByPostIdOrderByCreatedAtDesc(postId)).isEmpty();
     }
 
@@ -117,10 +69,8 @@ class EvaluationAuthorizationIntegrationTest {
         evaluate(teacher, "RETURNED", "差し戻し");
         evaluate(teacher, "APPROVED", "再提出を承認");
 
-        // 最新は APPROVED（後勝ち）
         mockMvc.perform(get("/api/posts/" + postId + "/evaluation").cookie(teacher))
                 .andExpect(jsonPath("$.result").value("APPROVED"));
-        // 履歴は2件残る（母 S-4）
         assertThat(evaluationRepository.findByPostIdOrderByCreatedAtDesc(postId)).hasSize(2);
         assertThat(evaluationRepository.findByPostIdAndLatestIsTrue(postId)).isPresent();
     }
@@ -141,42 +91,10 @@ class EvaluationAuthorizationIntegrationTest {
                 .andExpect(status().isUnauthorized());
     }
 
-    // ---- helpers ----
-
     private void evaluate(Cookie teacher, String result, String comment) throws Exception {
         mockMvc.perform(post("/api/posts/" + postId + "/evaluation").cookie(teacher)
                         .contentType("application/json")
                         .content("{\"result\":\"" + result + "\",\"comment\":\"" + comment + "\"}"))
                 .andExpect(status().isOk());
-    }
-
-    private Cookie login(String email) throws Exception {
-        MvcResult res = mockMvc.perform(post("/api/auth/login")
-                        .contentType("application/json")
-                        .content("{\"email\":\"" + email + "\",\"password\":\"" + PW + "\"}"))
-                .andExpect(status().isOk()).andReturn();
-        Cookie access = res.getResponse().getCookie(AuthCookies.ACCESS);
-        assertThat(access).isNotNull();
-        return access;
-    }
-
-    private Cohort newCohort(String name) {
-        Cohort c = new Cohort();
-        c.setName(name);
-        c.setCreatedAt(OffsetDateTime.now());
-        return cohortRepository.save(c);
-    }
-
-    private String newUser(String email, UserRole role, Long cohortId) {
-        OffsetDateTime now = OffsetDateTime.now();
-        User u = new User();
-        u.setEmail(email);
-        u.setPasswordHash(passwordEncoder.encode(PW));
-        u.setDisplayName(email);
-        u.setRole(role);
-        u.setCohortId(cohortId);
-        u.setCreatedAt(now);
-        u.setUpdatedAt(now);
-        return userRepository.save(u).getEmail();
     }
 }

--- a/review-board/backend/src/test/java/com/reviewboard/domain/post/PostAuthorizationIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/post/PostAuthorizationIntegrationTest.java
@@ -1,30 +1,13 @@
 package com.reviewboard.domain.post;
 
-import com.reviewboard.domain.auth.AuthCookies;
-import com.reviewboard.domain.auth.RefreshTokenRepository;
 import com.reviewboard.domain.cohort.Cohort;
-import com.reviewboard.domain.cohort.CohortRepository;
-import com.reviewboard.domain.user.User;
-import com.reviewboard.domain.user.UserRepository;
 import com.reviewboard.domain.user.UserRole;
+import com.reviewboard.support.AbstractIntegrationTest;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
-import java.time.OffsetDateTime;
-
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -34,43 +17,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * <p>cohort A（所有者 a1・同 cohort の a2）と cohort B（b1）を用意し、
  * 所有者境界・cohort 境界・未認証を網羅する。他人/他 cohort は存在を漏らさず 404（IDOR 遮断）。
  */
-@SpringBootTest
-@AutoConfigureMockMvc
-@Testcontainers
-class PostAuthorizationIntegrationTest {
-
-    @Container
-    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", postgres::getJdbcUrl);
-        registry.add("spring.datasource.username", postgres::getUsername);
-        registry.add("spring.datasource.password", postgres::getPassword);
-        registry.add("app.jwt.secret", () -> "test-secret-please-change-32chars-minimum");
-    }
-
-    @Autowired MockMvc mockMvc;
-    @Autowired CohortRepository cohortRepository;
-    @Autowired UserRepository userRepository;
-    @Autowired PostRepository postRepository;
-    @Autowired RefreshTokenRepository refreshTokenRepository;
-    @Autowired PasswordEncoder passwordEncoder;
-
-    private static final String PASSWORD = "correct-horse-battery";
+class PostAuthorizationIntegrationTest extends AbstractIntegrationTest {
 
     private String a1Email;  // cohort A・投稿の所有者
     private String a2Email;  // cohort A・別の受講生（非所有者）
     private String b1Email;  // cohort B・別 cohort
 
     @BeforeEach
-    void setUp() {
-        // FK 依存順に削除：posts/refresh_tokens(→users) を user より先に消す（テスト間分離）。
-        postRepository.deleteAll();
-        refreshTokenRepository.deleteAll();
-        userRepository.deleteAll();
-        cohortRepository.deleteAll();
-
+    void seed() {
         Cohort a = newCohort("cohort A");
         Cohort b = newCohort("cohort B");
         a1Email = newUser("a1@example.com", UserRole.STUDENT, a.getId()).getEmail();
@@ -94,10 +48,8 @@ class PostAuthorizationIntegrationTest {
         long id = createPost(a1, "a1 の投稿");
 
         Cookie a2 = login(a2Email);
-        // 同 cohort なので閲覧はできる
         mockMvc.perform(get("/api/posts/" + id).cookie(a2))
                 .andExpect(status().isOk());
-        // しかし他人の投稿は編集・削除不可（所有者でない → 404）
         mockMvc.perform(put("/api/posts/" + id).cookie(a2)
                         .contentType("application/json")
                         .content(body("乗っ取り編集")))
@@ -127,12 +79,10 @@ class PostAuthorizationIntegrationTest {
         Cookie a1 = login(a1Email);
         createPost(a1, "A の投稿");
 
-        // b1（cohort B）の一覧には A の投稿は出ない
         mockMvc.perform(get("/api/posts").cookie(login(b1Email)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content.length()").value(0));
 
-        // a2（cohort A）の一覧には出る
         mockMvc.perform(get("/api/posts").cookie(login(a2Email)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content.length()").value(1));
@@ -151,7 +101,6 @@ class PostAuthorizationIntegrationTest {
 
         mockMvc.perform(delete("/api/posts/" + id).cookie(a1))
                 .andExpect(status().isNoContent());
-        // 論理削除後は本人でも取得不可（404）
         mockMvc.perform(get("/api/posts/" + id).cookie(a1))
                 .andExpect(status().isNotFound());
     }
@@ -174,42 +123,10 @@ class PostAuthorizationIntegrationTest {
                         .content(body(title)))
                 .andExpect(status().isCreated())
                 .andReturn();
-        return com.jayway.jsonpath.JsonPath.parse(res.getResponse().getContentAsString())
-                .read("$.id", Integer.class).longValue();
+        return readId(res);
     }
 
     private String body(String title) {
         return "{\"title\":\"" + title + "\",\"description\":\"説明文です\"}";
-    }
-
-    private Cookie login(String email) throws Exception {
-        MvcResult res = mockMvc.perform(post("/api/auth/login")
-                        .contentType("application/json")
-                        .content("{\"email\":\"" + email + "\",\"password\":\"" + PASSWORD + "\"}"))
-                .andExpect(status().isOk())
-                .andReturn();
-        Cookie access = res.getResponse().getCookie(AuthCookies.ACCESS);
-        assertThat(access).isNotNull();
-        return access;
-    }
-
-    private Cohort newCohort(String name) {
-        Cohort c = new Cohort();
-        c.setName(name);
-        c.setCreatedAt(OffsetDateTime.now());
-        return cohortRepository.save(c);
-    }
-
-    private User newUser(String email, UserRole role, Long cohortId) {
-        OffsetDateTime now = OffsetDateTime.now();
-        User u = new User();
-        u.setEmail(email);
-        u.setPasswordHash(passwordEncoder.encode(PASSWORD));
-        u.setDisplayName(email);
-        u.setRole(role);
-        u.setCohortId(cohortId);
-        u.setCreatedAt(now);
-        u.setUpdatedAt(now);
-        return userRepository.save(u);
     }
 }

--- a/review-board/backend/src/test/java/com/reviewboard/domain/profile/ProfileAuthorizationIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/profile/ProfileAuthorizationIntegrationTest.java
@@ -1,36 +1,14 @@
 package com.reviewboard.domain.profile;
 
-import com.reviewboard.domain.auth.AuthCookies;
-import com.reviewboard.domain.auth.RefreshTokenRepository;
 import com.reviewboard.domain.cohort.Cohort;
-import com.reviewboard.domain.cohort.CohortRepository;
-import com.reviewboard.domain.evaluation.EvaluationRepository;
-import com.reviewboard.domain.post.PostRepository;
-import com.reviewboard.domain.review.ReviewAxisCommentRepository;
-import com.reviewboard.domain.review.ReviewRepository;
-import com.reviewboard.domain.review.ThanksRepository;
 import com.reviewboard.domain.user.User;
-import com.reviewboard.domain.user.UserRepository;
 import com.reviewboard.domain.user.UserRole;
-import com.jayway.jsonpath.JsonPath;
+import com.reviewboard.support.AbstractIntegrationTest;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
-import java.time.OffsetDateTime;
-
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -39,34 +17,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * 投稿履歴/もらったレビュー(講師強調)/合格バッジ/したレビュー実績の集約と、
  * cohort 境界（他 cohort は 404）・未認証を検証する。
  */
-@SpringBootTest
-@AutoConfigureMockMvc
-@Testcontainers
-class ProfileAuthorizationIntegrationTest {
-
-    @Container
-    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", postgres::getJdbcUrl);
-        registry.add("spring.datasource.username", postgres::getUsername);
-        registry.add("spring.datasource.password", postgres::getPassword);
-        registry.add("app.jwt.secret", () -> "test-secret-please-change-32chars-minimum");
-    }
-
-    @Autowired MockMvc mockMvc;
-    @Autowired CohortRepository cohortRepository;
-    @Autowired UserRepository userRepository;
-    @Autowired PostRepository postRepository;
-    @Autowired ReviewRepository reviewRepository;
-    @Autowired ReviewAxisCommentRepository axisCommentRepository;
-    @Autowired ThanksRepository thanksRepository;
-    @Autowired EvaluationRepository evaluationRepository;
-    @Autowired RefreshTokenRepository refreshTokenRepository;
-    @Autowired PasswordEncoder passwordEncoder;
-
-    private static final String PW = "correct-horse-battery";
+class ProfileAuthorizationIntegrationTest extends AbstractIntegrationTest {
 
     private long authorId;
     private long reviewerId;
@@ -76,16 +27,7 @@ class ProfileAuthorizationIntegrationTest {
     private String bEmail;
 
     @BeforeEach
-    void setUp() throws Exception {
-        thanksRepository.deleteAll();
-        axisCommentRepository.deleteAll();
-        evaluationRepository.deleteAll();
-        reviewRepository.deleteAll();
-        postRepository.deleteAll();
-        refreshTokenRepository.deleteAll();
-        userRepository.deleteAll();
-        cohortRepository.deleteAll();
-
+    void seed() throws Exception {
         Cohort a = newCohort("A");
         Cohort b = newCohort("B");
         User author = newUser("author@example.com", UserRole.STUDENT, a.getId());
@@ -113,12 +55,9 @@ class ProfileAuthorizationIntegrationTest {
         mockMvc.perform(get("/api/users/" + authorId + "/profile").cookie(login(authorEmail)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.posts.length()").value(2))
-                // 新しい順：作品2 が先頭、作品1 は合格バッジ付き
                 .andExpect(jsonPath("$.posts[?(@.title == '作品1')].approved").value(true))
-                // もらったレビューは2件（受講生＋講師）、講師レビューが強調対象
                 .andExpect(jsonPath("$.receivedReviews.length()").value(2))
                 .andExpect(jsonPath("$.receivedReviews[?(@.teacherReview == true)].reviewerRole").value("TEACHER"))
-                // F-PROF-03 もらったレビュー数（author 視点）
                 .andExpect(jsonPath("$.stats.receivedReviewsCount").value(2));
     }
 
@@ -178,39 +117,5 @@ class ProfileAuthorizationIntegrationTest {
                         .contentType("application/json")
                         .content("{\"result\":\"" + result + "\",\"comment\":\"" + comment + "\"}"))
                 .andExpect(status().isOk());
-    }
-
-    private long readId(MvcResult res) throws Exception {
-        return JsonPath.parse(res.getResponse().getContentAsString()).read("$.id", Integer.class).longValue();
-    }
-
-    private Cookie login(String email) throws Exception {
-        MvcResult res = mockMvc.perform(post("/api/auth/login")
-                        .contentType("application/json")
-                        .content("{\"email\":\"" + email + "\",\"password\":\"" + PW + "\"}"))
-                .andExpect(status().isOk()).andReturn();
-        Cookie access = res.getResponse().getCookie(AuthCookies.ACCESS);
-        assertThat(access).isNotNull();
-        return access;
-    }
-
-    private Cohort newCohort(String name) {
-        Cohort c = new Cohort();
-        c.setName(name);
-        c.setCreatedAt(OffsetDateTime.now());
-        return cohortRepository.save(c);
-    }
-
-    private User newUser(String email, UserRole role, Long cohortId) {
-        OffsetDateTime now = OffsetDateTime.now();
-        User u = new User();
-        u.setEmail(email);
-        u.setPasswordHash(passwordEncoder.encode(PW));
-        u.setDisplayName(email);
-        u.setRole(role);
-        u.setCohortId(cohortId);
-        u.setCreatedAt(now);
-        u.setUpdatedAt(now);
-        return userRepository.save(u);
     }
 }

--- a/review-board/backend/src/test/java/com/reviewboard/domain/review/ReviewAuthorizationIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/review/ReviewAuthorizationIntegrationTest.java
@@ -1,32 +1,13 @@
 package com.reviewboard.domain.review;
 
-import com.reviewboard.domain.auth.AuthCookies;
-import com.reviewboard.domain.auth.RefreshTokenRepository;
 import com.reviewboard.domain.cohort.Cohort;
-import com.reviewboard.domain.cohort.CohortRepository;
-import com.reviewboard.domain.post.PostRepository;
-import com.reviewboard.domain.user.User;
-import com.reviewboard.domain.user.UserRepository;
 import com.reviewboard.domain.user.UserRole;
-import com.jayway.jsonpath.JsonPath;
+import com.reviewboard.support.AbstractIntegrationTest;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
-import java.time.OffsetDateTime;
-
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -34,33 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * F-REV の認可テスト（★S軸・テスト計画書 §6）。
  * cohort 境界・自己レビュー禁止・所有者・ありがとう権限（投稿者のみ・冪等）を網羅する。
  */
-@SpringBootTest
-@AutoConfigureMockMvc
-@Testcontainers
-class ReviewAuthorizationIntegrationTest {
-
-    @Container
-    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", postgres::getJdbcUrl);
-        registry.add("spring.datasource.username", postgres::getUsername);
-        registry.add("spring.datasource.password", postgres::getPassword);
-        registry.add("app.jwt.secret", () -> "test-secret-please-change-32chars-minimum");
-    }
-
-    @Autowired MockMvc mockMvc;
-    @Autowired CohortRepository cohortRepository;
-    @Autowired UserRepository userRepository;
-    @Autowired PostRepository postRepository;
-    @Autowired ReviewRepository reviewRepository;
-    @Autowired ReviewAxisCommentRepository axisCommentRepository;
-    @Autowired ThanksRepository thanksRepository;
-    @Autowired RefreshTokenRepository refreshTokenRepository;
-    @Autowired PasswordEncoder passwordEncoder;
-
-    private static final String PW = "correct-horse-battery";
+class ReviewAuthorizationIntegrationTest extends AbstractIntegrationTest {
 
     private String authorEmail;   // cohort A・投稿の所有者
     private String reviewerEmail; // cohort A・レビュアー
@@ -70,25 +25,15 @@ class ReviewAuthorizationIntegrationTest {
     private long postId;          // author の投稿
 
     @BeforeEach
-    void setUp() throws Exception {
-        // FK 依存順に削除
-        thanksRepository.deleteAll();
-        axisCommentRepository.deleteAll();
-        reviewRepository.deleteAll();
-        postRepository.deleteAll();
-        refreshTokenRepository.deleteAll();
-        userRepository.deleteAll();
-        cohortRepository.deleteAll();
-
+    void seed() throws Exception {
         Cohort a = newCohort("A");
         Cohort b = newCohort("B");
-        authorEmail = newUser("author@example.com", UserRole.STUDENT, a.getId());
-        reviewerEmail = newUser("reviewer@example.com", UserRole.STUDENT, a.getId());
-        otherEmail = newUser("other@example.com", UserRole.STUDENT, a.getId());
-        teacherEmail = newUser("teacher@example.com", UserRole.TEACHER, a.getId());
-        bEmail = newUser("b@example.com", UserRole.STUDENT, b.getId());
+        authorEmail = newUser("author@example.com", UserRole.STUDENT, a.getId()).getEmail();
+        reviewerEmail = newUser("reviewer@example.com", UserRole.STUDENT, a.getId()).getEmail();
+        otherEmail = newUser("other@example.com", UserRole.STUDENT, a.getId()).getEmail();
+        teacherEmail = newUser("teacher@example.com", UserRole.TEACHER, a.getId()).getEmail();
+        bEmail = newUser("b@example.com", UserRole.STUDENT, b.getId()).getEmail();
 
-        // author が投稿を1件作る
         MvcResult res = mockMvc.perform(post("/api/posts").cookie(login(authorEmail))
                         .contentType("application/json")
                         .content("{\"title\":\"作品\",\"description\":\"説明\"}"))
@@ -167,11 +112,9 @@ class ReviewAuthorizationIntegrationTest {
     void thanks_only_by_post_author_and_idempotent() throws Exception {
         long reviewId = createReview(reviewerEmail);
 
-        // 第三者は不可（投稿者でない）→ 403
         mockMvc.perform(post("/api/reviews/" + reviewId + "/thanks").cookie(login(otherEmail)))
                 .andExpect(status().isForbidden());
 
-        // 投稿者は可、2回送っても冪等（thanksCount は 1）
         Cookie author = login(authorEmail);
         mockMvc.perform(post("/api/reviews/" + reviewId + "/thanks").cookie(author))
                 .andExpect(status().isNoContent());
@@ -201,40 +144,5 @@ class ReviewAuthorizationIntegrationTest {
     private String reviewBody() {
         return "{\"good\":\"よい\",\"improvement\":\"改善案\","
                 + "\"axisComments\":[{\"axis\":\"SECURITY\",\"comment\":\"認可OK\"}]}";
-    }
-
-    private long readId(MvcResult res) throws Exception {
-        return JsonPath.parse(res.getResponse().getContentAsString())
-                .read("$.id", Integer.class).longValue();
-    }
-
-    private Cookie login(String email) throws Exception {
-        MvcResult res = mockMvc.perform(post("/api/auth/login")
-                        .contentType("application/json")
-                        .content("{\"email\":\"" + email + "\",\"password\":\"" + PW + "\"}"))
-                .andExpect(status().isOk()).andReturn();
-        Cookie access = res.getResponse().getCookie(AuthCookies.ACCESS);
-        assertThat(access).isNotNull();
-        return access;
-    }
-
-    private Cohort newCohort(String name) {
-        Cohort c = new Cohort();
-        c.setName(name);
-        c.setCreatedAt(OffsetDateTime.now());
-        return cohortRepository.save(c);
-    }
-
-    private String newUser(String email, UserRole role, Long cohortId) {
-        OffsetDateTime now = OffsetDateTime.now();
-        User u = new User();
-        u.setEmail(email);
-        u.setPasswordHash(passwordEncoder.encode(PW));
-        u.setDisplayName(email);
-        u.setRole(role);
-        u.setCohortId(cohortId);
-        u.setCreatedAt(now);
-        u.setUpdatedAt(now);
-        return userRepository.save(u).getEmail();
     }
 }

--- a/review-board/backend/src/test/java/com/reviewboard/support/AbstractIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/support/AbstractIntegrationTest.java
@@ -1,0 +1,130 @@
+package com.reviewboard.support;
+
+import com.reviewboard.domain.audit.AuditLogRepository;
+import com.reviewboard.domain.auth.AuthCookies;
+import com.reviewboard.domain.auth.RefreshTokenRepository;
+import com.reviewboard.domain.cohort.Cohort;
+import com.reviewboard.domain.cohort.CohortRepository;
+import com.reviewboard.domain.evaluation.EvaluationRepository;
+import com.reviewboard.domain.post.PostRepository;
+import com.reviewboard.domain.review.ReviewAxisCommentRepository;
+import com.reviewboard.domain.review.ReviewRepository;
+import com.reviewboard.domain.review.ThanksRepository;
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRepository;
+import com.reviewboard.domain.user.UserRole;
+import com.jayway.jsonpath.JsonPath;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 統合テストの共通基盤。Testcontainers の PostgreSQL・テスト間の FK 依存順クリーンアップ・
+ * ログイン/ユーザー作成のヘルパーを集約する。
+ *
+ * <p>各ドメインで散在していた {@code deleteAll()} の順序ミス（refresh_tokens / audit_logs などの
+ * 子テーブルを親 users より先に消さず FK 違反）を一箇所に集約し、再発（過去3回）を断つ。
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+public abstract class AbstractIntegrationTest {
+
+    /**
+     * singleton container パターン：{@code @Container}（クラスごとに start/stop）ではなく、
+     * static 初期化で一度だけ起動し JVM 終了まで止めない。全テストクラスで1つの DB を共有し、
+     * クラス間でコンテナが停止されて "Could not open JPA EntityManager" になるのを防ぐ。
+     * 後始末は Testcontainers の Ryuk（JVM 終了時）に委ねる。
+     */
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16");
+
+    static {
+        POSTGRES.start();
+    }
+
+    @DynamicPropertySource
+    static void datasourceProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("app.jwt.secret", () -> "test-secret-please-change-32chars-minimum");
+    }
+
+    protected static final String PASSWORD = "correct-horse-battery";
+
+    @Autowired protected MockMvc mockMvc;
+    @Autowired protected CohortRepository cohortRepository;
+    @Autowired protected UserRepository userRepository;
+    @Autowired protected PostRepository postRepository;
+    @Autowired protected ReviewRepository reviewRepository;
+    @Autowired protected ReviewAxisCommentRepository axisCommentRepository;
+    @Autowired protected ThanksRepository thanksRepository;
+    @Autowired protected EvaluationRepository evaluationRepository;
+    @Autowired protected AuditLogRepository auditLogRepository;
+    @Autowired protected RefreshTokenRepository refreshTokenRepository;
+    @Autowired protected org.springframework.security.crypto.password.PasswordEncoder passwordEncoder;
+
+    /** FK 依存順（子 → 親）に全テーブルを掃除する。サブクラスで追加掃除が要れば override 可。 */
+    @BeforeEach
+    void cleanDatabase() {
+        auditLogRepository.deleteAll();
+        thanksRepository.deleteAll();
+        axisCommentRepository.deleteAll();
+        evaluationRepository.deleteAll();
+        reviewRepository.deleteAll();
+        postRepository.deleteAll();
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        cohortRepository.deleteAll();
+    }
+
+    // ---- 共通ヘルパー ----
+
+    protected Cohort newCohort(String name) {
+        Cohort c = new Cohort();
+        c.setName(name);
+        c.setCreatedAt(OffsetDateTime.now());
+        return cohortRepository.save(c);
+    }
+
+    protected User newUser(String email, UserRole role, Long cohortId) {
+        OffsetDateTime now = OffsetDateTime.now();
+        User u = new User();
+        u.setEmail(email);
+        u.setPasswordHash(passwordEncoder.encode(PASSWORD));
+        u.setDisplayName(email);
+        u.setRole(role);
+        u.setCohortId(cohortId);
+        u.setCreatedAt(now);
+        u.setUpdatedAt(now);
+        return userRepository.save(u);
+    }
+
+    /** メール+パスワードでログインし、access Cookie を返す。 */
+    protected Cookie login(String email) throws Exception {
+        MvcResult res = mockMvc.perform(post("/api/auth/login")
+                        .contentType("application/json")
+                        .content("{\"email\":\"" + email + "\",\"password\":\"" + PASSWORD + "\"}"))
+                .andExpect(status().isOk()).andReturn();
+        Cookie access = res.getResponse().getCookie(AuthCookies.ACCESS);
+        assertThat(access).isNotNull();
+        return access;
+    }
+
+    /** レスポンス body の $.id を long で取り出す。 */
+    protected long readId(MvcResult res) throws Exception {
+        return JsonPath.parse(res.getResponse().getContentAsString()).read("$.id", Integer.class).longValue();
+    }
+}


### PR DESCRIPTION
## 関連 Issue

Closes #99

---

## 変更の概要

要件定義書 §4-1（★重点軸）の MUST「監査ログで誰が・いつ・誰の資源に・何をしたかを追跡できる」を満たす。V1 スキーマに存在しながら未配線だった `audit_logs` を記録・閲覧の両面で実体化した。

### 記録（書き込み）
- Post / Review / Evaluation の変更操作で監査行を残す
  - `POST_CREATED/UPDATED/DELETED`・`REVIEW_CREATED/DELETED`・`THANKS_SENT`・`EVALUATION_APPROVED/RETURNED`
- `AuditService.record()` は呼び出し元トランザクションに参加（`Propagation.MANDATORY`）→「**操作がコミットされたときだけ監査行も残る**」を保証
- actor / cohort は principal（検証済み JWT）から導出（クライアント入力を信用しない）

### 閲覧（読み取り）
- GET /api/audit-logs：`@PreAuthorize("hasRole('TEACHER')")` で講師限定・自 cohort のみ・新しい順ページネーション
- 監査情報は機微なため受講生は **403**

## 変更の種別

- [x] feat（新機能の追加）
- [x] test（テストの追加・修正）
- [x] refactor（テスト基盤の共通化）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（`./gradlew clean test` グリーン・**全31件**）
- [x] 既存の機能が壊れていないことを確認した
- [x] `.env` ファイルやパスワードをコミットしていない（テスト用ダミー値のみ）

### テスト（Testcontainers PostgreSQL 16）
- 監査4件：操作で監査行が残る / 講師は閲覧可 / **受講生は403** / 他 cohort のログは見えない / 未ログイン401

## あわせて実施：テスト基盤の共通化（再発バグの根絶）

監査配線で `audit_logs` が users の新たな子テーブルになり、各テストの `deleteAll` 順序ミス（過去3回再発した FK クリーンアップ問題）が顕在化したため、根本対処した：

- **`AbstractIntegrationTest`** を新設し、FK 依存順の全テーブル掃除・`login`/`newUser` ヘルパー・Testcontainers を集約。全6テストクラスを移行（重複を解消）
- **singleton container パターン**採用：`@Container`（クラス毎 start/stop）だと共有 static コンテナが先頭クラス終了時に停止し、後続クラスが `Could not open JPA EntityManager` で落ちる。static 初期化で一度だけ起動し JVM 終了まで止めない方式に変更（クラス横断で1 DB を共有・高速化も兼ねる）

---

## レビュー時に特に確認してほしい点

- 監査記録の `Propagation.MANDATORY`（呼び出し元 TX 必須）が「操作と監査の原子性」を担保している点
- 監査ログ閲覧の cohort 境界（他 cohort のログが返らない）

> 学習スコープのため、監査ログの改ざん防止（WORM/署名）・外部 SIEM 連携は対象外（本実装移行時に再検討・要件 §2-2）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)