### PR TITLE
feat: フロント第2スライス（投稿詳細・レビュー・講師評価・成長記録）

### DIFF
--- a/review-board/frontend/src/App.jsx
+++ b/review-board/frontend/src/App.jsx
@@ -4,23 +4,31 @@ import ProtectedRoute from './components/ProtectedRoute';
 import Header from './components/Header';
 import LoginPage from './pages/LoginPage';
 import PostsPage from './pages/PostsPage';
+import NewPostPage from './pages/NewPostPage';
+import PostDetailPage from './pages/PostDetailPage';
+import ProfilePage from './pages/ProfilePage';
+
+// 認証必須ページの共通レイアウト（ヘッダー＋本文）。
+function Shell({ children }) {
+  return (
+    <ProtectedRoute>
+      <div className="min-h-screen bg-gray-50">
+        <Header />
+        {children}
+      </div>
+    </ProtectedRoute>
+  );
+}
 
 export default function App() {
   return (
     <AuthProvider>
       <Routes>
         <Route path="/login" element={<LoginPage />} />
-        <Route
-          path="/"
-          element={
-            <ProtectedRoute>
-              <div className="min-h-screen bg-gray-50">
-                <Header />
-                <PostsPage />
-              </div>
-            </ProtectedRoute>
-          }
-        />
+        <Route path="/" element={<Shell><PostsPage /></Shell>} />
+        <Route path="/posts/new" element={<Shell><NewPostPage /></Shell>} />
+        <Route path="/posts/:id" element={<Shell><PostDetailPage /></Shell>} />
+        <Route path="/users/:id/profile" element={<Shell><ProfilePage /></Shell>} />
       </Routes>
     </AuthProvider>
   );

--- a/review-board/frontend/src/api/evaluations.js
+++ b/review-board/frontend/src/api/evaluations.js
@@ -1,0 +1,15 @@
+import client from './client';
+
+// F-EVAL-01 最新評価の取得。未評価は backend が 404 → null に倒す。
+export const fetchEvaluation = (postId) =>
+  client
+    .get(`/posts/${postId}/evaluation`)
+    .then((r) => r.data)
+    .catch((e) => {
+      if (e.response?.status === 404) return null;
+      throw e;
+    });
+
+// F-EVAL-01 評価する（講師ロールのみ。受講生は backend が 403）
+export const evaluate = (postId, body) =>
+  client.post(`/posts/${postId}/evaluation`, body).then((r) => r.data);

--- a/review-board/frontend/src/api/posts.js
+++ b/review-board/frontend/src/api/posts.js
@@ -3,3 +3,9 @@ import client from './client';
 // F-POST-03 一覧（同 cohort・ページネーション）。Spring の Slice 形（content[]）を返す。
 export const fetchPosts = (page = 0, size = 20) =>
   client.get('/posts', { params: { page, size } }).then((r) => r.data);
+
+// F-POST-03 単体取得
+export const fetchPost = (id) => client.get(`/posts/${id}`).then((r) => r.data);
+
+// F-POST-01 作成（タイトル/説明は必須、URL は任意）
+export const createPost = (data) => client.post('/posts', data).then((r) => r.data);

--- a/review-board/frontend/src/api/profile.js
+++ b/review-board/frontend/src/api/profile.js
@@ -1,0 +1,5 @@
+import client from './client';
+
+// F-PROF 成長記録（同 cohort のみ閲覧可）
+export const fetchProfile = (userId) =>
+  client.get(`/users/${userId}/profile`).then((r) => r.data);

--- a/review-board/frontend/src/api/reviews.js
+++ b/review-board/frontend/src/api/reviews.js
@@ -1,0 +1,12 @@
+import client from './client';
+
+// F-REV-01/02 一覧（reviewer の role 付き）
+export const fetchReviews = (postId) =>
+  client.get(`/posts/${postId}/reviews`).then((r) => r.data);
+
+// F-REV-01 作成（good/improvement 必須、axisComments 任意）
+export const createReview = (postId, body) =>
+  client.post(`/posts/${postId}/reviews`, body).then((r) => r.data);
+
+// F-REV-03 ありがとう（投稿者のみ・冪等）
+export const sendThanks = (reviewId) => client.post(`/reviews/${reviewId}/thanks`);

--- a/review-board/frontend/src/components/EvaluationPanel.jsx
+++ b/review-board/frontend/src/components/EvaluationPanel.jsx
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import { EVAL_LABEL } from '../constants';
+import { evaluate } from '../api/evaluations';
+
+// F-EVAL-01：講師の最終評価。受講生には現在の評価のみ表示、講師には評価フォームを出す。
+// 出し分けは UX 補助で、実際の権限は backend（受講生の送信は 403）。
+export default function EvaluationPanel({ postId, evaluation, isTeacher, onEvaluated }) {
+  const [result, setResult] = useState('APPROVED');
+  const [comment, setComment] = useState('');
+  const [error, setError] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const submit = async (e) => {
+    e.preventDefault();
+    setError('');
+    setBusy(true);
+    try {
+      const ev = await evaluate(postId, { result, comment });
+      setComment('');
+      onEvaluated?.(ev);
+    } catch (err) {
+      setError(err.response?.status === 403 ? '評価は講師のみ可能です' : '送信に失敗しました');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section className="rounded-lg border border-gray-200 bg-white p-4">
+      <h3 className="mb-3 font-medium text-gray-800">講師による最終評価</h3>
+
+      {evaluation ? (
+        <div className={`mb-3 rounded p-3 text-sm ${evaluation.approved ? 'bg-green-50 text-green-700' : 'bg-orange-50 text-orange-700'}`}>
+          <span className="font-medium">
+            {evaluation.approved ? '🏅 合格' : '↩ 差し戻し'}
+          </span>
+          <p className="mt-1 text-gray-600">{evaluation.comment}</p>
+        </div>
+      ) : (
+        <p className="mb-3 text-sm text-gray-500">まだ評価はありません。</p>
+      )}
+
+      {isTeacher && (
+        <form onSubmit={submit} className="border-t border-gray-100 pt-3">
+          {error && <p className="mb-2 rounded bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+          <div className="mb-2 flex gap-4 text-sm">
+            {['APPROVED', 'RETURNED'].map((r) => (
+              <label key={r} className="flex items-center gap-1">
+                <input type="radio" name="result" value={r} checked={result === r} onChange={() => setResult(r)} />
+                {EVAL_LABEL[r]}
+              </label>
+            ))}
+          </div>
+          <textarea
+            required
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            placeholder="評価コメント"
+            className="mb-2 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            rows={2}
+          />
+          <button
+            type="submit"
+            disabled={busy}
+            className="rounded bg-amber-600 px-4 py-2 text-sm font-medium text-white hover:bg-amber-700 disabled:opacity-50"
+          >
+            {busy ? '送信中…' : '評価を確定'}
+          </button>
+        </form>
+      )}
+    </section>
+  );
+}

--- a/review-board/frontend/src/components/Header.jsx
+++ b/review-board/frontend/src/components/Header.jsx
@@ -1,12 +1,21 @@
+import { Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
-
-const ROLE_LABEL = { STUDENT: '受講生', TEACHER: '講師' };
+import { ROLE_LABEL } from '../constants';
 
 export default function Header() {
   const { user, logout } = useAuth();
   return (
     <header className="flex items-center justify-between border-b border-gray-200 bg-white px-6 py-3">
-      <h1 className="text-lg font-bold text-gray-800">review-board</h1>
+      <div className="flex items-center gap-6">
+        <Link to="/" className="text-lg font-bold text-gray-800">review-board</Link>
+        {user && (
+          <nav className="flex gap-4 text-sm text-gray-600">
+            <Link to="/" className="hover:text-gray-900">投稿一覧</Link>
+            <Link to="/posts/new" className="hover:text-gray-900">新規投稿</Link>
+            <Link to={`/users/${user.id}/profile`} className="hover:text-gray-900">自分の成長記録</Link>
+          </nav>
+        )}
+      </div>
       {user && (
         <div className="flex items-center gap-4 text-sm">
           <span className="text-gray-600">

--- a/review-board/frontend/src/components/ReviewForm.jsx
+++ b/review-board/frontend/src/components/ReviewForm.jsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import { AXES } from '../constants';
+import { createReview } from '../api/reviews';
+
+// F-REV-01：良かった点・改善提案は必須、観点別コメント（4軸）は任意。
+export default function ReviewForm({ postId, onCreated }) {
+  const [good, setGood] = useState('');
+  const [improvement, setImprovement] = useState('');
+  const [axis, setAxis] = useState({});
+  const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const submit = async (e) => {
+    e.preventDefault();
+    setError('');
+    setSubmitting(true);
+    const axisComments = AXES.filter((a) => axis[a.key]?.trim()).map((a) => ({
+      axis: a.key,
+      comment: axis[a.key].trim(),
+    }));
+    try {
+      const created = await createReview(postId, { good, improvement, axisComments });
+      setGood('');
+      setImprovement('');
+      setAxis({});
+      onCreated?.(created);
+    } catch (err) {
+      const s = err.response?.status;
+      if (s === 400) setError('自分の投稿にはレビューできません');
+      else if (s === 404) setError('この投稿にはレビューできません');
+      else setError('送信に失敗しました');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={submit} className="rounded-lg border border-gray-200 bg-white p-4">
+      <h3 className="mb-3 font-medium text-gray-800">レビューを書く</h3>
+      {error && <p className="mb-3 rounded bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+      <label className="mb-1 block text-sm text-gray-600">✅ 良かった点（必須）</label>
+      <textarea
+        required
+        value={good}
+        onChange={(e) => setGood(e.target.value)}
+        className="mb-3 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+        rows={2}
+      />
+      <label className="mb-1 block text-sm text-gray-600">💡 もっと良くなる点（必須）</label>
+      <textarea
+        required
+        value={improvement}
+        onChange={(e) => setImprovement(e.target.value)}
+        className="mb-3 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+        rows={2}
+      />
+      <p className="mb-2 text-xs text-gray-400">観点別コメント（任意・埋めたい軸だけでOK）</p>
+      {AXES.map((a) => (
+        <div key={a.key} className="mb-2">
+          <label className="mb-1 block text-xs text-gray-500">{a.label}</label>
+          <input
+            value={axis[a.key] ?? ''}
+            onChange={(e) => setAxis((prev) => ({ ...prev, [a.key]: e.target.value }))}
+            className="w-full rounded border border-gray-200 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none"
+          />
+        </div>
+      ))}
+      <button
+        type="submit"
+        disabled={submitting}
+        className="mt-2 rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+      >
+        {submitting ? '送信中…' : 'レビューを投稿'}
+      </button>
+    </form>
+  );
+}

--- a/review-board/frontend/src/components/ReviewItem.jsx
+++ b/review-board/frontend/src/components/ReviewItem.jsx
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { AXIS_LABEL } from '../constants';
+import { sendThanks } from '../api/reviews';
+
+// 1 件のレビュー表示。講師レビューは特別表示（F-REV-02）。
+// 投稿者には「ありがとう」ボタンを出す（F-REV-03。実際の権限は backend が判定）。
+export default function ReviewItem({ review, canThank, onThanked }) {
+  const [thanks, setThanks] = useState(review.thanksCount);
+  const [done, setDone] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const thank = async () => {
+    setBusy(true);
+    try {
+      await sendThanks(review.id);
+      setThanks((n) => n + 1);
+      setDone(true);
+      onThanked?.();
+    } catch {
+      // 既に送信済み等は穏やかに無視（冪等）
+      setDone(true);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <li className={`rounded-lg border p-4 ${review.teacherReview ? 'border-amber-300 bg-amber-50' : 'border-gray-200 bg-white'}`}>
+      <div className="mb-2 flex items-center gap-2 text-sm">
+        <Link to={`/users/${review.reviewerUserId}/profile`} className="font-medium text-gray-800 hover:underline">
+          {review.reviewerDisplayName}
+        </Link>
+        {review.teacherReview && (
+          <span className="rounded bg-amber-200 px-2 py-0.5 text-xs text-amber-800">講師レビュー</span>
+        )}
+      </div>
+      <p className="text-sm text-gray-700"><span className="text-green-600">✅ 良かった点：</span>{review.good}</p>
+      <p className="mt-1 text-sm text-gray-700"><span className="text-blue-600">💡 改善点：</span>{review.improvement}</p>
+      {review.axisComments?.length > 0 && (
+        <ul className="mt-2 space-y-1 border-t border-gray-100 pt-2">
+          {review.axisComments.map((c) => (
+            <li key={c.axis} className="text-xs text-gray-600">
+              <span className="text-gray-400">{AXIS_LABEL[c.axis] ?? c.axis}：</span>{c.comment}
+            </li>
+          ))}
+        </ul>
+      )}
+      <div className="mt-2 flex items-center gap-3 text-xs text-gray-500">
+        <span>🙏 ありがとう {thanks}</span>
+        {canThank && (
+          <button
+            onClick={thank}
+            disabled={busy || done}
+            className="rounded border border-gray-300 px-2 py-0.5 text-gray-600 hover:bg-gray-50 disabled:opacity-50"
+          >
+            {done ? '送信済み' : 'ありがとうを送る'}
+          </button>
+        )}
+      </div>
+    </li>
+  );
+}

--- a/review-board/frontend/src/constants.js
+++ b/review-board/frontend/src/constants.js
@@ -1,0 +1,15 @@
+// 母の品質4軸に対応する観点別コメントの軸（F-REV-01）。
+export const AXES = [
+  { key: 'CORRECTNESS', label: '①動作・正しさ' },
+  { key: 'MAINTAINABILITY', label: '②可読性・保守性' },
+  { key: 'SECURITY', label: '③セキュリティ' },
+  { key: 'PERFORMANCE', label: '④性能・UX' },
+];
+
+export const AXIS_LABEL = Object.fromEntries(AXES.map((a) => [a.key, a.label]));
+
+export const ROLE_LABEL = { STUDENT: '受講生', TEACHER: '講師' };
+
+export const RECRUIT_LABEL = { OPEN: 'レビュー募集中', CLOSED: '募集終了' };
+
+export const EVAL_LABEL = { APPROVED: '合格', RETURNED: '差し戻し' };

--- a/review-board/frontend/src/pages/NewPostPage.jsx
+++ b/review-board/frontend/src/pages/NewPostPage.jsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { createPost } from '../api/posts';
+
+// F-POST-01：成果物の投稿（タイトル/説明は必須、URL は任意）。
+export default function NewPostPage() {
+  const navigate = useNavigate();
+  const [form, setForm] = useState({ title: '', description: '', repoUrl: '', demoUrl: '' });
+  const [error, setError] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const set = (k) => (e) => setForm((p) => ({ ...p, [k]: e.target.value }));
+
+  const submit = async (e) => {
+    e.preventDefault();
+    setError('');
+    setBusy(true);
+    try {
+      const post = await createPost({
+        title: form.title,
+        description: form.description,
+        repoUrl: form.repoUrl || null,
+        demoUrl: form.demoUrl || null,
+      });
+      navigate(`/posts/${post.id}`, { replace: true });
+    } catch {
+      setError('投稿に失敗しました');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <main className="mx-auto max-w-2xl p-6">
+      <h2 className="mb-4 text-lg font-bold text-gray-800">成果物を投稿</h2>
+      <form onSubmit={submit} className="rounded-lg border border-gray-200 bg-white p-6">
+        {error && <p className="mb-3 rounded bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+        <label className="mb-1 block text-sm text-gray-600">タイトル（必須）</label>
+        <input required value={form.title} onChange={set('title')} className="mb-4 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none" />
+        <label className="mb-1 block text-sm text-gray-600">説明（必須）</label>
+        <textarea required value={form.description} onChange={set('description')} rows={4} className="mb-4 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none" />
+        <label className="mb-1 block text-sm text-gray-600">リポジトリ URL（任意）</label>
+        <input type="url" value={form.repoUrl} onChange={set('repoUrl')} className="mb-4 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none" />
+        <label className="mb-1 block text-sm text-gray-600">デモ URL（任意）</label>
+        <input type="url" value={form.demoUrl} onChange={set('demoUrl')} className="mb-6 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none" />
+        <button type="submit" disabled={busy} className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50">
+          {busy ? '投稿中…' : '投稿する'}
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/review-board/frontend/src/pages/PostDetailPage.jsx
+++ b/review-board/frontend/src/pages/PostDetailPage.jsx
@@ -1,0 +1,72 @@
+import { useEffect, useState, useCallback } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { fetchPost } from '../api/posts';
+import { fetchReviews } from '../api/reviews';
+import { fetchEvaluation } from '../api/evaluations';
+import { useAuth } from '../context/AuthContext';
+import ReviewForm from '../components/ReviewForm';
+import ReviewItem from '../components/ReviewItem';
+import EvaluationPanel from '../components/EvaluationPanel';
+
+// 投稿詳細：本体＋レビュー一覧＋レビュー投稿＋講師評価。
+export default function PostDetailPage() {
+  const { id } = useParams();
+  const { user } = useAuth();
+  const [post, setPost] = useState(null);
+  const [reviews, setReviews] = useState([]);
+  const [evaluation, setEvaluation] = useState(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  const loadReviews = useCallback(() => fetchReviews(id).then(setReviews), [id]);
+
+  useEffect(() => {
+    setLoading(true);
+    Promise.all([fetchPost(id), fetchReviews(id), fetchEvaluation(id)])
+      .then(([p, r, e]) => {
+        setPost(p);
+        setReviews(r);
+        setEvaluation(e);
+      })
+      .catch((err) => setError(err.response?.status === 404 ? 'この投稿は見つかりません' : '取得に失敗しました'))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  if (loading) return <p className="p-6 text-gray-500">読み込み中…</p>;
+  if (error) return <p className="p-6 text-red-600">{error}</p>;
+
+  const isAuthor = user?.id === post.authorUserId;
+  const isTeacher = user?.role === 'TEACHER';
+
+  return (
+    <main className="mx-auto max-w-3xl space-y-6 p-6">
+      <Link to="/" className="text-sm text-blue-600 hover:underline">← 一覧へ</Link>
+
+      <article className="rounded-lg border border-gray-200 bg-white p-6">
+        <h2 className="text-xl font-bold text-gray-800">{post.title}</h2>
+        <p className="mt-3 whitespace-pre-wrap text-sm text-gray-700">{post.description}</p>
+        <div className="mt-3 flex gap-4 text-sm">
+          {post.repoUrl && <a href={post.repoUrl} target="_blank" rel="noreferrer" className="text-blue-600 hover:underline">リポジトリ</a>}
+          {post.demoUrl && <a href={post.demoUrl} target="_blank" rel="noreferrer" className="text-blue-600 hover:underline">デモ</a>}
+        </div>
+      </article>
+
+      <EvaluationPanel postId={post.id} evaluation={evaluation} isTeacher={isTeacher} onEvaluated={setEvaluation} />
+
+      <section>
+        <h3 className="mb-3 font-medium text-gray-800">レビュー（{reviews.length}）</h3>
+        {reviews.length === 0 ? (
+          <p className="mb-4 text-sm text-gray-500">まだレビューがありません。</p>
+        ) : (
+          <ul className="mb-4 space-y-3">
+            {reviews.map((r) => (
+              <ReviewItem key={r.id} review={r} canThank={isAuthor} onThanked={loadReviews} />
+            ))}
+          </ul>
+        )}
+        {/* 自分の投稿には自己レビュー不可（backend が 400）。フォームは他人の投稿でのみ出す。 */}
+        {!isAuthor && <ReviewForm postId={post.id} onCreated={() => loadReviews()} />}
+      </section>
+    </main>
+  );
+}

--- a/review-board/frontend/src/pages/PostsPage.jsx
+++ b/review-board/frontend/src/pages/PostsPage.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { fetchPosts } from '../api/posts';
-
-const STATUS_LABEL = { OPEN: 'レビュー募集中', CLOSED: '募集終了' };
+import { RECRUIT_LABEL } from '../constants';
 
 export default function PostsPage() {
   const [posts, setPosts] = useState([]);
@@ -20,20 +20,27 @@ export default function PostsPage() {
 
   return (
     <main className="mx-auto max-w-3xl p-6">
-      <h2 className="mb-4 text-lg font-bold text-gray-800">成果物（同じ期のメンバー）</h2>
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-lg font-bold text-gray-800">成果物（同じ期のメンバー）</h2>
+        <Link to="/posts/new" className="rounded bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700">
+          新規投稿
+        </Link>
+      </div>
       {posts.length === 0 ? (
         <p className="text-gray-500">まだ投稿がありません。</p>
       ) : (
         <ul className="space-y-3">
           {posts.map((p) => (
-            <li key={p.id} className="rounded-lg border border-gray-200 bg-white p-4">
-              <div className="flex items-center justify-between">
-                <h3 className="font-medium text-gray-800">{p.title}</h3>
-                <span className="rounded bg-blue-50 px-2 py-0.5 text-xs text-blue-600">
-                  {STATUS_LABEL[p.recruitStatus] ?? p.recruitStatus}
-                </span>
-              </div>
-              <p className="mt-1 text-sm text-gray-500">レビュー {p.reviewCount} 件</p>
+            <li key={p.id} className="rounded-lg border border-gray-200 bg-white p-4 hover:border-blue-300">
+              <Link to={`/posts/${p.id}`} className="block">
+                <div className="flex items-center justify-between">
+                  <h3 className="font-medium text-gray-800">{p.title}</h3>
+                  <span className="rounded bg-blue-50 px-2 py-0.5 text-xs text-blue-600">
+                    {RECRUIT_LABEL[p.recruitStatus] ?? p.recruitStatus}
+                  </span>
+                </div>
+                <p className="mt-1 text-sm text-gray-500">レビュー {p.reviewCount} 件</p>
+              </Link>
             </li>
           ))}
         </ul>

--- a/review-board/frontend/src/pages/ProfilePage.jsx
+++ b/review-board/frontend/src/pages/ProfilePage.jsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { fetchProfile } from '../api/profile';
+import { ROLE_LABEL, EVAL_LABEL } from '../constants';
+
+// F-PROF：成長記録ページ（本アプリの主役）。投稿履歴・もらったレビュー・実績・合格バッジ。
+export default function ProfilePage() {
+  const { id } = useParams();
+  const [profile, setProfile] = useState(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    fetchProfile(id)
+      .then(setProfile)
+      .catch((e) => setError(e.response?.status === 404 ? 'この成長記録は閲覧できません' : '取得に失敗しました'))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  if (loading) return <p className="p-6 text-gray-500">読み込み中…</p>;
+  if (error) return <p className="p-6 text-red-600">{error}</p>;
+
+  const { displayName, role, stats, posts, receivedReviews } = profile;
+
+  return (
+    <main className="mx-auto max-w-3xl space-y-6 p-6">
+      <header className="rounded-lg border border-gray-200 bg-white p-6">
+        <h2 className="text-xl font-bold text-gray-800">
+          {displayName}
+          <span className="ml-2 rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-500">{ROLE_LABEL[role] ?? role}</span>
+        </h2>
+        <div className="mt-4 grid grid-cols-3 gap-4 text-center">
+          <Stat label="もらったレビュー" value={stats.receivedReviewsCount} />
+          <Stat label="したレビュー" value={stats.givenReviewsCount} />
+          <Stat label="もらった🙏" value={stats.thanksReceivedCount} />
+        </div>
+      </header>
+
+      <section>
+        <h3 className="mb-3 font-medium text-gray-800">投稿した成果物（{posts.length}）</h3>
+        {posts.length === 0 ? (
+          <p className="text-sm text-gray-500">まだ投稿がありません。</p>
+        ) : (
+          <ul className="space-y-2">
+            {posts.map((p) => (
+              <li key={p.postId} className="flex items-center justify-between rounded-lg border border-gray-200 bg-white p-3">
+                <Link to={`/posts/${p.postId}`} className="text-sm font-medium text-gray-800 hover:underline">{p.title}</Link>
+                <span className="flex items-center gap-2 text-xs text-gray-500">
+                  レビュー {p.reviewCount}
+                  {p.approved && <span className="rounded bg-green-100 px-2 py-0.5 text-green-700">🏅 合格</span>}
+                  {p.evaluationResult === 'RETURNED' && <span className="rounded bg-orange-100 px-2 py-0.5 text-orange-700">{EVAL_LABEL.RETURNED}</span>}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section>
+        <h3 className="mb-3 font-medium text-gray-800">もらったレビュー（{receivedReviews.length}）</h3>
+        {receivedReviews.length === 0 ? (
+          <p className="text-sm text-gray-500">まだありません。</p>
+        ) : (
+          <ul className="space-y-2">
+            {receivedReviews.map((r) => (
+              <li key={r.reviewId} className={`rounded-lg border p-3 text-sm ${r.teacherReview ? 'border-amber-300 bg-amber-50' : 'border-gray-200 bg-white'}`}>
+                <span className="font-medium text-gray-700">{r.reviewerDisplayName}</span>
+                {r.teacherReview && <span className="ml-2 rounded bg-amber-200 px-2 py-0.5 text-xs text-amber-800">講師</span>}
+                <span className="ml-2 text-xs text-gray-400">🙏 {r.thanksCount}</span>
+                <p className="mt-1 text-gray-600">{r.good}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}
+
+function Stat({ label, value }) {
+  return (
+    <div className="rounded-lg bg-gray-50 p-3">
+      <div className="text-2xl font-bold text-gray-800">{value}</div>
+      <div className="text-xs text-gray-500">{label}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 関連 Issue

Closes #111

---

## 変更の概要

「投稿 → レビュー → 成長記録」ループを画面で完成させる第2スライス。

- **投稿作成フォーム**（F-POST-01）
- **投稿詳細ページ**：本体＋レビュー一覧＋レビュー投稿フォーム＋講師評価パネル
- **レビュー作成UI**（F-REV-01：良かった点/改善提案＋観点別4軸 任意）
- **ありがとう**（F-REV-03：投稿者のみ表示・冪等）
- **講師レビュー特別表示**（F-REV-02：`teacherReview` バッジ・強調色）
- **講師評価パネル**（F-EVAL-01：APPROVED/RETURNED＋コメント、講師ロールのみフォーム）＋合格バッジ
- **成長記録ページ**（F-PROF：投稿履歴・もらったレビュー・実績数・合格バッジ）＝本アプリの主役
- ルーティング／ヘッダーナビ（投稿一覧・新規投稿・自分の成長記録）

母 SEC-2：フォームの出し分け（ありがとう/評価）は UX 補助。**実際の認可は backend**（403/404 を画面で穏やかに表示。既存31テストで担保）。

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] `npm run build` 成功（111 modules）
- [x] 実ブラウザでログイン画面描画・ルーティング・**console エラーなし**（M-13。新ルーティング/インポートの回帰なし）
- [ ] 通し e2e（ログイン→投稿→レビュー→評価→成長記録）：backend + DB 稼働が必要なため本 PR では未実施（ローカル DB 認証情報の制約）。`docker-compose up` + `bootRun`（dev/SEED_PASSWORD）+ `npm run dev` で確認可能

---

## レビュー時に特に確認してほしい点

- フォーム出し分けの UX 補助と backend 認可の役割分担（自己レビューは自分の投稿でフォーム非表示＋backend 400、ありがとうは投稿者のみ表示＋backend 403）
- ProfilePage（主役）の集約表示が backend ProfileResponse と整合しているか

🤖 Generated with [Claude Code](https://claude.com/claude-code)