### PR TITLE
fix: 不正JSONボディが400でなく401を返す問題を修正

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/common/GlobalExceptionHandler.java
+++ b/review-board/backend/src/main/java/com/reviewboard/common/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -34,6 +35,16 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(InvalidRequestException.class)
     public ResponseEntity<ApiError> handleInvalidRequest(InvalidRequestException ex) {
         return ResponseEntity.badRequest().body(ApiError.of("INVALID_REQUEST", ex.getMessage()));
+    }
+
+    /**
+     * 読めない/不正な JSON ボディ（400）：enum 不一致・壊れた JSON など。
+     * これを握らないと未処理例外として /error 再ディスパッチが走り、SecurityContext が
+     * 引き継がれず 401 に化けて本来の 400 を覆い隠す（#131）。ここで 400 を確定させる。
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiError> handleNotReadable(HttpMessageNotReadableException ex) {
+        return ResponseEntity.badRequest().body(ApiError.of("MALFORMED_REQUEST", "リクエスト本文の形式が不正です"));
     }
 
     /** アップロード上限超過（413・SEC-8 のサイズ防御。multipart 段で弾く） */

--- a/review-board/backend/src/test/java/com/reviewboard/common/MalformedRequestIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/common/MalformedRequestIntegrationTest.java
@@ -1,0 +1,47 @@
+package com.reviewboard.common;
+
+import com.reviewboard.domain.user.UserRole;
+import com.reviewboard.support.AbstractIntegrationTest;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 不正な JSON ボディが 400 で返ること（#131 の回帰）。
+ * 認証済みなのに 401 へ化ける（/error 再ディスパッチでセキュリティ再評価）退行を防ぐ。
+ */
+class MalformedRequestIntegrationTest extends AbstractIntegrationTest {
+
+    private Cookie cookie;
+
+    @BeforeEach
+    void seed() throws Exception {
+        var cohort = newCohort("A");
+        String email = newUser("student@example.com", UserRole.STUDENT, cohort.getId()).getEmail();
+        cookie = login(email);
+    }
+
+    /** enum に無い値（壊れた列挙）→ 400（401 ではない）。 */
+    @Test
+    void invalid_enum_value_returns400_not401() throws Exception {
+        // ReviewAxis に存在しない "GOOD" を送る（実体は PERFORMANCE/CORRECTNESS/...）
+        mockMvc.perform(post("/api/posts/1/reviews").cookie(cookie)
+                        .contentType("application/json")
+                        .content("{\"good\":\"g\",\"improvement\":\"i\",\"axisComments\":[{\"axis\":\"GOOD\",\"comment\":\"x\"}]}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("MALFORMED_REQUEST"));
+    }
+
+    /** 構文的に壊れた JSON → 400（401 ではない）。 */
+    @Test
+    void broken_json_returns400_not401() throws Exception {
+        mockMvc.perform(post("/api/posts").cookie(cookie)
+                        .contentType("application/json")
+                        .content("{\"title\": "))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## 関連 Issue

Closes #131

---

## 変更の概要

認証済みでも不正な JSON ボディ（enum 不一致・壊れた JSON）で **400 ではなく 401** が返っていた問題を修正（#127 の性能計測中に発見）。

**真因**：`HttpMessageNotReadableException` 用の `@ExceptionHandler` が無く、未処理例外として `/error` 再ディスパッチが走り、その際 SecurityContext が引き継がれず未認証扱いになって 401 が本来の 400 を覆い隠していた（MDC には userId が記録されており、認証自体は成功していた）。

**修正**：`GlobalExceptionHandler` に `HttpMessageNotReadableException → 400（MALFORMED_REQUEST）` を追加。ERROR 再ディスパッチを起こさず正しい 400 を確定させる。

## 変更の種別

- [x] fix（バグ修正）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（`./gradlew build` 全 green）
- [x] 既存の機能が壊れていないことを確認した（結合テストで不正enum/壊れたJSON→400 を回帰）
- [x] `.env` ファイルやパスワードをコミットしていない

---

## レビュー時に特に確認してほしい点

- 400 を返す対象は「本文が読めない」ケース（enum 不一致・構文破損）。`@Valid` の制約違反は従来どおり `MethodArgumentNotValidException`（VALIDATION_ERROR）で 400。

🤖 Generated with [Claude Code](https://claude.com/claude-code)