### PR TITLE
feat: Phase2 心理的安全設定（F-SAFE-01）＋観点別レビュー依頼（F-REQ-01）

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/Post.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/Post.java
@@ -4,8 +4,11 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.BatchSize;
 
 import java.time.OffsetDateTime;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
  * 成果物（F-POST）。cohort_id を冗長保持し、一覧の cohort 境界を単純化（ER図 §3-2）。
@@ -55,6 +58,22 @@ public class Post {
     /** F-REV-05 ベストレビュー：投稿者が選んだ最も役立ったレビューの ID（未選択は null）。 */
     @Column(name = "best_review_id")
     private Long bestReviewId;
+
+    /** F-SAFE-01 心理的安全設定：投稿者が希望するレビューのトーン（単一・未設定は null）。 */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "review_tone", length = 20)
+    private ReviewTone reviewTone;
+
+    /**
+     * F-REQ-01 観点別レビュー依頼：募集したい観点（多値）。投稿削除で子行も自動削除。
+     * EAGER ＋ BatchSize で詳細取得時の遅延初期化を避けつつ一覧の N+1 を1クエリに束ねる。
+     */
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "post_review_aspects", joinColumns = @JoinColumn(name = "post_id"))
+    @Column(name = "aspect", length = 20)
+    @Enumerated(EnumType.STRING)
+    @BatchSize(size = 50)
+    private Set<ReviewAspect> reviewAspects = new LinkedHashSet<>();
 
     @Column(name = "deleted_at")
     private OffsetDateTime deletedAt;

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/PostService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/PostService.java
@@ -8,6 +8,7 @@ import com.reviewboard.domain.audit.AuditTargetType;
 import com.reviewboard.domain.auth.AuthPrincipal;
 import com.reviewboard.domain.post.dto.PostCreateRequest;
 import com.reviewboard.domain.post.dto.PostUpdateRequest;
+import java.util.Set;
 import com.reviewboard.domain.review.Review;
 import com.reviewboard.domain.review.ReviewRepository;
 import org.springframework.data.domain.PageRequest;
@@ -52,6 +53,7 @@ public class PostService {
         post.setDemoUrl(req.demoUrl());
         post.setScreenshotKey(req.screenshotKey());
         post.setRecruitStatus(RecruitStatus.OPEN);
+        applyReviewPreferences(post, req.reviewTone(), req.reviewAspects());
         post.setCreatedAt(now);
         post.setUpdatedAt(now);
         postRepository.save(post);
@@ -95,6 +97,7 @@ public class PostService {
         post.setRepoUrl(req.repoUrl());
         post.setDemoUrl(req.demoUrl());
         post.setScreenshotKey(req.screenshotKey());
+        applyReviewPreferences(post, req.reviewTone(), req.reviewAspects());
         post.setUpdatedAt(OffsetDateTime.now());
         auditService.record(principal, AuditAction.POST_UPDATED, AuditTargetType.POST, postId);
         return post;
@@ -123,6 +126,19 @@ public class PostService {
         Post post = loadOwned(principal, postId);
         post.setDeletedAt(OffsetDateTime.now());
         auditService.record(principal, AuditAction.POST_DELETED, AuditTargetType.POST, postId);
+    }
+
+    /**
+     * F-SAFE-01 / F-REQ-01：投稿者のレビュー希望（トーン・募集観点）を反映する。
+     * tone は null で未設定に戻る。aspects は送られた集合で全置換（null は空集合扱い）。
+     * 設定主体は所有者に限る（呼び出し元の create/loadOwned で担保。★S軸）。
+     */
+    private void applyReviewPreferences(Post post, ReviewTone tone, Set<ReviewAspect> aspects) {
+        post.setReviewTone(tone);
+        post.getReviewAspects().clear();
+        if (aspects != null) {
+            post.getReviewAspects().addAll(aspects);
+        }
     }
 
     /**

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/ReviewAspect.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/ReviewAspect.java
@@ -1,0 +1,12 @@
+package com.reviewboard.domain.post;
+
+/**
+ * F-REQ-01 観点別レビュー依頼：投稿者が名指しで募集できる観点（多値）。
+ */
+public enum ReviewAspect {
+    DB,
+    UI,
+    CODE,
+    SECURITY,
+    PERFORMANCE
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/ReviewTone.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/ReviewTone.java
@@ -1,0 +1,14 @@
+package com.reviewboard.domain.post;
+
+/**
+ * F-SAFE-01 心理的安全設定：投稿者が希望するレビューのトーン（単一選択）。
+ * 未設定は null（列 nullable）で表す。R-02（萎縮）対策の起点。
+ */
+public enum ReviewTone {
+    /** 初学者歓迎：基礎的な指摘も歓迎 */
+    WELCOME_BEGINNER,
+    /** 辛口OK：厳しめの指摘を歓迎 */
+    HARSH_OK,
+    /** 優しめ希望：言葉選びに配慮してほしい */
+    GENTLE
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostCreateRequest.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostCreateRequest.java
@@ -1,16 +1,25 @@
 package com.reviewboard.domain.post.dto;
 
+import com.reviewboard.domain.post.ReviewAspect;
+import com.reviewboard.domain.post.ReviewTone;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+
+import java.util.Set;
 
 /**
  * 投稿作成リクエスト（F-POST-01）。タイトルと説明は必須、URL/スクショキーは任意。
  * cohort_id・author は principal（検証済み JWT）から導出し、クライアント入力は信用しない（★S軸）。
+ *
+ * @param reviewTone    F-SAFE-01 希望トーン（任意・null は未設定）
+ * @param reviewAspects F-REQ-01 募集観点（任意・Set で重複排除。不正な enum 値は 400）
  */
 public record PostCreateRequest(
         @NotBlank @Size(max = 100) String title,
         @NotBlank String description,
         @Size(max = 512) String repoUrl,
         @Size(max = 512) String demoUrl,
-        @Size(max = 512) String screenshotKey) {
+        @Size(max = 512) String screenshotKey,
+        ReviewTone reviewTone,
+        Set<ReviewAspect> reviewAspects) {
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostResponse.java
@@ -2,8 +2,12 @@ package com.reviewboard.domain.post.dto;
 
 import com.reviewboard.domain.post.Post;
 import com.reviewboard.domain.post.RecruitStatus;
+import com.reviewboard.domain.post.ReviewAspect;
+import com.reviewboard.domain.post.ReviewTone;
 
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 投稿の詳細レスポンス（F-POST-03 単体取得）。
@@ -21,6 +25,8 @@ public record PostResponse(
         RecruitStatus recruitStatus,
         int reviewCount,
         Long bestReviewId,
+        ReviewTone reviewTone,
+        List<ReviewAspect> reviewAspects,
         OffsetDateTime createdAt,
         OffsetDateTime updatedAt) {
 
@@ -33,6 +39,7 @@ public record PostResponse(
                 p.getId(), p.getAuthorUserId(), p.getCohortId(),
                 p.getTitle(), p.getDescription(), p.getRepoUrl(), p.getDemoUrl(),
                 p.getScreenshotKey(), screenshotUrl, p.getRecruitStatus(), p.getReviewCount(),
-                p.getBestReviewId(), p.getCreatedAt(), p.getUpdatedAt());
+                p.getBestReviewId(), p.getReviewTone(), new ArrayList<>(p.getReviewAspects()),
+                p.getCreatedAt(), p.getUpdatedAt());
     }
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostSummaryResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostSummaryResponse.java
@@ -2,11 +2,16 @@ package com.reviewboard.domain.post.dto;
 
 import com.reviewboard.domain.post.Post;
 import com.reviewboard.domain.post.RecruitStatus;
+import com.reviewboard.domain.post.ReviewAspect;
+import com.reviewboard.domain.post.ReviewTone;
 
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 一覧用の軽量レスポンス（F-POST-03）。本文（description）は載せず転送量を抑える（母 P-2）。
+ * トーン・募集観点は一覧での「依頼の見える化」（F-SAFE-01/F-REQ-01）に使うため含める。
  */
 public record PostSummaryResponse(
         Long id,
@@ -14,11 +19,14 @@ public record PostSummaryResponse(
         String title,
         RecruitStatus recruitStatus,
         int reviewCount,
+        ReviewTone reviewTone,
+        List<ReviewAspect> reviewAspects,
         OffsetDateTime createdAt) {
 
     public static PostSummaryResponse from(Post p) {
         return new PostSummaryResponse(
                 p.getId(), p.getAuthorUserId(), p.getTitle(),
-                p.getRecruitStatus(), p.getReviewCount(), p.getCreatedAt());
+                p.getRecruitStatus(), p.getReviewCount(),
+                p.getReviewTone(), new ArrayList<>(p.getReviewAspects()), p.getCreatedAt());
     }
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostUpdateRequest.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostUpdateRequest.java
@@ -1,15 +1,24 @@
 package com.reviewboard.domain.post.dto;
 
+import com.reviewboard.domain.post.ReviewAspect;
+import com.reviewboard.domain.post.ReviewTone;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+import java.util.Set;
+
 /**
  * 投稿更新リクエスト（F-POST-02）。所有者のみ実行可（Service で検証、不一致は 404）。
+ *
+ * @param reviewTone    F-SAFE-01 希望トーン（任意・null は未設定に戻す）
+ * @param reviewAspects F-REQ-01 募集観点（任意・送られた集合で全置換）
  */
 public record PostUpdateRequest(
         @NotBlank @Size(max = 100) String title,
         @NotBlank String description,
         @Size(max = 512) String repoUrl,
         @Size(max = 512) String demoUrl,
-        @Size(max = 512) String screenshotKey) {
+        @Size(max = 512) String screenshotKey,
+        ReviewTone reviewTone,
+        Set<ReviewAspect> reviewAspects) {
 }

--- a/review-board/backend/src/main/resources/db/migration/V4__add_review_tone_and_aspects.sql
+++ b/review-board/backend/src/main/resources/db/migration/V4__add_review_tone_and_aspects.sql
@@ -1,0 +1,11 @@
+-- F-SAFE-01 心理的安全設定：投稿に「レビューのトーン区分」を単一で持たせる（投稿者本人のみ設定）。
+-- 値は ReviewTone（WELCOME_BEGINNER/HARSH_OK/GENTLE）。未設定は NULL。
+ALTER TABLE posts ADD COLUMN review_tone VARCHAR(20);
+
+-- F-REQ-01 観点別レビュー依頼：投稿者が募集したい観点を多値で名指し（5軸）。
+-- @ElementCollection で正規化。投稿削除時は Hibernate が自動で子行を消す（cleanup 順を増やさない）。
+CREATE TABLE post_review_aspects (
+    post_id BIGINT      NOT NULL REFERENCES posts (id),
+    aspect  VARCHAR(20) NOT NULL,
+    PRIMARY KEY (post_id, aspect)
+);

--- a/review-board/backend/src/test/java/com/reviewboard/domain/post/PostReviewPreferenceIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/post/PostReviewPreferenceIntegrationTest.java
@@ -1,0 +1,114 @@
+package com.reviewboard.domain.post;
+
+import com.reviewboard.domain.user.UserRole;
+import com.reviewboard.support.AbstractIntegrationTest;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * F-SAFE-01 心理的安全設定 ＋ F-REQ-01 観点別レビュー依頼の統合テスト。
+ *
+ * <p>新規エンドポイントは無く、既存 POST/PUT /api/posts に相乗りする（認可境界は据え置き）。
+ * S軸標準として「設定は所有者のみ・他人の更新は 404・他 cohort は不可視（404）・不正 enum は 400」を確認する。
+ */
+class PostReviewPreferenceIntegrationTest extends AbstractIntegrationTest {
+
+    private String authorEmail;
+    private String otherEmail;
+    private long cohortId;
+
+    @BeforeEach
+    void seed() throws Exception {
+        var cohort = newCohort("A");
+        cohortId = cohort.getId();
+        authorEmail = newUser("author@example.com", UserRole.STUDENT, cohortId).getEmail();
+        otherEmail = newUser("other@example.com", UserRole.STUDENT, cohortId).getEmail();
+    }
+
+    /** 作成時にトーン・観点を設定でき、詳細取得で返る。 */
+    @Test
+    void create_with_tone_and_aspects_persists() throws Exception {
+        MvcResult res = mockMvc.perform(post("/api/posts").cookie(login(authorEmail))
+                        .contentType("application/json")
+                        .content("{\"title\":\"作品\",\"description\":\"説明\",\"reviewTone\":\"GENTLE\",\"reviewAspects\":[\"DB\",\"SECURITY\"]}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.reviewTone").value("GENTLE"))
+                .andExpect(jsonPath("$.reviewAspects", org.hamcrest.Matchers.containsInAnyOrder("DB", "SECURITY")))
+                .andReturn();
+        long id = readId(res);
+
+        mockMvc.perform(get("/api/posts/" + id).cookie(login(authorEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.reviewTone").value("GENTLE"))
+                .andExpect(jsonPath("$.reviewAspects", org.hamcrest.Matchers.containsInAnyOrder("DB", "SECURITY")));
+    }
+
+    /** 未指定なら未設定（null）・空配列で作成できる。 */
+    @Test
+    void create_without_preferences_defaults_to_unset() throws Exception {
+        MvcResult res = mockMvc.perform(post("/api/posts").cookie(login(authorEmail))
+                        .contentType("application/json")
+                        .content("{\"title\":\"作品\",\"description\":\"説明\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.reviewTone").doesNotExist())
+                .andExpect(jsonPath("$.reviewAspects").isEmpty())
+                .andReturn();
+    }
+
+    /** 所有者は更新で全置換できる（トーン変更・観点入れ替え）。 */
+    @Test
+    void owner_can_update_preferences() throws Exception {
+        long id = createPost(login(authorEmail), "{\"title\":\"作品\",\"description\":\"説明\",\"reviewTone\":\"HARSH_OK\",\"reviewAspects\":[\"CODE\"]}");
+
+        mockMvc.perform(put("/api/posts/" + id).cookie(login(authorEmail))
+                        .contentType("application/json")
+                        .content("{\"title\":\"作品\",\"description\":\"説明\",\"reviewTone\":\"WELCOME_BEGINNER\",\"reviewAspects\":[\"UI\",\"PERFORMANCE\"]}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.reviewTone").value("WELCOME_BEGINNER"))
+                .andExpect(jsonPath("$.reviewAspects", org.hamcrest.Matchers.containsInAnyOrder("UI", "PERFORMANCE")));
+    }
+
+    /** ★非所有者は更新できない（存在を漏らさず 404）。 */
+    @Test
+    void non_owner_cannot_update_returns404() throws Exception {
+        long id = createPost(login(authorEmail), "{\"title\":\"作品\",\"description\":\"説明\",\"reviewTone\":\"GENTLE\"}");
+        mockMvc.perform(put("/api/posts/" + id).cookie(login(otherEmail))
+                        .contentType("application/json")
+                        .content("{\"title\":\"乗っ取り\",\"description\":\"説明\",\"reviewTone\":\"HARSH_OK\"}"))
+                .andExpect(status().isNotFound());
+    }
+
+    /** 他 cohort からは投稿自体が不可視（404）。 */
+    @Test
+    void other_cohort_cannot_read_returns404() throws Exception {
+        long id = createPost(login(authorEmail), "{\"title\":\"作品\",\"description\":\"説明\",\"reviewAspects\":[\"DB\"]}");
+        var cohortB = newCohort("B");
+        String outsider = newUser("out@example.com", UserRole.STUDENT, cohortB.getId()).getEmail();
+        mockMvc.perform(get("/api/posts/" + id).cookie(login(outsider)))
+                .andExpect(status().isNotFound());
+    }
+
+    /** 不正な enum 値（観点）は 400（HttpMessageNotReadable → InvalidRequest）。 */
+    @Test
+    void invalid_aspect_value_returns400() throws Exception {
+        mockMvc.perform(post("/api/posts").cookie(login(authorEmail))
+                        .contentType("application/json")
+                        .content("{\"title\":\"作品\",\"description\":\"説明\",\"reviewAspects\":[\"NOPE\"]}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    private long createPost(Cookie cookie, String body) throws Exception {
+        MvcResult res = mockMvc.perform(post("/api/posts").cookie(cookie)
+                        .contentType("application/json").content(body))
+                .andExpect(status().isCreated()).andReturn();
+        return readId(res);
+    }
+}

--- a/review-board/frontend/src/components/ReviewPrefBadges.jsx
+++ b/review-board/frontend/src/components/ReviewPrefBadges.jsx
@@ -1,0 +1,21 @@
+import { TONE_LABEL, ASPECT_LABEL } from '../constants/reviewPrefs';
+
+// F-SAFE-01 / F-REQ-01：投稿のトーン希望・募集観点をバッジ表示する（読み取り専用）。
+// reviewers が「どんなレビューが歓迎か」を一目で把握できるようにする。
+export default function ReviewPrefBadges({ tone, aspects = [], className = '' }) {
+  if (!tone && (!aspects || aspects.length === 0)) return null;
+  return (
+    <div className={`flex flex-wrap items-center gap-2 ${className}`}>
+      {tone && (
+        <span className="rounded-full bg-amber-50 px-2.5 py-0.5 text-xs font-medium text-amber-700 ring-1 ring-amber-200">
+          🫶 {TONE_LABEL[tone] ?? tone}
+        </span>
+      )}
+      {aspects.map((a) => (
+        <span key={a} className="rounded-full bg-indigo-50 px-2.5 py-0.5 text-xs font-medium text-indigo-700 ring-1 ring-indigo-200">
+          🔍 {ASPECT_LABEL[a] ?? a}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/review-board/frontend/src/components/ReviewPrefFields.jsx
+++ b/review-board/frontend/src/components/ReviewPrefFields.jsx
@@ -1,0 +1,39 @@
+import { TONE_OPTIONS, ASPECT_OPTIONS } from '../constants/reviewPrefs';
+
+// F-SAFE-01 / F-REQ-01：投稿フォームのトーン（単一）・募集観点（多値）入力。
+// props: tone(string|null), aspects(string[]), onToneChange, onAspectsChange。
+export default function ReviewPrefFields({ tone, aspects = [], onToneChange, onAspectsChange }) {
+  const toggleAspect = (value) => {
+    onAspectsChange(aspects.includes(value) ? aspects.filter((a) => a !== value) : [...aspects, value]);
+  };
+
+  return (
+    <fieldset className="mb-4 rounded border border-gray-200 p-4">
+      <legend className="px-1 text-sm font-medium text-gray-700">レビューの希望（任意）</legend>
+
+      <p className="mb-1 text-sm text-gray-600">どんなトーンが歓迎ですか？</p>
+      <div className="mb-4 flex flex-wrap gap-3" role="radiogroup" aria-label="希望トーン">
+        <label className="flex cursor-pointer items-center gap-1.5 text-sm text-gray-700">
+          <input type="radio" name="reviewTone" checked={!tone} onChange={() => onToneChange(null)} />
+          指定しない
+        </label>
+        {TONE_OPTIONS.map((o) => (
+          <label key={o.value} className="flex cursor-pointer items-center gap-1.5 text-sm text-gray-700" title={o.hint}>
+            <input type="radio" name="reviewTone" checked={tone === o.value} onChange={() => onToneChange(o.value)} />
+            {o.label}
+          </label>
+        ))}
+      </div>
+
+      <p className="mb-1 text-sm text-gray-600">特に見てほしい観点（複数選択可）</p>
+      <div className="flex flex-wrap gap-3">
+        {ASPECT_OPTIONS.map((o) => (
+          <label key={o.value} className="flex cursor-pointer items-center gap-1.5 text-sm text-gray-700">
+            <input type="checkbox" checked={aspects.includes(o.value)} onChange={() => toggleAspect(o.value)} />
+            {o.label}
+          </label>
+        ))}
+      </div>
+    </fieldset>
+  );
+}

--- a/review-board/frontend/src/constants/reviewPrefs.js
+++ b/review-board/frontend/src/constants/reviewPrefs.js
@@ -1,0 +1,22 @@
+// F-SAFE-01 / F-REQ-01：トーン区分・募集観点の表示ラベルと選択肢を一元管理する。
+// backend の enum 名（ReviewTone / ReviewAspect）と一致させること。
+
+// 希望トーン（単一選択。未設定は null）
+export const TONE_OPTIONS = [
+  { value: 'WELCOME_BEGINNER', label: '初学者歓迎', hint: '基礎的な指摘も歓迎' },
+  { value: 'HARSH_OK', label: '辛口OK', hint: '厳しめの指摘を歓迎' },
+  { value: 'GENTLE', label: '優しめ希望', hint: '言葉選びに配慮してほしい' },
+];
+
+export const TONE_LABEL = Object.fromEntries(TONE_OPTIONS.map((o) => [o.value, o.label]));
+
+// 募集観点（多値）
+export const ASPECT_OPTIONS = [
+  { value: 'DB', label: 'DB' },
+  { value: 'UI', label: 'UI' },
+  { value: 'CODE', label: 'コード' },
+  { value: 'SECURITY', label: 'セキュリティ' },
+  { value: 'PERFORMANCE', label: 'パフォーマンス' },
+];
+
+export const ASPECT_LABEL = Object.fromEntries(ASPECT_OPTIONS.map((o) => [o.value, o.label]));

--- a/review-board/frontend/src/pages/NewPostPage.jsx
+++ b/review-board/frontend/src/pages/NewPostPage.jsx
@@ -2,11 +2,12 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { createPost } from '../api/posts';
 import ScreenshotUploader from '../components/ScreenshotUploader';
+import ReviewPrefFields from '../components/ReviewPrefFields';
 
 // F-POST-01：成果物の投稿（タイトル/説明は必須、URL・スクショは任意）。
 export default function NewPostPage() {
   const navigate = useNavigate();
-  const [form, setForm] = useState({ title: '', description: '', repoUrl: '', demoUrl: '', screenshotKey: null });
+  const [form, setForm] = useState({ title: '', description: '', repoUrl: '', demoUrl: '', screenshotKey: null, reviewTone: null, reviewAspects: [] });
   const [error, setError] = useState('');
   const [busy, setBusy] = useState(false);
 
@@ -23,6 +24,8 @@ export default function NewPostPage() {
         repoUrl: form.repoUrl || null,
         demoUrl: form.demoUrl || null,
         screenshotKey: form.screenshotKey || null,
+        reviewTone: form.reviewTone,
+        reviewAspects: form.reviewAspects,
       });
       navigate(`/posts/${post.id}`, { replace: true });
     } catch {
@@ -46,6 +49,12 @@ export default function NewPostPage() {
         <label className="mb-1 block text-sm text-gray-600">デモ URL（任意）</label>
         <input type="url" value={form.demoUrl} onChange={set('demoUrl')} className="mb-4 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none" />
         <ScreenshotUploader onChange={(key) => setForm((p) => ({ ...p, screenshotKey: key }))} />
+        <ReviewPrefFields
+          tone={form.reviewTone}
+          aspects={form.reviewAspects}
+          onToneChange={(v) => setForm((p) => ({ ...p, reviewTone: v }))}
+          onAspectsChange={(v) => setForm((p) => ({ ...p, reviewAspects: v }))}
+        />
         <button type="submit" disabled={busy} className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50">
           {busy ? '投稿中…' : '投稿する'}
         </button>

--- a/review-board/frontend/src/pages/PostDetailPage.jsx
+++ b/review-board/frontend/src/pages/PostDetailPage.jsx
@@ -7,6 +7,7 @@ import { useAuth } from '../context/AuthContext';
 import ReviewForm from '../components/ReviewForm';
 import ReviewItem from '../components/ReviewItem';
 import EvaluationPanel from '../components/EvaluationPanel';
+import ReviewPrefBadges from '../components/ReviewPrefBadges';
 
 // 投稿詳細：本体＋レビュー一覧＋レビュー投稿＋講師評価。
 export default function PostDetailPage() {
@@ -73,6 +74,7 @@ export default function PostDetailPage() {
             </div>
           )}
         </div>
+        <ReviewPrefBadges tone={post.reviewTone} aspects={post.reviewAspects} className="mt-3" />
         <p className="mt-3 whitespace-pre-wrap text-sm text-gray-700">{post.description}</p>
         {post.screenshotUrl && (
           <img src={post.screenshotUrl} alt={`${post.title} のスクリーンショット`} className="mt-4 max-h-96 rounded border border-gray-200" />

--- a/review-board/frontend/src/pages/PostEditPage.jsx
+++ b/review-board/frontend/src/pages/PostEditPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { fetchPost, updatePost } from '../api/posts';
 import ScreenshotUploader from '../components/ScreenshotUploader';
+import ReviewPrefFields from '../components/ReviewPrefFields';
 
 // F-POST-02 投稿の編集（所有者のみ。非所有者は backend が 404）。
 export default function PostEditPage() {
@@ -22,6 +23,8 @@ export default function PostEditPage() {
           demoUrl: p.demoUrl ?? '',
           // 未変更なら既存 key を維持。差し替え時に Uploader が新 key を入れる。
           screenshotKey: p.screenshotKey ?? null,
+          reviewTone: p.reviewTone ?? null,
+          reviewAspects: p.reviewAspects ?? [],
         });
         setScreenshotUrl(p.screenshotUrl ?? '');
       })
@@ -41,6 +44,8 @@ export default function PostEditPage() {
         repoUrl: form.repoUrl || null,
         demoUrl: form.demoUrl || null,
         screenshotKey: form.screenshotKey || null,
+        reviewTone: form.reviewTone,
+        reviewAspects: form.reviewAspects,
       });
       navigate(`/posts/${id}`, { replace: true });
     } catch (err) {
@@ -67,6 +72,12 @@ export default function PostEditPage() {
         <label className="mb-1 block text-sm text-gray-600">デモ URL（任意）</label>
         <input type="url" value={form.demoUrl} onChange={set('demoUrl')} className="mb-4 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none" />
         <ScreenshotUploader initialUrl={screenshotUrl} onChange={(key) => setForm((p) => ({ ...p, screenshotKey: key }))} />
+        <ReviewPrefFields
+          tone={form.reviewTone}
+          aspects={form.reviewAspects}
+          onToneChange={(v) => setForm((p) => ({ ...p, reviewTone: v }))}
+          onAspectsChange={(v) => setForm((p) => ({ ...p, reviewAspects: v }))}
+        />
         <div className="flex gap-3">
           <button type="submit" disabled={busy} className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50">
             {busy ? '更新中…' : '更新する'}

--- a/review-board/frontend/src/pages/PostsPage.jsx
+++ b/review-board/frontend/src/pages/PostsPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { fetchPosts } from '../api/posts';
 import { RECRUIT_LABEL } from '../constants';
+import ReviewPrefBadges from '../components/ReviewPrefBadges';
 
 // F-POST-03 一覧 ＋ F-SEARCH-01 検索 ＋ F-FILTER-01 絞り込み/並び替え。
 export default function PostsPage() {
@@ -97,6 +98,7 @@ export default function PostsPage() {
                     {RECRUIT_LABEL[p.recruitStatus] ?? p.recruitStatus}
                   </span>
                 </div>
+                <ReviewPrefBadges tone={p.reviewTone} aspects={p.reviewAspects} className="mt-2" />
                 <p className="mt-1 text-sm text-gray-500">レビュー {p.reviewCount} 件</p>
               </Link>
             </li>


### PR DESCRIPTION
## 関連 Issue

Closes #141

---

## 変更の概要

Phase 2 の 2 機能を 1 PR で実装（投稿フォーム同screen のため束ねた）。

### F-SAFE-01 心理的安全設定（投稿者本人）
- 投稿に「希望レビュートーン」を**単一選択**で持たせる（R-02 萎縮対策）
- 値：未設定（null）／初学者歓迎（WELCOME_BEGINNER）／辛口OK（HARSH_OK）／優しめ希望（GENTLE）
- `posts.review_tone` 列を追加

### F-REQ-01 観点別レビュー依頼（投稿者本人）
- 募集したい観点を**多値5軸**で名指し：DB／UI／コード／セキュリティ／パフォーマンス
- `post_review_aspects` 子テーブル（@ElementCollection で正規化・投稿削除で子行も自動削除）

### 重点軸（認可）方針
- **新規エンドポイントは追加せず**、既存 `POST/PUT /api/posts` に相乗り → 認可境界は据え置き
- tone/aspects の設定・変更は所有者のみ（既存 create/loadOwned で担保）
- 表示は同 cohort 内のみ（既存 get の cohort 境界）
- 一覧・詳細でバッジ表示、投稿/編集フォームに入力 UI を追加

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（Chrome DevTools：作成→詳細→一覧→編集の全置換まで確認・投稿API全て200）
- [x] 既存の機能が壊れていないことを確認した（backend 全テスト green／frontend lint・build OK／V4 migration 適用 v3→v4）
- [x] `.env` ファイルやパスワードをコミットしていない

### 自動テスト（重点軸標準・拒否系）
`PostReviewPreferenceIntegrationTest`：
- 作成でトーン/観点が永続・詳細で返る
- 未指定は未設定（null・空配列）
- 所有者は全置換できる
- **非所有者の更新は 404**／**他 cohort は不可視 404**／**不正 enum は 400**

---

## レビュー時に特に確認してほしい点

- aspects を `@ElementCollection`（EAGER＋BatchSize=50）にした判断。子エンティティ化せず投稿削除時の自動カスケードと cleanup 順の単純化を優先。一覧の N+1 は BatchSize で1クエリに束ねる想定。