### PR TITLE
docs: 脅威モデリング表（認可境界）を文書化

### DIFF
--- a/review-board/docs/脅威モデリング.md
+++ b/review-board/docs/脅威モデリング.md
@@ -1,0 +1,140 @@
+# review-board 脅威モデリング（認可境界）
+
+> 本書は要件定義書 §0 / §4-1（★S軸）の MUST
+> 「主要な認可境界（誰が・何に・何の権限を持つか）を脅威モデリング表として文書化・保持する」を満たす。
+> [テスト計画書.md](./テスト計画書.md) の認可テストマトリクスと対になり、
+> 「どの脅威を・どこで・どう防ぎ・どのテストで保証するか」を一枚に集約する。
+>
+> **生きた文書として運用する**：認可ロジックや @PreAuthorize を変更したら本書とテストを同時に更新する。
+
+---
+
+## 改訂履歴
+
+| 版 | 日付 | 改訂者 | 内容 |
+|---|---|---|---|
+| 0.1 | 2026-05-23 | hideharu-AI | 初版。Phase 1 MVP（F-AUTH/POST/REV/EVAL/PROF + 監査ログ）実装済みの認可境界を反映 |
+
+---
+
+## 1. スコープと前提
+
+- 対象：review-board バックエンド（Phase 1 MVP）の認可境界。クローズド・cohort 内・ロール（受講生／講師）。
+- 前提：全 API はログイン必須（`/actuator/health` と `/api/auth/login|refresh|logout` のみ公開）。
+- 認証は JWT in HttpOnly Cookie（母 SEC-7）。**認可判定はクライアント入力ではなく、検証済み JWT から導出した `AuthPrincipal(userId, cohortId, role)` のみを信頼する。**
+- 本書が扱わない範囲（学習スコープ・本実装移行時に再検討、要件 §2-2）：WAF / CloudFront、レート制限、SAST、監査ログの改ざん防止（WORM/署名）、SIEM 連携。
+
+---
+
+## 2. 資産（保護対象）と保護目標
+
+| 資産 | 保護目標 | 主な脅威 |
+|---|---|---|
+| 投稿（成果物） | 同 cohort 内のみ閲覧／所有者のみ編集・削除 | IDOR（他人・他 cohort の閲覧/改変） |
+| レビュー | 同 cohort 内で作成／所有者のみ編集・削除 | IDOR、自己レビュー、なりすまし |
+| ありがとう | 投稿者のみ送信・冪等 | 権限のないユーザーの送信、二重計上 |
+| 講師評価（合格バッジ） | **講師ロールのみ**作成 | **権限昇格**（受講生による自己承認） |
+| 成長記録（プロフィール） | 同 cohort 内のみ閲覧 | 他 cohort の記録の覗き見 |
+| 監査ログ | **講師ロールのみ**・自 cohort のみ閲覧 | 機微情報の漏洩、他 cohort の活動の覗き見 |
+| 認証情報（refresh token） | 平文非保存・使い捨て・盗用検知 | トークン盗用・再利用 |
+
+---
+
+## 3. アクターと信頼境界
+
+### アクター（ロール）
+
+| アクター | 権限の要旨 |
+|---|---|
+| 未ログイン | 何もできない（401） |
+| 受講生（STUDENT） | 同 cohort の閲覧・投稿・レビュー・自分の資源の編集削除・自分の投稿へのありがとう |
+| 講師（TEACHER） | 受講生の全権限 ＋ 最終評価（合格／差し戻し）＋ 監査ログ閲覧。レビューは特別表示 |
+| （将来）admin | 複数 cohort 横断（Phase 3。現状は未実装） |
+
+### 信頼境界（3 層）
+
+本アプリの認可は次の 3 つの境界の AND で判定する。**いずれもバックエンドで検証**し、フロントの表示制御には依存しない。
+
+1. **認証境界**：有効な access Cookie があるか（無ければ 401）。
+2. **cohort 境界**：対象資源が `principal.cohortId` に属するか（属さなければ存在を漏らさず **404**）。
+3. **所有者／ロール境界**：その操作を行う資格があるか（所有者か／必要ロールを持つか）。
+
+---
+
+## 4. 認可境界マトリクス（誰が・何に・何の権限）
+
+> 実装済みエンドポイントの一覧。「拒否時コード」は不正アクセス時の応答（§6 の方針に従う）。
+> 判定は各 Service／Controller に一元化（母 M-3）。
+
+| # | 操作 | エンドポイント | 未ログイン | 受講生 | 講師 | 主な境界 | 不正時 | 強制箇所 |
+|---|---|---|---|---|---|---|---|---|
+| 1 | ログイン | `POST /api/auth/login` | ✅ | ✅ | ✅ | — | 401 | `AuthService` |
+| 2 | 自分の情報 | `GET /api/auth/me` | ❌ | ✅ | ✅ | 認証 | 401 | SecurityConfig |
+| 3 | 投稿作成 | `POST /api/posts` | ❌ | ✅ | ✅ | 認証 | 401 | `PostService.create`（cohort/author は principal 由来） |
+| 4 | 投稿一覧 | `GET /api/posts` | ❌ | ✅(自cohort) | ✅(自cohort) | cohort | 401 | `PostService.listForCohort` |
+| 5 | 投稿取得 | `GET /api/posts/{id}` | ❌ | ✅(自cohort) | ✅(自cohort) | cohort | 404 | `PostService.get` |
+| 6 | 投稿編集/削除 | `PUT/DELETE /api/posts/{id}` | ❌ | 所有者のみ | 所有者のみ | cohort＋所有者 | 404 | `PostService.loadOwned` |
+| 7 | レビュー作成 | `POST /api/posts/{id}/reviews` | ❌ | ✅(自cohort・他人の投稿) | ✅ | cohort＋自己レビュー禁止 | 404 / 400 | `ReviewService.create` |
+| 8 | レビュー一覧 | `GET /api/posts/{id}/reviews` | ❌ | ✅(自cohort) | ✅(自cohort) | cohort | 404 | `ReviewService.listForPost` |
+| 9 | レビュー編集/削除 | `PUT/DELETE /api/reviews/{id}` | ❌ | 所有者のみ | 所有者のみ | 所有者 | 404 | `ReviewService.ownedReview` |
+| 10 | ありがとう | `POST /api/reviews/{id}/thanks` | ❌ | 投稿者のみ | 投稿者のみ | 投稿の所有者 | 403 | `ReviewService.thank` |
+| 11 | 最終評価 | `POST /api/posts/{id}/evaluation` | ❌ | ❌ | ✅(自cohort) | **ロール（講師）**＋cohort | 403 / 404 | `@PreAuthorize` + `EvaluationService` |
+| 12 | 評価取得 | `GET /api/posts/{id}/evaluation` | ❌ | ✅(自cohort) | ✅(自cohort) | cohort | 404 | `EvaluationService.getLatest` |
+| 13 | 成長記録 | `GET /api/users/{id}/profile` | ❌ | ✅(自cohort) | ✅(自cohort) | cohort | 404 | `ProfileService.getProfile` |
+| 14 | 監査ログ閲覧 | `GET /api/audit-logs` | ❌ | ❌ | ✅(自cohort) | **ロール（講師）**＋cohort | 403 | `@PreAuthorize` + `AuditService` |
+
+---
+
+## 5. 脅威 → 対策 → 実装 → テスト
+
+> STRIDE のうち本アプリで重い **Elevation of Privilege（権限昇格）** と **Information Disclosure（情報漏洩＝IDOR）** を中心に整理する。
+
+| ID | 脅威（STRIDE） | シナリオ | 対策 | 強制箇所 | テスト |
+|---|---|---|---|---|---|
+| T-1 | 情報漏洩 / IDOR | URL の ID を書き換えて他人・他 cohort の投稿/レビュー/評価/成長記録に到達 | cohort 境界クエリ＋所有者検証。不一致は存在を漏らさず **404** | `PostService` / `ReviewService` / `ProfileService` の cohort 限定 finder | `PostAuthorizationIntegrationTest`・`ReviewAuthorizationIntegrationTest`・`ProfileAuthorizationIntegrationTest`（他cohort/他人=404） |
+| T-2 | 権限昇格 | 受講生が講師限定の最終評価を呼び自分の作品を自己承認 | `@PreAuthorize("hasRole('TEACHER')")` でメソッド前に遮断（**403**） | `EvaluationController` / `AuditController` | `EvaluationAuthorizationIntegrationTest#student_cannot_evaluate_returns403`・`AuditAuthorizationIntegrationTest#student_cannot_view_audit_logs_returns403` |
+| T-3 | なりすまし | 他人になりすまして投稿/レビュー作成、または改変 | author/reviewer/cohort は**クライアント入力でなく検証済み JWT（principal）から導出**。所有者でない編集削除は 404 | `PostService.create` / `ReviewService.create` / `*ownedReview/loadOwned` | 各 `*AuthorizationIntegrationTest`（非所有者の編集削除=404） |
+| T-4 | 改ざん / 不正操作 | 自分の投稿を自分でレビューして実績水増し、ありがとうの二重計上 | 自己レビュー禁止（**400**）、ありがとうは投稿者のみ（**403**）＋ uq_thanks で冪等 | `ReviewService.create` / `ReviewService.thank` | `ReviewAuthorizationIntegrationTest#self_review_is_rejected`・`#thanks_only_by_post_author_and_idempotent` |
+| T-5 | トークン盗用 | refresh token の漏洩・再利用 | access 短命＋refresh は SHA-256 ハッシュ保存・使い捨て rotation・**reuse 検知で全失効**。Cookie は HttpOnly+Secure+SameSite=Strict | `RefreshTokenService.rotate` / `JwtService` / `AuthCookies` | `AuthIntegrationTest`（login/me 401） |
+| T-6 | 否認（Repudiation） | 「やっていない」と主張、操作の追跡不能 | 主要変更操作を監査ログに記録（誰が・いつ・誰の資源に・何を）。操作と同一 TX（`MANDATORY`）でコミット時のみ記録 | `AuditService.record`（Post/Review/Evaluation Service から呼ぶ） | `AuditAuthorizationIntegrationTest#actions_are_recorded...` |
+| T-7 | 情報漏洩（監査） | 受講生や他 cohort が監査ログを覗く | 講師ロール限定＋自 cohort のみ返す | `@PreAuthorize` + `AuditService.listForCohort` | `AuditAuthorizationIntegrationTest#teacher_sees_only_own_cohort_logs` |
+| T-8 | 既知脆弱性の混入 | 依存ライブラリの High/Critical 脆弱性 | CI で Trivy 走査・High/Critical 検出でビルド fail（0 件維持） | `.github/workflows/review-board-dependency-scan.yml` | CI（PR/main push で常時実行） |
+
+---
+
+## 6. 応答方針（コードの使い分け）
+
+不正アクセス時にどのステータスを返すかを統一する。**「存在を漏らさない」ことが IDOR 対策の要**。
+
+| コード | いつ | 理由 |
+|---|---|---|
+| **401** Unauthorized | 未ログイン（有効な access Cookie が無い） | 認証が必要 |
+| **404** Not Found | 他 cohort・他人の資源・削除済み・存在しない ID | **存在の有無を漏らさず ID 列挙を防ぐ**（403 と区別しない） |
+| **403** Forbidden | 資源は可視だが操作する資格が無い（ロール不足・ありがとうが投稿者でない） | 操作禁止を明示（存在は隠す必要がない場面） |
+| **400** Bad Request | ビジネスルール違反（自己レビュー・観点軸の重複） | 入力は正当だがルール上不可 |
+
+> **404 と 403 の使い分けの原則**：閲覧できない資源は **404**（存在を隠す）。閲覧はできるが操作できない場合は **403**（存在は既知）。
+> 例：他 cohort の投稿は 404（見えてはいけない）／自分が見ている他人のレビューへのありがとうは 403（レビューは見えるが送れない）。
+
+---
+
+## 7. 残存リスク・本実装移行時の再検討
+
+学習スコープのため現フェーズで簡素化している項目（要件 §2-2 の横断原則に従い、本実装移行時に再検討）：
+
+| 項目 | 現状 | 本実装での対応候補 |
+|---|---|---|
+| レート制限 / ブルートフォース対策 | 無し | ログイン試行のレート制限・アカウントロック |
+| 監査ログの完全性 | 追記のみ（改ざん防止なし） | WORM ストレージ／署名／外部 SIEM 連携 |
+| admin ロール・複数 cohort 横断 | 未実装（テーブルは role/cohort を保持済み） | admin 追加時に本表へ行を追加 |
+| スクショの実ファイル取扱い | `screenshotKey` 文字列のみ（MinIO 連携は未実装） | アップロード経路の認可・ウイルススキャン・署名 URL |
+| ネットワーク層防御 | 無し | WAF / CloudFront / レート制限 |
+
+---
+
+## 8. 関連ドキュメント
+
+- [要件定義書.md](./要件定義書.md) §0・§3-2・§4-1（S軸宣言・RBAC・S基準）
+- [テスト計画書.md](./テスト計画書.md) §6 認可テストマトリクス（本書と対）
+- [ER図.md](./ER図.md)（cohort/role/所有者カラム・audit_logs）
+- [機能一覧.md](./機能一覧.md)（エンドポイント仕様）


### PR DESCRIPTION
## 関連 Issue

Closes #103

---

## 変更の概要

要件定義書 §4-1（★重点軸）の MUST「主要な認可境界（誰が・何に・何の権限を持つか）を脅威モデリング表として文書化・保持する」を満たす。これで **重点軸の床4本柱が完成**（①認可テスト全網羅 ②監査ログ ③依存スキャンCI ④脅威モデリング）。

`review-board/docs/脅威モデリング.md` を新規作成：

- **資産と保護目標** / アクター・**3層の信頼境界**（認証・cohort・所有者/ロール）
- **認可境界マトリクス**：実装済み全14エンドポイントを「誰が・何に・何の権限・不正時コード・強制箇所」で一覧化
- **脅威 → 対策 → 実装 → テストの対応表**（T-1〜T-8：IDOR / 権限昇格 / なりすまし / 否認 / トークン盗用 / 既知脆弱性）
- **応答方針**（401/403/404/400 の使い分けと根拠＝「存在を漏らさない」）
- 残存リスク・本実装移行時の再検討

実装（各 Service の認可判定・`@PreAuthorize`・監査ログ）と各 `*AuthorizationIntegrationTest` に紐付けた**生きた文書**として運用する。

## 変更の種別

- [x] docs（ドキュメントのみの変更）

---

## 動作確認チェックリスト

- [x] コード変更なし（ドキュメントのみ）
- [x] 関連ドキュメントへのリンク先が実在することを確認
- [x] 記載した強制箇所（Service/Controller メソッド）・テストが実装と一致

---

## レビュー時に特に確認してほしい点

- §4 認可境界マトリクスが実装の現状と一致しているか（特に 404/403 の使い分け）
- §5 の脅威 → テスト紐付けに漏れがないか（全14エンドポイントが拒否系テストでカバーされているか）

🤖 Generated with [Claude Code](https://claude.com/claude-code)