### PR TITLE
feat: Phase2 継続の可視化（F-STREAK-01）

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/domain/profile/ProfileService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/profile/ProfileService.java
@@ -16,6 +16,10 @@ import com.reviewboard.domain.user.UserRole;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -28,6 +32,9 @@ import java.util.stream.Collectors;
  */
 @Service
 public class ProfileService {
+
+    /** 「活動日」を判定するタイムゾーン。利用者は日本の受講生のため JST 固定（§1-6）。 */
+    private static final ZoneId DISPLAY_ZONE = ZoneId.of("Asia/Tokyo");
 
     private final UserRepository userRepository;
     private final PostRepository postRepository;
@@ -83,8 +90,16 @@ public class ProfileService {
                 target.getReceivedReviewsCount(), target.getGivenReviewsCount(),
                 target.getThanksReceivedCount());
 
+        // F-STREAK-01：活動日 = 投稿した日 ＋ レビューを実施した日（本人視点）。
+        List<Review> givenReviews = reviewRepository.findByReviewerUserIdAndDeletedAtIsNull(userId);
+        List<OffsetDateTime> activities = new ArrayList<>();
+        posts.forEach(p -> activities.add(p.getCreatedAt()));
+        givenReviews.forEach(r -> activities.add(r.getCreatedAt()));
+        ProfileResponse.Streak streak = StreakCalculator.compute(
+                activities, LocalDate.now(DISPLAY_ZONE), DISPLAY_ZONE);
+
         return new ProfileResponse(
                 target.getId(), target.getDisplayName(), target.getRole(), target.getBio(),
-                stats, postEntries, received);
+                stats, streak, postEntries, received);
     }
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/profile/StreakCalculator.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/profile/StreakCalculator.java
@@ -1,0 +1,84 @@
+package com.reviewboard.domain.profile;
+
+import com.reviewboard.domain.profile.dto.ProfileResponse;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Collection;
+import java.util.List;
+import java.util.TreeSet;
+
+/**
+ * F-STREAK-01 継続の可視化：活動タイムスタンプ（投稿・レビュー実施）から連続日数を集計する純粋関数。
+ *
+ * <p>副作用も DB 依存も持たないため単体テストで完結する。「活動日」は表示ゾーン（JST）の
+ * カレンダー日で重複排除する。非競争（他者比較なし）の自己積み上げ指標（§1-6 継続は力なり）。
+ */
+public final class StreakCalculator {
+
+    /** 達成バッジのしきい値（連続日数）。最長連続が到達したものを達成とみなす。 */
+    static final List<Integer> BADGE_THRESHOLDS = List.of(3, 7, 14, 30);
+
+    private StreakCalculator() {
+    }
+
+    /**
+     * 活動タイムスタンプ群から継続指標を組み立てる。
+     *
+     * @param activities 投稿・実施レビューの作成日時（順不同・重複可・null 要素は無視）
+     * @param today      「現在の連続」の起点となる当日（呼び出し側で zone を揃えて渡す）
+     * @param zone       カレンダー日に落とすタイムゾーン（JST 想定）
+     */
+    public static ProfileResponse.Streak compute(Collection<OffsetDateTime> activities,
+                                                 LocalDate today, ZoneId zone) {
+        // 活動日を昇順・重複排除で集合化
+        TreeSet<LocalDate> days = new TreeSet<>();
+        for (OffsetDateTime ts : activities) {
+            if (ts != null) {
+                days.add(ts.atZoneSameInstant(zone).toLocalDate());
+            }
+        }
+        if (days.isEmpty()) {
+            return new ProfileResponse.Streak(0, 0, 0, null, List.of());
+        }
+
+        int longest = longestRun(days);
+        int current = currentRun(days, today);
+        LocalDate lastActive = days.last();
+        List<Integer> badges = BADGE_THRESHOLDS.stream().filter(t -> longest >= t).toList();
+
+        return new ProfileResponse.Streak(current, longest, days.size(), lastActive, badges);
+    }
+
+    /** 連続する暦日の最長ラン長。 */
+    private static int longestRun(TreeSet<LocalDate> days) {
+        int longest = 0;
+        int run = 0;
+        LocalDate prev = null;
+        for (LocalDate d : days) {
+            run = (prev != null && prev.plusDays(1).equals(d)) ? run + 1 : 1;
+            longest = Math.max(longest, run);
+            prev = d;
+        }
+        return longest;
+    }
+
+    /**
+     * 当日（または前日）を起点に遡る連続日数。最終活動日が今日でも昨日でもなければ 0
+     * （丸一日空くまでは途切れさせない＝「昨日まで猶予」）。
+     */
+    private static int currentRun(TreeSet<LocalDate> days, LocalDate today) {
+        LocalDate last = days.last();
+        if (last.isBefore(today.minusDays(1))) {
+            return 0;
+        }
+        int run = 0;
+        LocalDate cursor = last;
+        while (days.contains(cursor)) {
+            run++;
+            cursor = cursor.minusDays(1);
+        }
+        return run;
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/profile/dto/ProfileResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/profile/dto/ProfileResponse.java
@@ -4,12 +4,13 @@ import com.reviewboard.domain.evaluation.EvaluationResult;
 import com.reviewboard.domain.post.RecruitStatus;
 import com.reviewboard.domain.user.UserRole;
 
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;
 
 /**
  * 成長記録ページ（F-PROF・本アプリの主役）のレスポンス。
- * 投稿履歴・もらったレビュー・実績数・合格バッジを1ユーザー視点で集約する。
+ * 投稿履歴・もらったレビュー・実績数・合格バッジ・継続記録を1ユーザー視点で集約する。
  */
 public record ProfileResponse(
         Long userId,
@@ -17,11 +18,29 @@ public record ProfileResponse(
         UserRole role,
         String bio,
         Stats stats,
+        Streak streak,
         List<PostEntry> posts,
         List<ReceivedReview> receivedReviews) {
 
     /** F-PROF-03 実績数（非正規化カウンタ） */
     public record Stats(int receivedReviewsCount, int givenReviewsCount, int thanksReceivedCount) {
+    }
+
+    /**
+     * F-STREAK-01 継続の可視化（§1-6 継続は力なり・非競争）。
+     *
+     * @param currentStreak   今日 or 昨日を起点に連続する活動日数
+     * @param longestStreak   過去の最長連続活動日数
+     * @param totalActiveDays 活動した延べ日数（重複排除）
+     * @param lastActiveDate  最終活動日（活動なしは null）
+     * @param achievedBadges  達成済みの連続日数バッジ（例：[3,7]）
+     */
+    public record Streak(
+            int currentStreak,
+            int longestStreak,
+            int totalActiveDays,
+            LocalDate lastActiveDate,
+            List<Integer> achievedBadges) {
     }
 
     /** F-PROF-01 投稿履歴 ＋ F-PROF-04 合格バッジ（approved） */

--- a/review-board/backend/src/test/java/com/reviewboard/domain/profile/StreakCalculatorTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/profile/StreakCalculatorTest.java
@@ -1,0 +1,104 @@
+package com.reviewboard.domain.profile;
+
+import com.reviewboard.domain.profile.dto.ProfileResponse;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * F-STREAK-01 連続日数集計の単体テスト（DB 非依存）。
+ * 活動日は JST のカレンダー日で重複排除する前提を固定する。
+ */
+class StreakCalculatorTest {
+
+    private static final ZoneId JST = ZoneId.of("Asia/Tokyo");
+    private static final LocalDate TODAY = LocalDate.of(2026, 5, 23);
+
+    /** JST の特定日の正午の OffsetDateTime（日付の取り違いを避ける）。 */
+    private static OffsetDateTime at(LocalDate d) {
+        return d.atTime(12, 0).atZone(JST).toOffsetDateTime();
+    }
+
+    @Test
+    void empty_activities_yields_zero() {
+        var s = StreakCalculator.compute(List.of(), TODAY, JST);
+        assertThat(s.currentStreak()).isZero();
+        assertThat(s.longestStreak()).isZero();
+        assertThat(s.totalActiveDays()).isZero();
+        assertThat(s.lastActiveDate()).isNull();
+        assertThat(s.achievedBadges()).isEmpty();
+    }
+
+    @Test
+    void same_day_multiple_activities_count_as_one_day() {
+        var s = StreakCalculator.compute(
+                List.of(at(TODAY), at(TODAY), at(TODAY)), TODAY, JST);
+        assertThat(s.totalActiveDays()).isEqualTo(1);
+        assertThat(s.currentStreak()).isEqualTo(1);
+        assertThat(s.longestStreak()).isEqualTo(1);
+    }
+
+    @Test
+    void consecutive_days_ending_today_form_current_streak() {
+        var s = StreakCalculator.compute(
+                List.of(at(TODAY), at(TODAY.minusDays(1)), at(TODAY.minusDays(2))), TODAY, JST);
+        assertThat(s.currentStreak()).isEqualTo(3);
+        assertThat(s.longestStreak()).isEqualTo(3);
+        assertThat(s.achievedBadges()).containsExactly(3);
+    }
+
+    @Test
+    void streak_ending_yesterday_still_counts_as_current() {
+        var s = StreakCalculator.compute(
+                List.of(at(TODAY.minusDays(1)), at(TODAY.minusDays(2))), TODAY, JST);
+        assertThat(s.currentStreak()).isEqualTo(2);
+    }
+
+    @Test
+    void gap_of_two_days_breaks_current_streak() {
+        var s = StreakCalculator.compute(
+                List.of(at(TODAY.minusDays(2)), at(TODAY.minusDays(3))), TODAY, JST);
+        assertThat(s.currentStreak()).isZero();
+        assertThat(s.longestStreak()).isEqualTo(2);
+    }
+
+    @Test
+    void longest_run_picks_max_among_separate_runs() {
+        // 5日連続 → 空き → 直近2日連続
+        var s = StreakCalculator.compute(List.of(
+                at(LocalDate.of(2026, 5, 1)), at(LocalDate.of(2026, 5, 2)), at(LocalDate.of(2026, 5, 3)),
+                at(LocalDate.of(2026, 5, 4)), at(LocalDate.of(2026, 5, 5)),
+                at(TODAY), at(TODAY.minusDays(1))), TODAY, JST);
+        assertThat(s.longestStreak()).isEqualTo(5);
+        assertThat(s.currentStreak()).isEqualTo(2);
+        assertThat(s.totalActiveDays()).isEqualTo(7);
+    }
+
+    @Test
+    void badges_accumulate_by_longest_streak() {
+        // 8日連続 → 3,7 を達成、14/30 は未達
+        var days = new java.util.ArrayList<OffsetDateTime>();
+        for (int i = 0; i < 8; i++) {
+            days.add(at(TODAY.minusDays(i)));
+        }
+        var s = StreakCalculator.compute(days, TODAY, JST);
+        assertThat(s.longestStreak()).isEqualTo(8);
+        assertThat(s.achievedBadges()).containsExactly(3, 7);
+    }
+
+    /** UTC 深夜でも JST 換算で正しい暦日になる（境界の取り違い防止）。 */
+    @Test
+    void utc_late_night_maps_to_next_jst_day() {
+        // 2026-05-22T20:00Z = 2026-05-23T05:00 JST → TODAY 扱い
+        OffsetDateTime utcLateNight = OffsetDateTime.of(2026, 5, 22, 20, 0, 0, 0, ZoneOffset.UTC);
+        var s = StreakCalculator.compute(List.of(utcLateNight), TODAY, JST);
+        assertThat(s.lastActiveDate()).isEqualTo(TODAY);
+        assertThat(s.currentStreak()).isEqualTo(1);
+    }
+}

--- a/review-board/frontend/src/pages/ProfilePage.jsx
+++ b/review-board/frontend/src/pages/ProfilePage.jsx
@@ -21,7 +21,7 @@ export default function ProfilePage() {
   if (loading) return <p className="p-6 text-gray-500">読み込み中…</p>;
   if (error) return <p className="p-6 text-red-600">{error}</p>;
 
-  const { displayName, role, stats, posts, receivedReviews } = profile;
+  const { displayName, role, stats, streak, posts, receivedReviews } = profile;
 
   return (
     <main className="mx-auto max-w-3xl space-y-6 p-6">
@@ -36,6 +36,8 @@ export default function ProfilePage() {
           <Stat label="もらった🙏" value={stats.thanksReceivedCount} />
         </div>
       </header>
+
+      {streak && <StreakCard streak={streak} />}
 
       <section>
         <h3 className="mb-3 font-medium text-gray-800">投稿した成果物（{posts.length}）</h3>
@@ -84,5 +86,30 @@ function Stat({ label, value }) {
       <div className="text-2xl font-bold text-gray-800">{value}</div>
       <div className="text-xs text-gray-500">{label}</div>
     </div>
+  );
+}
+
+// F-STREAK-01 継続の可視化（§1-6 継続は力なり・非競争）。投稿/レビューの活動日から集計した値を表示。
+function StreakCard({ streak }) {
+  const { currentStreak, longestStreak, totalActiveDays, achievedBadges = [] } = streak;
+  return (
+    <section className="rounded-lg border border-orange-200 bg-orange-50 p-6">
+      <h3 className="mb-3 font-medium text-orange-800">継続の記録 <span className="text-xs font-normal text-orange-600">（投稿・レビューを続けた日数）</span></h3>
+      <div className="grid grid-cols-3 gap-4 text-center">
+        <Stat label="現在の連続" value={`🔥 ${currentStreak}日`} />
+        <Stat label="最長連続" value={`🏔️ ${longestStreak}日`} />
+        <Stat label="活動した日" value={`📅 ${totalActiveDays}日`} />
+      </div>
+      {achievedBadges.length > 0 && (
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          <span className="text-xs text-orange-700">達成バッジ：</span>
+          {achievedBadges.map((d) => (
+            <span key={d} className="rounded-full bg-orange-100 px-2.5 py-0.5 text-xs font-medium text-orange-700 ring-1 ring-orange-300">
+              🏅 {d}日連続
+            </span>
+          ))}
+        </div>
+      )}
+    </section>
   );
 }


### PR DESCRIPTION
## 関連 Issue

Closes #143

---

## 変更の概要

成長記録ページ（F-PROF・主役）に「継続の可視化」を追加。§1-6「継続は力なり」の体現。

- **現在の連続日数**（🔥）・**最長連続日数**（🏔️）・**総活動日数**（📅）
- **達成バッジ**：3／7／14／30 日連続
- **非競争**：他者比較・ランキングなし（R-02・初心者が傷つかない）

### 設計
- **新テーブル不要**。投稿(createdAt)＋実施レビュー(createdAt)の日付から読み側集計
- 活動日 = その日に投稿 or レビューをした日（JST カレンダー日で重複排除）
- current streak = 今日 or 昨日を起点に連続する日数（丸一日空くまで途切れさせない）
- 集計ロジックは純粋関数 `StreakCalculator` に分離 → DB 非依存の単体テストで網羅
- 既存 `ProfileService` の cohort 境界（同 cohort のみ可視・他404）に相乗り → 認可境界据え置き

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（Chrome DevTools：成長記録ページに継続カード表示・コンソールエラーなし）
- [x] 既存の機能が壊れていないことを確認した（backend 全テスト green／frontend lint・build OK）
- [x] `.env` ファイルやパスワードをコミットしていない

### 自動テスト（StreakCalculatorTest・DB 非依存）
空／同日重複→1日／連続→current・longest・バッジ／昨日終端も current 継続／2日空きで current=0／別ランの最長採用／バッジ累積／UTC深夜→翌JST日

---

## レビュー時に特に確認してほしい点

- 「活動日」の定義を投稿＋実施レビューの 2 種にした点（thanks や返信は含めていない）。継続の動機づけとして主要な能動行動に絞った。
- タイムゾーンを JST 固定にした点（利用者は日本の受講生）。境界は単体テストで担保。