### PR TITLE
chore: 依存脆弱性スキャンを CI に常設（High/Critical ゲート）

### DIFF
--- a/.github/workflows/review-board-dependency-scan.yml
+++ b/.github/workflows/review-board-dependency-scan.yml
@@ -1,0 +1,68 @@
+name: review-board Dependency Scan (S軸)
+
+# ============================================================
+# 要件定義書 §4-1（★S軸）MUST：依存脆弱性スキャンを CI に常設し
+# High/Critical 0 件を維持する。
+#
+# 方式：Spring Boot の bootJar をビルドし、Trivy で fat jar を走査する。
+# fat jar の BOOT-INF/lib に同梱される transitive 依存まで検出できるため、
+# Gradle lockfile が無くても網羅的にスキャンできる（NVD API キー不要）。
+# ============================================================
+
+on:
+  pull_request:
+    paths:
+      - 'review-board/backend/**'
+      - '.github/workflows/review-board-dependency-scan.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'review-board/backend/**'
+      - '.github/workflows/review-board-dependency-scan.yml'
+  workflow_dispatch:
+
+# 同一 PR の旧 run はキャンセル（リソース節約）
+concurrency:
+  group: rb-depscan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: review-board/backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      # JDK 21 を入れ、Gradle の foojay toolchain が JDK 25 を自動取得する
+      # （ローカルと同条件。技術スタック.md M-14）。
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build bootJar
+        run: ./gradlew bootJar --no-daemon
+
+      # fat jar を走査。HIGH/CRITICAL を検出したら exit-code 1 で fail。
+      # ignore-unfixed: 修正版が無い脆弱性は対処不能なため除外（0 件維持の対象は修正可能なもの）。
+      - name: Trivy scan (fail on HIGH/CRITICAL)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: rootfs
+          scan-ref: review-board/backend/build/libs
+          severity: HIGH,CRITICAL
+          exit-code: '1'
+          ignore-unfixed: true
+          scanners: vuln

--- a/.github/workflows/review-board-dependency-scan.yml
+++ b/.github/workflows/review-board-dependency-scan.yml
@@ -58,7 +58,7 @@ jobs:
       # fat jar を走査。HIGH/CRITICAL を検出したら exit-code 1 で fail。
       # ignore-unfixed: 修正版が無い脆弱性は対処不能なため除外（0 件維持の対象は修正可能なもの）。
       - name: Trivy scan (fail on HIGH/CRITICAL)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: rootfs
           scan-ref: review-board/backend/build/libs

--- a/review-board/backend/build.gradle
+++ b/review-board/backend/build.gradle
@@ -1,12 +1,21 @@
 plugins {
 	id 'java'
 	id 'jacoco'
-	id 'org.springframework.boot' version '3.5.5'
+	id 'org.springframework.boot' version '3.5.14'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.reviewboard'
 version = '0.0.1-SNAPSHOT'
+
+// ★S軸：依存脆弱性スキャン(CI/Trivy)で検出された High/Critical を 0 件に保つための
+// バージョン上書き。Spring Boot 3.5.14 で大半が解消するが、BOM 管理版より新しい
+// 修正版が必要なものは spring-boot-dependencies の version property を上書きする。
+// 各値は Trivy が示した fixed version に対応（更新時は CI の検出結果で再確認すること）。
+ext['tomcat.version'] = '10.1.55'              // CVE-2026-41293 ほか tomcat 系
+ext['spring-framework.version'] = '6.2.11'     // CVE-2025-41249
+ext['spring-security.version'] = '6.5.9'       // CVE-2026-22732 / CVE-2025-41248
+ext['postgresql.version'] = '42.7.11'          // CVE-2026-42198
 
 java {
 	// Java 25 (LTS)。技術スタック.md §2-1 / §8。foojay resolver により


### PR DESCRIPTION
## 関連 Issue

Closes #101

---

## 変更の概要

要件定義書 §4-1（★重点軸）の MUST「依存脆弱性スキャンを CI に常設し、High/Critical 0 件を維持」を満たす。認可テスト・監査ログに続く **重点軸の床の最後のピース**。

- GitHub Actions `review-board-dependency-scan.yml` を追加
- Spring Boot の `bootJar` をビルド → **Trivy で fat jar を走査**（BOOT-INF/lib の transitive 依存まで検出。Gradle lockfile 不要・NVD API キー不要）
- **HIGH / CRITICAL を検出したら exit-code 1 でビルド fail**
- `ignore-unfixed: true`（修正版が無い脆弱性は対処不能なため除外）
- JDK21 setup → Gradle foojay toolchain が JDK25 を自動取得（ローカルと同条件・M-14）
- トリガ：review-board/backend or 本ワークフロー変更時の PR / main push / 手動（workflow_dispatch）

## 変更の種別

- [x] chore（設定・ツール・依存関係の変更）

---

## 動作確認チェックリスト

- [x] ローカルで `./gradlew clean bootJar` が成功（fat jar 71MB 生成）= CI のビルド段を検証
- [ ] 本 PR で CI ワークフローが発火し、現状の依存に High/Critical がない（グリーン）こと ← この PR の Actions 実行で確認
- [x] `.env` ファイルやパスワードをコミットしていない

---

## レビュー時に特に確認してほしい点

- Trivy の fat jar 走査で transitive 依存まで網羅できている点（lockfile レスでの網羅性）
- `ignore-unfixed: true` の妥当性（0 件維持の対象を「修正可能な High/Critical」に限定）

> 学習スコープのため SAST・コンテナイメージスキャン・SBOM 公開は対象外（本実装移行時に再検討・要件 §2-2）。
> 補足：実装中に iCloud 同期由来の `* 2.java` 重複が src に出現しビルドを壊したため、追跡外の複製8件を Trash に退避して解消（コミット対象外・正ファイルは PR #100 で追跡済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)