### PR TITLE
feat: フロント 投稿・レビューの編集／削除 UI（自分の資源のみ）

### DIFF
--- a/review-board/frontend/src/App.jsx
+++ b/review-board/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import Header from './components/Header';
 import LoginPage from './pages/LoginPage';
 import PostsPage from './pages/PostsPage';
 import NewPostPage from './pages/NewPostPage';
+import PostEditPage from './pages/PostEditPage';
 import PostDetailPage from './pages/PostDetailPage';
 import ProfilePage from './pages/ProfilePage';
 
@@ -27,6 +28,7 @@ export default function App() {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/" element={<Shell><PostsPage /></Shell>} />
         <Route path="/posts/new" element={<Shell><NewPostPage /></Shell>} />
+        <Route path="/posts/:id/edit" element={<Shell><PostEditPage /></Shell>} />
         <Route path="/posts/:id" element={<Shell><PostDetailPage /></Shell>} />
         <Route path="/users/:id/profile" element={<Shell><ProfilePage /></Shell>} />
       </Routes>

--- a/review-board/frontend/src/api/posts.js
+++ b/review-board/frontend/src/api/posts.js
@@ -9,3 +9,9 @@ export const fetchPost = (id) => client.get(`/posts/${id}`).then((r) => r.data);
 
 // F-POST-01 作成（タイトル/説明は必須、URL は任意）
 export const createPost = (data) => client.post('/posts', data).then((r) => r.data);
+
+// F-POST-02 編集（所有者のみ・backend が非所有者を 404）
+export const updatePost = (id, data) => client.put(`/posts/${id}`, data).then((r) => r.data);
+
+// F-POST-02 論理削除（所有者のみ）
+export const deletePost = (id) => client.delete(`/posts/${id}`);

--- a/review-board/frontend/src/api/reviews.js
+++ b/review-board/frontend/src/api/reviews.js
@@ -8,5 +8,12 @@ export const fetchReviews = (postId) =>
 export const createReview = (postId, body) =>
   client.post(`/posts/${postId}/reviews`, body).then((r) => r.data);
 
+// F-REV 編集（所有者のみ・backend が非所有者を 404）
+export const updateReview = (reviewId, body) =>
+  client.put(`/reviews/${reviewId}`, body).then((r) => r.data);
+
+// F-REV 論理削除（所有者のみ）
+export const deleteReview = (reviewId) => client.delete(`/reviews/${reviewId}`);
+
 // F-REV-03 ありがとう（投稿者のみ・冪等）
 export const sendThanks = (reviewId) => client.post(`/reviews/${reviewId}/thanks`);

--- a/review-board/frontend/src/components/ReviewItem.jsx
+++ b/review-board/frontend/src/components/ReviewItem.jsx
@@ -1,25 +1,51 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { AXIS_LABEL } from '../constants';
-import { sendThanks } from '../api/reviews';
+import { sendThanks, updateReview, deleteReview } from '../api/reviews';
 
 // 1 件のレビュー表示。講師レビューは特別表示（F-REV-02）。
-// 投稿者には「ありがとう」ボタンを出す（F-REV-03。実際の権限は backend が判定）。
-export default function ReviewItem({ review, canThank, onThanked }) {
+// 投稿者には「ありがとう」（F-REV-03）、レビュー所有者には編集/削除を出す（権限は backend が判定）。
+export default function ReviewItem({ review, canThank, isOwner, onChanged }) {
   const [thanks, setThanks] = useState(review.thanksCount);
-  const [done, setDone] = useState(false);
+  const [thanked, setThanked] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [good, setGood] = useState(review.good);
+  const [improvement, setImprovement] = useState(review.improvement);
 
   const thank = async () => {
     setBusy(true);
     try {
       await sendThanks(review.id);
       setThanks((n) => n + 1);
-      setDone(true);
-      onThanked?.();
+      setThanked(true);
+      onChanged?.();
     } catch {
-      // 既に送信済み等は穏やかに無視（冪等）
-      setDone(true);
+      setThanked(true);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const saveEdit = async () => {
+    setBusy(true);
+    try {
+      // 既存の観点別コメントは保持して再送（backend は update で入れ替えるため）
+      const axisComments = (review.axisComments ?? []).map((c) => ({ axis: c.axis, comment: c.comment }));
+      await updateReview(review.id, { good, improvement, axisComments });
+      setEditing(false);
+      onChanged?.();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const remove = async () => {
+    if (!window.confirm('このレビューを削除しますか？')) return;
+    setBusy(true);
+    try {
+      await deleteReview(review.id);
+      onChanged?.();
     } finally {
       setBusy(false);
     }
@@ -35,27 +61,44 @@ export default function ReviewItem({ review, canThank, onThanked }) {
           <span className="rounded bg-amber-200 px-2 py-0.5 text-xs text-amber-800">講師レビュー</span>
         )}
       </div>
-      <p className="text-sm text-gray-700"><span className="text-green-600">✅ 良かった点：</span>{review.good}</p>
-      <p className="mt-1 text-sm text-gray-700"><span className="text-blue-600">💡 改善点：</span>{review.improvement}</p>
-      {review.axisComments?.length > 0 && (
-        <ul className="mt-2 space-y-1 border-t border-gray-100 pt-2">
-          {review.axisComments.map((c) => (
-            <li key={c.axis} className="text-xs text-gray-600">
-              <span className="text-gray-400">{AXIS_LABEL[c.axis] ?? c.axis}：</span>{c.comment}
-            </li>
-          ))}
-        </ul>
+
+      {editing ? (
+        <div className="space-y-2">
+          <textarea value={good} onChange={(e) => setGood(e.target.value)} rows={2} className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none" />
+          <textarea value={improvement} onChange={(e) => setImprovement(e.target.value)} rows={2} className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none" />
+          <div className="flex gap-2">
+            <button onClick={saveEdit} disabled={busy} className="rounded bg-blue-600 px-3 py-1 text-xs text-white hover:bg-blue-700 disabled:opacity-50">保存</button>
+            <button onClick={() => { setEditing(false); setGood(review.good); setImprovement(review.improvement); }} className="rounded border border-gray-300 px-3 py-1 text-xs text-gray-600 hover:bg-gray-50">キャンセル</button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <p className="text-sm text-gray-700"><span className="text-green-600">✅ 良かった点：</span>{review.good}</p>
+          <p className="mt-1 text-sm text-gray-700"><span className="text-blue-600">💡 改善点：</span>{review.improvement}</p>
+          {review.axisComments?.length > 0 && (
+            <ul className="mt-2 space-y-1 border-t border-gray-100 pt-2">
+              {review.axisComments.map((c) => (
+                <li key={c.axis} className="text-xs text-gray-600">
+                  <span className="text-gray-400">{AXIS_LABEL[c.axis] ?? c.axis}：</span>{c.comment}
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
       )}
+
       <div className="mt-2 flex items-center gap-3 text-xs text-gray-500">
         <span>🙏 ありがとう {thanks}</span>
         {canThank && (
-          <button
-            onClick={thank}
-            disabled={busy || done}
-            className="rounded border border-gray-300 px-2 py-0.5 text-gray-600 hover:bg-gray-50 disabled:opacity-50"
-          >
-            {done ? '送信済み' : 'ありがとうを送る'}
+          <button onClick={thank} disabled={busy || thanked} className="rounded border border-gray-300 px-2 py-0.5 text-gray-600 hover:bg-gray-50 disabled:opacity-50">
+            {thanked ? '送信済み' : 'ありがとうを送る'}
           </button>
+        )}
+        {isOwner && !editing && (
+          <>
+            <button onClick={() => setEditing(true)} className="text-blue-600 hover:underline">編集</button>
+            <button onClick={remove} disabled={busy} className="text-red-500 hover:underline disabled:opacity-50">削除</button>
+          </>
         )}
       </div>
     </li>

--- a/review-board/frontend/src/pages/PostDetailPage.jsx
+++ b/review-board/frontend/src/pages/PostDetailPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback } from 'react';
-import { useParams, Link } from 'react-router-dom';
-import { fetchPost } from '../api/posts';
+import { useParams, Link, useNavigate } from 'react-router-dom';
+import { fetchPost, deletePost } from '../api/posts';
 import { fetchReviews } from '../api/reviews';
 import { fetchEvaluation } from '../api/evaluations';
 import { useAuth } from '../context/AuthContext';
@@ -11,6 +11,7 @@ import EvaluationPanel from '../components/EvaluationPanel';
 // 投稿詳細：本体＋レビュー一覧＋レビュー投稿＋講師評価。
 export default function PostDetailPage() {
   const { id } = useParams();
+  const navigate = useNavigate();
   const { user } = useAuth();
   const [post, setPost] = useState(null);
   const [reviews, setReviews] = useState([]);
@@ -38,12 +39,30 @@ export default function PostDetailPage() {
   const isAuthor = user?.id === post.authorUserId;
   const isTeacher = user?.role === 'TEACHER';
 
+  const removePost = async () => {
+    if (!window.confirm('この投稿を削除しますか？')) return;
+    try {
+      await deletePost(post.id);
+      navigate('/', { replace: true });
+    } catch {
+      setError('削除に失敗しました');
+    }
+  };
+
   return (
     <main className="mx-auto max-w-3xl space-y-6 p-6">
       <Link to="/" className="text-sm text-blue-600 hover:underline">← 一覧へ</Link>
 
       <article className="rounded-lg border border-gray-200 bg-white p-6">
-        <h2 className="text-xl font-bold text-gray-800">{post.title}</h2>
+        <div className="flex items-start justify-between">
+          <h2 className="text-xl font-bold text-gray-800">{post.title}</h2>
+          {isAuthor && (
+            <div className="flex gap-3 text-sm">
+              <Link to={`/posts/${post.id}/edit`} className="text-blue-600 hover:underline">編集</Link>
+              <button onClick={removePost} className="text-red-500 hover:underline">削除</button>
+            </div>
+          )}
+        </div>
         <p className="mt-3 whitespace-pre-wrap text-sm text-gray-700">{post.description}</p>
         <div className="mt-3 flex gap-4 text-sm">
           {post.repoUrl && <a href={post.repoUrl} target="_blank" rel="noreferrer" className="text-blue-600 hover:underline">リポジトリ</a>}
@@ -60,7 +79,13 @@ export default function PostDetailPage() {
         ) : (
           <ul className="mb-4 space-y-3">
             {reviews.map((r) => (
-              <ReviewItem key={r.id} review={r} canThank={isAuthor} onThanked={loadReviews} />
+              <ReviewItem
+                key={r.id}
+                review={r}
+                canThank={isAuthor}
+                isOwner={user?.id === r.reviewerUserId}
+                onChanged={loadReviews}
+              />
             ))}
           </ul>
         )}

--- a/review-board/frontend/src/pages/PostEditPage.jsx
+++ b/review-board/frontend/src/pages/PostEditPage.jsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { fetchPost, updatePost } from '../api/posts';
+
+// F-POST-02 投稿の編集（所有者のみ。非所有者は backend が 404）。
+export default function PostEditPage() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [form, setForm] = useState(null);
+  const [error, setError] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    fetchPost(id)
+      .then((p) => setForm({
+        title: p.title,
+        description: p.description,
+        repoUrl: p.repoUrl ?? '',
+        demoUrl: p.demoUrl ?? '',
+      }))
+      .catch((e) => setError(e.response?.status === 404 ? 'この投稿は編集できません' : '取得に失敗しました'));
+  }, [id]);
+
+  const set = (k) => (e) => setForm((p) => ({ ...p, [k]: e.target.value }));
+
+  const submit = async (e) => {
+    e.preventDefault();
+    setError('');
+    setBusy(true);
+    try {
+      await updatePost(id, {
+        title: form.title,
+        description: form.description,
+        repoUrl: form.repoUrl || null,
+        demoUrl: form.demoUrl || null,
+      });
+      navigate(`/posts/${id}`, { replace: true });
+    } catch (err) {
+      setError(err.response?.status === 404 ? '権限がありません' : '更新に失敗しました');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (error && !form) return <p className="p-6 text-red-600">{error}</p>;
+  if (!form) return <p className="p-6 text-gray-500">読み込み中…</p>;
+
+  return (
+    <main className="mx-auto max-w-2xl p-6">
+      <h2 className="mb-4 text-lg font-bold text-gray-800">投稿を編集</h2>
+      <form onSubmit={submit} className="rounded-lg border border-gray-200 bg-white p-6">
+        {error && <p className="mb-3 rounded bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+        <label className="mb-1 block text-sm text-gray-600">タイトル（必須）</label>
+        <input required value={form.title} onChange={set('title')} className="mb-4 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none" />
+        <label className="mb-1 block text-sm text-gray-600">説明（必須）</label>
+        <textarea required value={form.description} onChange={set('description')} rows={4} className="mb-4 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none" />
+        <label className="mb-1 block text-sm text-gray-600">リポジトリ URL（任意）</label>
+        <input type="url" value={form.repoUrl} onChange={set('repoUrl')} className="mb-4 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none" />
+        <label className="mb-1 block text-sm text-gray-600">デモ URL（任意）</label>
+        <input type="url" value={form.demoUrl} onChange={set('demoUrl')} className="mb-6 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none" />
+        <div className="flex gap-3">
+          <button type="submit" disabled={busy} className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50">
+            {busy ? '更新中…' : '更新する'}
+          </button>
+          <button type="button" onClick={() => navigate(`/posts/${id}`)} className="rounded border border-gray-300 px-4 py-2 text-sm text-gray-600 hover:bg-gray-50">
+            キャンセル
+          </button>
+        </div>
+      </form>
+    </main>
+  );
+}


### PR DESCRIPTION
## 関連 Issue

Closes #115

---

## 変更の概要

backend の F-POST-02 / F-REV 編集・論理削除（所有者限定・PUT/DELETE）を画面から操作できるようにし、フロントの CRUD を完成。

- **投稿**：所有者に「編集」（/posts/:id/edit）・「削除」（確認ダイアログ→DELETE→一覧へ）
- **レビュー**：所有者にインライン「編集」・「削除」（観点別コメントは保持して再送）
- 出し分け（編集/削除ボタン表示）は UX 補助。**実際の認可は backend**（非所有者は 404・既存31テストで担保）

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] `npm run lint`（0 error）・`npm run build` 成功
- [ ] frontend CI（lint→build）green ← Actions で確認
- [ ] 実 e2e（編集・削除）：backend 起動時に確認可能

---

## レビュー時に特に確認してほしい点

- レビュー編集時に観点別コメントを保持して再送している点（backend update は axisComments を入れ替えるため）
- 投稿/レビューの所有者判定（`user.id === authorUserId/reviewerUserId`）は UX 補助で、認可は backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)