### PR TITLE
chore: backend の build・test を CI 化（M-6 Fail Fast）

### DIFF
--- a/.github/workflows/review-board-ci.yml
+++ b/.github/workflows/review-board-ci.yml
@@ -1,0 +1,68 @@
+name: review-board CI (build & test)
+
+# ============================================================
+# 母 M-6：CI は Fail Fast（lint→build→test）。問題は安く速く落とす。
+# 本ワークフローは review-board/backend の build（compile）→ test を回す。
+# test は Testcontainers(PostgreSQL) を使うため runner の Docker を利用する。
+# 依存脆弱性スキャンは review-board-dependency-scan.yml に分離（並列実行）。
+# ============================================================
+
+on:
+  pull_request:
+    paths:
+      - 'review-board/backend/**'
+      - '.github/workflows/review-board-ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'review-board/backend/**'
+      - '.github/workflows/review-board-ci.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: rb-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: review-board/backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      # JDK 21 を入れ、Gradle の foojay toolchain が JDK 25 を自動取得する
+      # （ローカルと同条件。技術スタック.md M-14）。
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      # Fail Fast：まずコンパイル（軽量）で速く落とす。
+      - name: Build (compile)
+        run: ./gradlew compileJava compileTestJava --no-daemon
+
+      # 結合テスト（Testcontainers PostgreSQL）。runner には Docker が同梱。
+      - name: Test
+        run: ./gradlew test --no-daemon
+
+      # 失敗時にテストレポートを保全（M-10：ログを残す）。
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: review-board/backend/build/reports/tests/test
+          retention-days: 7
+          if-no-files-found: ignore


### PR DESCRIPTION
## 関連 Issue

Closes #107

---

## 変更の概要

品質判定表で「要改善」だった **M-6（CI は Fail Fast：build→test）** を前進させる。`review-board-ci.yml` を追加。

- **Fail Fast 順**：build（compileJava/compileTestJava・軽量で速く落とす）→ test
- test は **Testcontainers(PostgreSQL)** を runner の Docker で実行（全31認可テスト）
- JDK21 setup → Gradle foojay が JDK25 を自動取得（ローカルと同条件・M-14）
- 失敗時はテストレポートを artifact 保全（M-10）
- 依存脆弱性スキャン（別 workflow）と並列

## 変更の種別

- [x] chore（設定・ツール・依存関係の変更）

---

## 動作確認チェックリスト

- [x] ローカルで `./gradlew compileJava compileTestJava` と `./gradlew test`（全31件 green）を確認済み
- [ ] 本 PR で CI が発火し build→test green になること ← この PR の Actions で確認
- [x] `.env` ファイルやパスワードをコミットしていない

---

## レビュー時に特に確認してほしい点

- CI 上で Testcontainers が runner の Docker で起動し、全31テストが green になるか（`api.version` 既定 1.44 が runner の Docker でも有効か）

🤖 Generated with [Claude Code](https://claude.com/claude-code)