### PR TITLE
docs: インフラ構成.md（AWS 構成・Phase3 計画）を作成

### DIFF
--- a/review-board/docs/インフラ構成.md
+++ b/review-board/docs/インフラ構成.md
@@ -1,0 +1,204 @@
+# review-board インフラ構成（AWS・Phase 3 計画）
+
+**プロジェクト名：** review-board（成長支援型レビューコミュニティ）
+**作成日：** 2026-05-23
+**バージョン：** 0.1（設計・**未デプロイ**）
+**スコープ：** AWS 上でのデプロイ環境（Phase 3 で構築予定）
+
+> 本書は AWS 上で稼働するインフラの **設計方針** と **構成図** を示す。
+> **現時点は未デプロイ**（Phase 1〜2 はローカルのみ）。デプロイ着手時に作成する `infra/` の
+> **Terraform コードを正**とし、本書は「全体像と意図」を保持する。
+> family（task-board）の [インフラ構成.md](../../task-board/docs/インフラ構成.md) と
+> 修練城の AWS 防御層を継承し、review-board 固有（S軸・S3 スクショ・JWT Cookie）を追記する。
+
+---
+
+## 目次
+
+1. [全体構成図](#1-全体構成図)
+2. [採用クラウドサービス](#2-採用クラウドサービス)
+3. [ネットワーク設計](#3-ネットワーク設計)
+4. [セキュリティ設計（多層防御）](#4-セキュリティ設計多層防御)
+5. [運用フロー](#5-運用フロー)
+6. [無料枠・コストポリシー](#6-無料枠コストポリシー)
+7. [IaC 方針](#7-iac方針)
+8. [AI 誤操作の多層防御（修練城継承）](#8-ai-誤操作の多層防御修練城継承)
+9. [既知のインシデント参照](#9-既知のインシデント参照)
+10. [簡素化と本実装移行時の論点](#10-簡素化と本実装移行時の論点)
+
+---
+
+## 1. 全体構成図
+
+```
+ [ユーザーのブラウザ]
+        │  HTTPS(443)
+        ▼
+ ┌──────────────────────── VPC (10.0.0.0/16) ────────────────────────┐
+ │                                                                    │
+ │   Public Subnet (10.0.1.0/24)            Private Subnet(10.0.2.0/24)│
+ │  ┌───────────────────────────┐         ┌────────────────────────┐ │
+ │  │ EC2 (t3.micro 無料枠)       │         │ RDS PostgreSQL          │ │
+ │  │  - nginx(443/80)            │  5432   │ (db.t3.micro 無料枠)     │ │
+ │  │    └ React 静的配信         │ ──────▶ │  - 非公開(EC2 SGのみ許可) │ │
+ │  │  - Spring Boot(8082)        │         │  - deletion_protection  │ │
+ │  │    └ /api/*                 │         └────────────────────────┘ │
+ │  │  EIP(固定IP)                │                                     │
+ │  └──────────┬────────────────┘                                     │
+ │             │ HTTPS(VPCエンドポイント or NAT)                         │
+ └─────────────┼──────────────────────────────────────────────────────┘
+               ▼
+        ┌─────────────────┐
+        │ S3 (スクショ保存) │  ← ローカルの MinIO を本番は S3 に置換（SEC-8）
+        │  - 非公開バケット │     署名付きURLで配信・magic byte検証は API 側
+        └─────────────────┘
+
+        ┌─────────────────┐
+        │ AWS Budgets      │  月 $0.50 超で通知（コスト防御）
+        └─────────────────┘
+```
+
+> **配置の意図**：EC2（public）が web を終端し、RDS（private）は EC2 のセキュリティグループからのみ
+> 到達可能にして直接公開しない（最小露出）。スクショは S3（非公開＋署名付き URL）に隔離する。
+
+---
+
+## 2. 採用クラウドサービス
+
+| サービス | 用途 | 無料枠 |
+|---|---|---|
+| EC2（t3.micro / x86 or t4g.micro / ARM） | backend(8082) + React 静的配信(nginx) | 12ヶ月 750h/月 |
+| RDS PostgreSQL（db.t3.micro） | アプリ DB（Flyway 管理） | 12ヶ月 750h/月・20GB |
+| S3 | 成果物スクショ（MinIO の本番置換・SEC-8/P-10） | 5GB |
+| EIP | 固定パブリック IP | EC2 稼働中は無料 |
+| AWS Budgets | コスト通知（月 $0.50 閾値） | 無料 |
+| IAM | 最小権限ロール（CI/デプロイ用） | 無料 |
+
+> ローカル開発のポート（Backend 8082 / Vite 5175 / PG 5434 / MinIO 9002・9003）は**ローカル専用**。
+> 本番は nginx が 443/80 を終端し、backend は内部 8082、DB は RDS、スクショは S3 に置換する。
+
+---
+
+## 3. ネットワーク設計
+
+### サブネット配置
+
+| サブネット | CIDR | 配置 | 公開 |
+|---|---|---|---|
+| Public | 10.0.1.0/24 | EC2（EIP 付与） | あり（web/SSH） |
+| Private | 10.0.2.0/24 | RDS PostgreSQL | なし |
+
+### セキュリティグループ（最小開放）
+
+| SG | インバウンド | ソース |
+|---|---|---|
+| EC2 用 | 443/80（web）・22（SSH） | web は 0.0.0.0/0（学習）・SSH は自宅 IP 限定 |
+| RDS 用 | 5432 | **EC2 用 SG からのみ**（IP では開けない） |
+
+---
+
+## 4. セキュリティ設計（多層防御）
+
+review-board は **S軸（セキュリティ・認可）が突出点**。インフラ層もそれを支える。
+
+- **HTTPS 終端**：nginx（Let's Encrypt）で 443 を終端。**JWT は HttpOnly + Secure + SameSite=Strict Cookie**（`JWT_COOKIE_SECURE=true`）。HTTP では Secure Cookie が無効になるため、本番は HTTPS 必須（母 SEC-13）。
+- **RDS 非公開**：EC2 SG からのみ。インターネットから直接到達不可。`deletion_protection = true`。
+- **S3 スクショ**：バケットは**非公開**。アップロードは API 経由で **magic byte 検証＋サイズ上限**（SEC-8）、配信は**署名付き URL**。バケットポリシーで public read を禁止。
+- **機密情報**：DB パスワード・JWT secret は **SSM Parameter Store / Secrets Manager**（または起動時 env）で注入。平文ハードコード禁止（SEC-9）。
+- **CORS**：本番フロントのオリジンのみ許可（`CORS_ALLOWED_ORIGIN`）。ワイルドカード禁止（SEC-11）。
+- **IAM 最小権限**：CI/デプロイ用ロールは必要なアクションのみ。削除系には Deny ガード（§8）。
+
+---
+
+## 5. 運用フロー
+
+### 構築（IaC）
+
+1. `infra/` の Terraform で VPC / EC2 / RDS / S3 / IAM / Budgets を作成（`terraform plan` → 人間承認 → `apply`）。
+2. EC2 に backend（jar）と React build（静的）を配置、nginx 設定、env（DB/JWT/CORS/S3）注入。
+3. Flyway がアプリ起動時に DB スキーマを適用。
+
+### 撤収・コスト抑制
+
+- 使わない期間は **RDS を停止**。AWS 仕様で停止 RDS は **7 日後に自動再起動**するため、[`rds-auto-stop.yml`](../../.github/workflows/rds-auto-stop.yml) と同方式で 5 日ごとに再停止する（修練城 F3）。
+- 本格的な解体は §8 の手順（`prevent_destroy` を外す → apply → destroy）に従い、**人間承認をはさむ**。
+
+### 日常運用
+
+- 監視・ログは [ログ・監視・障害対応設計書.md](./ログ・監視・障害対応設計書.md) に従う（Actuator health・将来 Micrometer/CloudWatch）。
+- デプロイは Issue→PR→squash（M-1/M-2）。CI（build/test・依存スキャン・lint）green を前提。
+
+---
+
+## 6. 無料枠・コストポリシー
+
+- **目標：月 $0.50 以下**（要件 §2-2）。
+- EC2・RDS は無料枠インスタンス（t3.micro / db.t3.micro）に限定。`describe-instance-types` で無料枠該当を確認（terraform-quality-check）。
+- S3 は 5GB 内。スクショはサイズ上限＋古いものの purge で管理。
+- **AWS Budgets** で月 $0.50 超を通知。超過の早期検知。
+- 無料枠を守るルール：インスタンスタイプを上げない／不要リソースは即削除（ただし削除は §8 の承認フロー）。
+
+---
+
+## 7. IaC 方針
+
+| Terraform で管理する | Terraform で管理しない |
+|---|---|
+| VPC・サブネット・SG・ルート / EC2・EIP / RDS / S3 / IAM ロール / Budgets | EC2 内のアプリ配置（jar/静的ファイル）・nginx 設定（構成管理 or デプロイスクリプト） / TLS 証明書（Let's Encrypt 自動更新） |
+
+- `terraform plan` の差分に **意図しない destroy** が無いことを必ず確認（CLAUDE.md §12-4）。
+- `terraform-quality-check` スキルで fmt/validate/tflint/tfsec/機密スキャン/無料枠確認/ドリフト検出を一括実行。
+
+---
+
+## 8. AI 誤操作の多層防御（修練城継承）
+
+CLAUDE.md §12 の多層防御を本プロジェクトにも適用する：
+
+| 階層 | 内容 |
+|---|---|
+| 1. Claude 設定 | `permissions.deny` で破壊的コマンド拒否（`terraform destroy` / `aws *delete*` 等） |
+| 2. Terraform 保護 | RDS 等に `lifecycle { prevent_destroy = true }` ＋ `deletion_protection = true` |
+| 3. 開発ルール | CLAUDE.md §6・§12 の禁止事項（AI 単独で destroy/delete を完結させない） |
+| 4. コードレビュー | PR ベース・`terraform plan` 差分レビュー（意図しない destroy の検出） |
+| 5. AWS 保護（将来） | IAM 最小権限 / SCP / **クロスアカウントバックアップ**（同一アカウント内バックアップは同じ削除で消える） |
+
+> 正規の削除手順：`prevent_destroy = false` に変更 → `apply`（lifecycle のみ）→ `destroy` → 完了後 `true` に戻す。
+> **「ワンコマンドで destroy できない」状態をデフォルト**にする。
+
+---
+
+## 9. 既知のインシデント参照
+
+- 母要件定義書 §13-1「2026年：Claude Code が Terraform で本番環境を全削除」。
+  多層防御がすべて外れていた状態（auto-approve・dev/prod 同一 tfstate・prevent_destroy 未設定・同一アカウントバックアップ・PR なし直 apply）。
+  → 本構成は §8 の階層 1〜4 を適用し、階層 5 は本格運用フェーズで実装する。
+- 障害対応・診断は [ログ・監視・障害対応設計書.md](./ログ・監視・障害対応設計書.md) §6 と family `docs/incidents/`（症状→兆候→真因）を参照。
+
+---
+
+## 10. 簡素化と本実装移行時の論点
+
+学習スコープのため現フェーズで簡素化する（要件 §2-2・恒久排除ではなく現フェーズの判断）：
+
+| 項目 | 現フェーズ | 本実装移行時 |
+|---|---|---|
+| CloudFront / CDN | 対象外 | 静的配信の CDN 化・キャッシュ |
+| WAF | 対象外 | L7 防御・レート制限 |
+| Multi-AZ / 冗長化（S-2） | 単一 AZ・単一インスタンス | RDS Multi-AZ・ALB + 複数 EC2 |
+| ゼロダウンタイムデプロイ（S-7） | 停止を伴う入れ替え | ローリング / Blue-Green |
+| クロスアカウントバックアップ | なし | 別アカウントへ自動バックアップ |
+| 監視（メトリクス/アラート） | health のみ | CloudWatch / Micrometer（§ログ設計書） |
+
+> これらは判定表で S-2/S-7/M-14 を「対象外（Phase3）」とした項目に対応する。デプロイ時に本書と判定表を更新する。
+
+---
+
+## 関連ドキュメント
+
+- [要件定義書.md](./要件定義書.md) §2-2（コスト・簡素化）・§4（非機能）
+- [付録A_判定表.md](./付録A_判定表.md)（S-2/S-7/M-14 の判定）
+- [脅威モデリング.md](./脅威モデリング.md)（アプリ層の認可境界）
+- [ログ・監視・障害対応設計書.md](./ログ・監視・障害対応設計書.md)（運用・監視）
+- [技術スタック.md](./技術スタック.md)（採用技術）
+- task-board [インフラ構成.md](../../task-board/docs/インフラ構成.md)（継承元フォーマット）・[.github/workflows/rds-auto-stop.yml](../../.github/workflows/rds-auto-stop.yml)（RDS 自動停止の実例）


### PR DESCRIPTION
## 関連 Issue

Closes #119

---

## 変更の概要

要件定義書 §関連ドキュメントに予定されていた「インフラ構成.md（AWS 構成図）」を、デプロイ前の今のうちに整備。family（task-board）のフォーマットと修練城の AWS 防御層を継承し、review-board 固有（重点軸・S3 スクショ・JWT Cookie）を追記。

- **全体構成図**：EC2（nginx で React 静的配信 + Spring Boot 8082）/ RDS PostgreSQL（private）/ S3（スクショ）/ Budgets
- **ネットワーク**：VPC・public/private サブネット・SG 最小開放（RDS は EC2 SG からのみ）
- **セキュリティ多層防御**：HTTPS + JWT Secure Cookie / S3 非公開 + 署名付き URL + SEC-8 magic byte / 機密は SSM / CORS / IAM 最小権限
- **運用**：IaC 構築 / RDS auto-stop での撤収（既存 `rds-auto-stop.yml` 方式）/ 日常
- **無料枠**：月 $0.50 以下・Budgets 通知
- **AI 誤操作の多層防御 5 階層**（`prevent_destroy` / `deletion_protection`・CLAUDE.md §12 継承）
- **既知インシデント参照**（共通方針 §13 Terraform 全削除事故）
- **簡素化**（CloudFront/WAF/Multi-AZ 対象外）を判定表 S-2/S-7/M-14 と対応づけ

**未デプロイの Phase 3 計画**であることを明記。実体は将来 `infra/` の Terraform を正とする。

## 変更の種別

- [x] docs（ドキュメントのみの変更）

---

## 動作確認チェックリスト

- [x] コード変更なし
- [x] 未デプロイ（計画）であることを明記・過剰宣言しない
- [x] 判定表 S-2/S-7/M-14・ログ設計書・脅威モデリングとの相互リンク整合

---

## レビュー時に特に確認してほしい点

- 無料枠（$0.50/月）と防御層（prevent_destroy/RDS auto-stop）の方針が妥当か
- S3 スクショの SEC-8（magic byte 検証・署名付き URL・非公開バケット）の設計

🤖 Generated with [Claude Code](https://claude.com/claude-code)