### PR TITLE
feat: 観測性を実装（構造化ログ＋MDC・Micrometer 4ゴールデンシグナル）

### DIFF
--- a/review-board/backend/build.gradle
+++ b/review-board/backend/build.gradle
@@ -34,6 +34,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	// 4 ゴールデンシグナルの収集（母 §3-1）。http.server.requests（Latency/Traffic/Errors）と
+	// Hikari/JVM（Saturation）を Micrometer が Actuator 経由で /actuator/prometheus に公開する。
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 	// ★S軸の中核：RBAC + 認可（SecurityConfig）
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	// JWT (HS256, HttpOnly Cookie 認証。技術スタック.md §2-4)

--- a/review-board/backend/src/main/java/com/reviewboard/config/SecurityConfig.java
+++ b/review-board/backend/src/main/java/com/reviewboard/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.reviewboard.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.reviewboard.common.ApiError;
 import com.reviewboard.domain.auth.JwtAuthenticationFilter;
+import com.reviewboard.observability.MdcLoggingFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
@@ -36,7 +37,8 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http, JwtAuthenticationFilter jwtFilter) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http, JwtAuthenticationFilter jwtFilter,
+                                           MdcLoggingFilter mdcFilter) throws Exception {
         http
             .cors(Customizer.withDefaults())
             // JWT in HttpOnly Cookie + SameSite=Strict 方式。CSRF は SameSite で緩和する
@@ -44,8 +46,12 @@ public class SecurityConfig {
             .csrf(csrf -> csrf.disable())
             .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
+                // health は監視プローブ用に開放（liveness/readiness）。
                 .requestMatchers("/actuator/health",
                         "/api/auth/login", "/api/auth/refresh", "/api/auth/logout").permitAll()
+                // 運用メトリクスは情報漏えいを避けるため運用ロール（講師）限定（SEC-2/SEC-11）。
+                // 誰でも JVM ヒープ・Hikari プール・流量を覗ける状態にしない。
+                .requestMatchers("/actuator/**").hasRole("TEACHER")
                 .anyRequest().authenticated())
             .exceptionHandling(ex -> ex
                 .authenticationEntryPoint((req, res, e) ->
@@ -54,7 +60,9 @@ public class SecurityConfig {
                         writeError(res, HttpStatus.FORBIDDEN, "FORBIDDEN", "この操作を行う権限がありません")))
             .httpBasic(basic -> basic.disable())
             .formLogin(form -> form.disable())
-            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+            // jwt の後段で MDC に requestId/userId を載せる（SecurityContext 確立後）。
+            .addFilterAfter(mdcFilter, JwtAuthenticationFilter.class);
         return http.build();
     }
 

--- a/review-board/backend/src/main/java/com/reviewboard/observability/MdcLoggingFilter.java
+++ b/review-board/backend/src/main/java/com/reviewboard/observability/MdcLoggingFilter.java
@@ -1,0 +1,72 @@
+package com.reviewboard.observability;
+
+import com.reviewboard.domain.auth.AuthPrincipal;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.lang.NonNull;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * 1リクエストを横断追跡するための相関 ID を MDC に載せる（母 §3-1 オブザーバビリティ）。
+ *
+ * <ul>
+ *   <li>{@code requestId}：受信した {@code X-Request-Id} を尊重し、無ければ UUID を採番する
+ *       （ロードバランサ／フロントが付けた ID を引き継げる）。レスポンスにも同名で返す。</li>
+ *   <li>{@code userId}：検証済みの {@link AuthPrincipal} から導出する（クライアント入力ではない）。
+ *       未認証なら付与しない（プレーンログでは空欄になる）。</li>
+ * </ul>
+ *
+ * <p>{@link com.reviewboard.domain.auth.JwtAuthenticationFilter} の後段に挿す（SecurityConfig）。
+ * その時点で SecurityContext は確立済みのため userId を載せられる。
+ * 機密（パスワード・トークン）は MDC に載せない（SEC-9）。
+ */
+@Component
+public class MdcLoggingFilter extends OncePerRequestFilter {
+
+    /** MDC キー。Logback パターン（%X{...}）・構造化ログのフィールド名と一致させること。 */
+    static final String REQUEST_ID = "requestId";
+    static final String USER_ID = "userId";
+    /** 相関 ID の受け渡しヘッダ。リクエスト・レスポンス共通。 */
+    static final String REQUEST_ID_HEADER = "X-Request-Id";
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain)
+            throws ServletException, IOException {
+        String requestId = resolveRequestId(request);
+        try {
+            MDC.put(REQUEST_ID, requestId);
+            response.setHeader(REQUEST_ID_HEADER, requestId);
+            currentUserId().ifPresent(id -> MDC.put(USER_ID, id));
+            filterChain.doFilter(request, response);
+        } finally {
+            // スレッドプール再利用で次のリクエストに漏れないよう必ず掃除する。
+            MDC.remove(REQUEST_ID);
+            MDC.remove(USER_ID);
+        }
+    }
+
+    private String resolveRequestId(HttpServletRequest request) {
+        String incoming = request.getHeader(REQUEST_ID_HEADER);
+        return StringUtils.hasText(incoming) ? incoming : UUID.randomUUID().toString();
+    }
+
+    private java.util.Optional<String> currentUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth != null && auth.getPrincipal() instanceof AuthPrincipal principal) {
+            return java.util.Optional.of(String.valueOf(principal.userId()));
+        }
+        return java.util.Optional.empty();
+    }
+}

--- a/review-board/backend/src/main/resources/application.yml
+++ b/review-board/backend/src/main/resources/application.yml
@@ -26,7 +26,22 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info
+        # health は監視プローブ用（SecurityConfig で permitAll）。
+        # metrics/prometheus は運用観測（SecurityConfig で ROLE_TEACHER 限定）。
+        include: health,info,metrics,prometheus
+  metrics:
+    tags:
+      application: review-board
+    distribution:
+      # 主要 API の P95/P99 を出せるようヒストグラムを有効化（P-1 性能目標と対）。
+      percentiles-histogram:
+        http.server.requests: true
+
+# ログ：1リクエストを横断追跡できるよう MDC の requestId/userId を出力する（母 §3-1）。
+# dev は読みやすいプレーンログ＋[requestId,userId]。prod は下の prod プロファイルで JSON 化。
+logging:
+  pattern:
+    correlation: "[%X{requestId:-},%X{userId:-}] "
 
 # アプリ固有設定（env 駆動。.env.example 参照）
 app:
@@ -42,3 +57,16 @@ app:
       endpoint: ${S3_ENDPOINT:http://localhost:9002}
       bucket: ${S3_BUCKET:review-board}
       region: ${S3_REGION:ap-northeast-1}
+
+---
+# prod プロファイル（M-5：dev/prod 分離）。
+# 本番は機械解析可能な JSON 構造化ログ（ECS 形式）を標準出力に流す。
+# MDC の requestId/userId は ECS の構造化フィールドとして自動的に含まれる。
+spring:
+  config:
+    activate:
+      on-profile: prod
+logging:
+  structured:
+    format:
+      console: ecs

--- a/review-board/backend/src/test/java/com/reviewboard/observability/ObservabilityIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/observability/ObservabilityIntegrationTest.java
@@ -1,0 +1,84 @@
+package com.reviewboard.observability;
+
+import com.reviewboard.domain.user.UserRole;
+import com.reviewboard.support.AbstractIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 観測性（母 §3-1）の検証。
+ *
+ * <ul>
+ *   <li>運用メトリクス（metrics/prometheus）の公開範囲が運用ロール（講師）限定であること
+ *       ＝誰でも JVM/Hikari/流量を覗けない（SEC-2/SEC-11）。</li>
+ *   <li>health は監視プローブ用に未認証で開放されていること。</li>
+ *   <li>相関 ID（X-Request-Id）が採番・引き継ぎ・レスポンス返却されること（{@link MdcLoggingFilter}）。</li>
+ * </ul>
+ */
+// Spring Boot はテスト時にメトリクスエクスポート（prometheus 等）を既定で無効化する。
+// 本テストは prometheus スクレイプを検証するため明示的に有効化する。
+@AutoConfigureObservability(tracing = false)
+class ObservabilityIntegrationTest extends AbstractIntegrationTest {
+
+    private String studentEmail;
+    private String teacherEmail;
+
+    @BeforeEach
+    void seed() {
+        var cohort = newCohort("A");
+        studentEmail = newUser("student@example.com", UserRole.STUDENT, cohort.getId()).getEmail();
+        teacherEmail = newUser("teacher@example.com", UserRole.TEACHER, cohort.getId()).getEmail();
+    }
+
+    @Test
+    void health_is_public_for_probes() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void prometheus_requires_authentication() throws Exception {
+        mockMvc.perform(get("/actuator/prometheus"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    /** ★受講生には運用メトリクスを見せない（情報漏えい防止）。 */
+    @Test
+    void student_cannot_read_metrics_returns403() throws Exception {
+        mockMvc.perform(get("/actuator/prometheus").cookie(login(studentEmail)))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(get("/actuator/metrics").cookie(login(studentEmail)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void teacher_can_scrape_golden_signals() throws Exception {
+        mockMvc.perform(get("/actuator/prometheus").cookie(login(teacherEmail)))
+                .andExpect(status().isOk())
+                // Latency/Traffic/Errors（http.server.requests）と Saturation（jvm）が出ていること。
+                .andExpect(content().string(containsString("http_server_requests")))
+                .andExpect(content().string(containsString("jvm_memory_used_bytes")));
+    }
+
+    /** 相関 ID 未指定なら採番してレスポンスに返す。 */
+    @Test
+    void generates_request_id_when_absent() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(header().exists("X-Request-Id"));
+    }
+
+    /** 受信した相関 ID を引き継いでレスポンスに返す（LB/フロント由来の ID を維持）。 */
+    @Test
+    void propagates_incoming_request_id() throws Exception {
+        mockMvc.perform(get("/actuator/health").header("X-Request-Id", "trace-abc-123"))
+                .andExpect(header().string("X-Request-Id", is("trace-abc-123")));
+    }
+}

--- a/review-board/docs/ログ・監視・障害対応設計書.md
+++ b/review-board/docs/ログ・監視・障害対応設計書.md
@@ -7,8 +7,9 @@
 > ログ・監視は母「第3部 横断要件」にあり判定表から漏れていた。本書でその穴を埋め、
 > 判定表に §3 横断要件の判定セクションを追補した。
 >
-> **正直な現状認識**：Phase 1 はログ・監視を**簡素化**している（SLF4J 既定 + audit_logs + Actuator health のみ）。
-> 本書は「現状」と「本実装移行時に追加すべき設計」を分けて記す（要件 §2-2 の横断原則）。
+> **正直な現状認識（#121 更新）**：当初 Phase 1 はログ・監視を簡素化していた（SLF4J 既定 + audit_logs + Actuator health のみ）。
+> #121 で運用観測（構造化ログ + MDC・Micrometer 4ゴールデンシグナル）を実装し §3-1 を A 化した。
+> 残る簡素化は「閾値超の自動アラート連携」のみで、Phase3（AWS デプロイ）で外部監視基盤と接続する（要件 §2-2 の横断原則）。
 
 ---
 
@@ -17,6 +18,7 @@
 | 版 | 日付 | 改訂者 | 内容 |
 |---|---|---|---|
 | 0.1 | 2026-05-23 | hideharu-AI | 初版。母 §3-1 を具体化し、現状（Phase1）と本実装の設計を区別。判定表の §3 横断要件漏れを補修 |
+| 0.2 | 2026-05-23 | hideharu-AI | #121 で運用観測（構造化ログ + MDC・Micrometer 4ゴールデンシグナル・metrics 公開を運用ロール限定）を実装。§2/§3-2/§4/§7 を「実装済」に更新し §3-1 を A 化 |
 
 ---
 
@@ -30,12 +32,12 @@
 
 ## 2. 4 ゴールデンシグナル（母 §3-1）
 
-| シグナル | review-board での観点 | 現状 | 本実装で追加 |
+| シグナル | review-board での観点 | 現状（#121 実装後） | 残り（Phase3） |
 |---|---|---|---|
-| Latency（遅延） | 投稿一覧・成長記録の API 応答（P-1 目標と対） | 未計測 | Actuator `metrics`/Micrometer + P95 監視 |
-| Traffic（流量） | ログイン・投稿・レビュー・評価のリクエスト数 | 未計測 | Micrometer counter |
-| Errors（エラー） | 5xx・認可失敗（401/403/404）の発生率 | アプリログに出力 | エラー率アラート（閾値超で通知） |
-| Saturation（飽和） | DB コネクションプール（Hikari）・JVM ヒープ | 未計測 | Actuator `metrics` で pool/heap 監視 |
+| Latency（遅延） | 投稿一覧・成長記録の API 応答（P-1 目標と対） | ✅ `http.server.requests` をヒストグラムで収集（P95/P99 算出可） | P-1 目標値との突合・自動アラート |
+| Traffic（流量） | ログイン・投稿・レビュー・評価のリクエスト数 | ✅ `http.server.requests` の count | — |
+| Errors（エラー） | 5xx・認可失敗（401/403/404）の発生率 | ✅ アプリログ＋`http.server.requests` の status タグで率を算出可 | エラー率アラート（閾値超で通知） |
+| Saturation（飽和） | DB コネクションプール（Hikari）・JVM ヒープ | ✅ `hikaricp_connections`・`jvm_memory_used_bytes` を公開 | 飽和アラート |
 
 > リアルタイム機能（WebSocket 等）は要件で対象外のため、接続数・配信遅延の監視は不要（母 §3-1 の該当項は N/A）。
 
@@ -57,11 +59,12 @@ review-board は2系統のログを**役割で分離**する。混同しない�
 
 ### 3-2. 構造化ログと追跡性（母 §3-1・B-Q26）
 
-- **現状**：プレーンテキストログ（Logback 既定）。requestId/userId の自動付与は未実装。
-- **本実装で追加**：
-  - JSON 構造化ログ（機械解析可能）。
-  - **MDC に requestId（リクエスト単位の相関 ID）と userId を自動付与**するフィルタを追加し、1リクエストのログを横断追跡できるようにする。userId は検証済み `AuthPrincipal` から。
-  - 機密（パスワード・トークン・JWT secret）はログに出さない（SEC-9 の延長）。
+- **実装済（#121）**：
+  - **MDC に requestId（リクエスト相関 ID）と userId を自動付与**する `MdcLoggingFilter` を追加（`JwtAuthenticationFilter` の後段。SecurityContext 確立後に userId を載せる）。
+  - requestId は受信した `X-Request-Id` を尊重し、無ければ UUID を採番。レスポンスにも同名ヘッダで返す（LB/フロント由来の ID を引き継いで横断追跡）。
+  - userId は検証済み `AuthPrincipal` から導出（クライアント入力ではない）。未認証なら付与しない。
+  - dev はプレーンログに `[requestId,userId]` を表示（`logging.pattern.correlation`）。**prod プロファイルは JSON 構造化ログ（ECS 形式）**で機械解析可能（M-5 の dev/prod 分離）。
+  - 機密（パスワード・トークン・JWT secret）は MDC・ログに出さない（SEC-9 の延長）。
 
 ### 3-3. ログレベル方針
 
@@ -76,8 +79,9 @@ review-board は2系統のログを**役割で分離**する。混同しない�
 
 ## 4. 監視エンドポイント（Actuator）
 
-- **現状**：`application.yml` で `health` / `info` のみ公開。
-- **本実装で追加**：`metrics` / `prometheus`（Micrometer）を**認証済み・運用ネットワーク限定**で公開し、4ゴールデンシグナルを収集。公開範囲は SEC-2/SEC-11 の精神で絞る（誰でも metrics を見られる状態にしない）。
+- **実装済（#121）**：`health` / `info` に加え `metrics` / `prometheus`（Micrometer）を公開し、4ゴールデンシグナルを収集。
+- **公開範囲を絞る（SEC-2/SEC-11）**：`health` は監視プローブ用に未認証開放、`metrics` / `prometheus` は **`ROLE_TEACHER`（運用ロール）限定**（`SecurityConfig` の `/actuator/**`）。受講生・未認証に JVM ヒープ・Hikari プール・流量を見せない。
+  - 統合テスト `ObservabilityIntegrationTest` で 401（未認証）/403（受講生）/200（講師）を回帰検証。
 
 ---
 
@@ -124,12 +128,13 @@ task-board `docs/incidents/` の運用を継承する。**新しい異常に直�
 | 項目 | 現状 | 判定 |
 |---|---|---|
 | 監視/オブザーバビリティの区別 | 設計で明記（本書） | A（設計） |
-| 4 ゴールデンシグナル | 未計測（health のみ） | 要改善（本実装で Micrometer） |
-| 構造化ログ + MDC 追跡 | 未実装（プレーンテキスト） | 要改善（本実装で JSON + requestId/userId） |
+| 4 ゴールデンシグナル | **#121 で実装**：Micrometer + `/actuator/prometheus`（http.server.requests=Latency/Traffic/Errors、Hikari/JVM=Saturation）。運用ロール限定 | **A** |
+| 構造化ログ + MDC 追跡 | **#121 で実装**：MDC に requestId/userId 自動付与（`MdcLoggingFilter`）。dev はプレーン＋相関欄、prod は JSON（ECS） | **A** |
 | 監査証跡（誰が・何を） | audit_logs で実装済 | **A**（S軸の中核） |
-| アラート → Runbook → 復旧 | Runbook を本書に定義（自動アラートは未） | A（手順）/ 自動アラートは本実装 |
+| アラート → Runbook → 復旧 | Runbook を本書に定義（閾値超の自動アラートは未） | A（手順）/ 自動アラートは Phase3（AWS）で追加 |
 
-> Phase 1（学習）はログ・監視を簡素化。**監査ログ（S軸）は実装済で A**、運用観測（メトリクス/構造化ログ/アラート）は本実装移行時に追加する（要件 §2-2）。
+> **更新（#121）**：運用観測（4ゴールデンシグナル・構造化ログ + MDC）を実装し、本項を A 化した。
+> **監査ログ（S軸）は従来どおり A**。残るは閾値超の自動アラート連携のみで、Phase3（AWS デプロイ）で外部監視基盤と接続する（要件 §2-2）。
 
 ---
 

--- a/review-board/docs/付録A_判定表.md
+++ b/review-board/docs/付録A_判定表.md
@@ -103,7 +103,7 @@
 
 | 横断要件 | 判定 | 根拠・備考 |
 |---|---|---|
-| §3-1 ログ・監視・オブザーバビリティ | 一部A | 監査ログ（誰が・何を）は audit_logs で **A**。構造化ログ/MDC・メトリクス/アラートは未実装＝要改善（本実装で追加。設計は設計書に記載） |
+| §3-1 ログ・監視・オブザーバビリティ | **A**（自動アラートのみ Phase3） | 監査ログ（誰が・何を）は audit_logs で **A**。構造化ログ/MDC（requestId/userId）・Micrometer 4ゴールデンシグナル（`/actuator/prometheus`・運用ロール限定）を **#121 で実装済＝A**。閾値超の自動アラート連携のみ Phase3（AWS）で追加 |
 | §3-2 設定・機密の外部化 | A | JWT secret/DB/seed すべて env 駆動・fail-fast・平文ハードコードなし（SEC-9 と一致） |
 | §3-3 エラーハンドリング標準 | A | `GlobalExceptionHandler` で一元化（401/403/404/400・silent catch なし） |
 | §3-4 リリース・運用フロー（誤操作多層防御） | A | Issue→PR→squash・main 保護・CI（build/test・依存スキャン・lint）。CLAUDE.md §12 の多層防御を継承 |


### PR DESCRIPTION
## 関連 Issue

Closes #121

---

## 変更の概要

共通の設計方針 §3-1（オブザーバビリティ）で「本実装で追加」と設計済みだった運用観測を実装し、品質判定表 横断要件群 §3-1 を **A 化**した。重点軸（監査ログ）は従来どおり A。

- **構造化ログ + MDC 追跡**：`MdcLoggingFilter` を追加。`requestId`（受信した `X-Request-Id` を尊重・無ければ UUID 採番・レスポンスにも返却）と `userId`（検証済み `AuthPrincipal` 由来）を MDC に自動付与し、1リクエストを横断追跡できる。dev はプレーンログ＋`[requestId,userId]`、**prod プロファイルは JSON 構造化ログ（ECS）**（M-5 の dev/prod 分離）。
- **Micrometer 4ゴールデンシグナル**：`micrometer-registry-prometheus` を追加し `/actuator/prometheus` を公開。Latency/Traffic/Errors は `http.server.requests`（ヒストグラムで P95/P99 算出可）、Saturation は Hikari/JVM ヒープ。
- **公開範囲を絞る（SEC-2/SEC-11）**：`health` は監視プローブ用に未認証開放、`metrics`/`prometheus` は **`ROLE_TEACHER`（運用ロール）限定**。受講生・未認証に JVM/プール/流量を見せない。
- **生きた文書を実装に追従**：判定表 §3-1・設計書 §2/§3-2/§4/§7 を「実装済」に更新。

## 変更の種別

- [x] feat（新機能の追加）
- [x] docs（生きた文書の追従更新を同梱）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（実機 bootRun で `/actuator/prometheus` 200・`http_server_requests`/`jvm_memory_used_bytes`/`hikaricp_connections` を確認、`X-Request-Id` 採番も確認）
- [x] 既存の機能が壊れていないことを確認した（`./gradlew build` 全テスト green）
- [x] `.env` ファイルやパスワードをコミットしていない

---

## レビュー時に特に確認してほしい点

- **テストの落とし穴**：Spring Boot はテスト時にメトリクスエクスポート（prometheus）を既定で無効化するため、`@AutoConfigureObservability(tracing = false)` を付けて MockMvc でも検証できるようにした（実機では元から公開される）。この事象は別途インシデント・ライブラリ化候補。
- **metrics の公開ロール**：運用ロールが講師しかいないため `ROLE_TEACHER` 限定とした。本格運用では専用 ops ロール／ネットワーク分離が望ましい（Phase3 論点）。

## スコープ外（follow-up）

- 閾値超の**自動アラート**連携は Phase3（AWS デプロイ）で外部監視基盤と接続。
- 性能目標値 P-1 の定義は別 Issue。
- 🆕 **判定表の別の追従漏れ**を発見：M-6（CI build/test 化＝#108 で実装済）・M-13/P-9（フロント未実装と記載だが #110〜116 で実装済）の行が古いまま。本 PR の観測性スコープ外のため**別 PR で追従修正**するのが安全（混ぜない方針）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)