### PR TITLE
feat: Phase2 下書き・自動保存（F-DRAFT-01）

### DIFF
--- a/review-board/frontend/src/components/DraftNotice.jsx
+++ b/review-board/frontend/src/components/DraftNotice.jsx
@@ -1,0 +1,11 @@
+// F-DRAFT-01：下書きを復元したことを知らせ、破棄も選べる小バナー。
+export default function DraftNotice({ onDiscard }) {
+  return (
+    <div className="mb-3 flex items-center justify-between rounded bg-blue-50 px-3 py-2 text-sm text-blue-700">
+      <span>📝 前回の下書きを復元しました。</span>
+      <button type="button" onClick={onDiscard} className="ml-3 text-blue-600 underline hover:text-blue-800">
+        破棄して新規作成
+      </button>
+    </div>
+  );
+}

--- a/review-board/frontend/src/components/ReviewForm.jsx
+++ b/review-board/frontend/src/components/ReviewForm.jsx
@@ -1,14 +1,33 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { AXES } from '../constants';
 import { createReview } from '../api/reviews';
+import { useDraft } from '../hooks/useDraft';
+import DraftNotice from './DraftNotice';
 
 // F-REV-01：良かった点・改善提案は必須、観点別コメント（4軸）は任意。
+// F-DRAFT-01：入力を localStorage に自動保存（postId 単位）し、再訪時に復元する。
 export default function ReviewForm({ postId, onCreated }) {
   const [good, setGood] = useState('');
   const [improvement, setImprovement] = useState('');
   const [axis, setAxis] = useState({});
   const [error, setError] = useState('');
   const [submitting, setSubmitting] = useState(false);
+
+  // 下書き：postId 単位で分離（投稿ごとにレビュー下書きを保持）。
+  const { restored, save, clear } = useDraft(`review-${postId}`, (d) => {
+    if (d.good != null) setGood(d.good);
+    if (d.improvement != null) setImprovement(d.improvement);
+    if (d.axis) setAxis(d.axis);
+  });
+  const dirty = !!(good || improvement || Object.values(axis).some((v) => v?.trim()));
+  useEffect(() => { if (dirty) save({ good, improvement, axis }); }, [good, improvement, axis, dirty, save]);
+
+  const discardDraft = () => {
+    clear();
+    setGood('');
+    setImprovement('');
+    setAxis({});
+  };
 
   const submit = async (e) => {
     e.preventDefault();
@@ -23,6 +42,7 @@ export default function ReviewForm({ postId, onCreated }) {
       setGood('');
       setImprovement('');
       setAxis({});
+      clear(); // 投稿成功で下書きは不要
       onCreated?.(created);
     } catch (err) {
       const s = err.response?.status;
@@ -37,6 +57,7 @@ export default function ReviewForm({ postId, onCreated }) {
   return (
     <form onSubmit={submit} className="rounded-lg border border-gray-200 bg-white p-4">
       <h3 className="mb-3 font-medium text-gray-800">レビューを書く</h3>
+      {restored && <DraftNotice onDiscard={discardDraft} />}
       {error && <p className="mb-3 rounded bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
       <label className="mb-1 block text-sm text-gray-600">✅ 良かった点（必須）</label>
       <textarea

--- a/review-board/frontend/src/hooks/useDraft.js
+++ b/review-board/frontend/src/hooks/useDraft.js
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAuth } from '../context/AuthContext';
+
+// F-DRAFT-01 下書き・自動保存（本人・localStorage 主体・backend なし）。
+// 入力をデバウンス保存し、再訪時に復元する。キーはユーザー単位で分離（共有端末でのアカウント間混在防止）。
+//
+// 使い方:
+//   const { restored, hasRestored, save, clear, discard } = useDraft('post-new', form, setForm);
+//   - restored:    マウント時に下書きがあれば一度だけ true（復元バナー表示用）
+//   - save(values): 値が変わるたび呼ぶ（300ms デバウンスで localStorage へ）
+//   - clear():      送信成功時に下書きを消す（バナーも消える）
+//   - discard():    ユーザーが「破棄」したとき（下書きを消しフォームを空に戻す側で利用）
+const DEBOUNCE_MS = 300;
+
+export function useDraft(name, applyDraft) {
+  const { user } = useAuth();
+  const storageKey = user ? `draft:${user.id}:${name}` : null;
+  const [restored, setRestored] = useState(false);
+  const timer = useRef(null);
+  const appliedKey = useRef(null);
+
+  // マウント時（ユーザー確定後）に一度だけ復元を試みる。
+  useEffect(() => {
+    if (!storageKey || appliedKey.current === storageKey) return;
+    appliedKey.current = storageKey;
+    try {
+      const raw = localStorage.getItem(storageKey);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        applyDraft(parsed);
+        setRestored(true);
+      }
+    } catch {
+      // 壊れた下書きは無視して捨てる
+      localStorage.removeItem(storageKey);
+    }
+    // applyDraft は呼び出し側で安定化させる（依存に含めない）
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [storageKey]);
+
+  // 値の変更をデバウンスして保存。storageKey 単位で安定参照にする（effect の依存に入れても無限ループしない）。
+  const save = useCallback((values) => {
+    if (!storageKey) return;
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => {
+      try {
+        localStorage.setItem(storageKey, JSON.stringify(values));
+      } catch {
+        // 容量超過等は黙って諦める（下書きは best-effort）
+      }
+    }, DEBOUNCE_MS);
+  }, [storageKey]);
+
+  const clear = useCallback(() => {
+    if (timer.current) clearTimeout(timer.current);
+    if (storageKey) localStorage.removeItem(storageKey);
+    setRestored(false);
+  }, [storageKey]);
+
+  // アンマウント時に保留中の保存タイマーを掃除
+  useEffect(() => () => timer.current && clearTimeout(timer.current), []);
+
+  return { restored, save, clear };
+}

--- a/review-board/frontend/src/pages/NewPostPage.jsx
+++ b/review-board/frontend/src/pages/NewPostPage.jsx
@@ -1,17 +1,34 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { createPost } from '../api/posts';
 import ScreenshotUploader from '../components/ScreenshotUploader';
 import ReviewPrefFields from '../components/ReviewPrefFields';
+import DraftNotice from '../components/DraftNotice';
+import { useDraft } from '../hooks/useDraft';
+
+const EMPTY = { title: '', description: '', repoUrl: '', demoUrl: '', screenshotKey: null, reviewTone: null, reviewAspects: [] };
 
 // F-POST-01：成果物の投稿（タイトル/説明は必須、URL・スクショは任意）。
+// F-DRAFT-01：入力を localStorage に自動保存し、再訪時に復元する。
 export default function NewPostPage() {
   const navigate = useNavigate();
-  const [form, setForm] = useState({ title: '', description: '', repoUrl: '', demoUrl: '', screenshotKey: null, reviewTone: null, reviewAspects: [] });
+  const [form, setForm] = useState(EMPTY);
   const [error, setError] = useState('');
   const [busy, setBusy] = useState(false);
 
+  // 下書き：復元はマウント時に form へ流し込み、変更のたびに自動保存。
+  const { restored, save, clear } = useDraft('post-new', (draft) => setForm((p) => ({ ...p, ...draft })));
+  // 空フォームは保存しない（「空の下書き復元」誤検知を防ぐ）。
+  const dirty = !!(form.title || form.description || form.repoUrl || form.demoUrl
+    || form.screenshotKey || form.reviewTone || form.reviewAspects.length);
+  useEffect(() => { if (dirty) save(form); }, [form, dirty, save]);
+
   const set = (k) => (e) => setForm((p) => ({ ...p, [k]: e.target.value }));
+
+  const discardDraft = () => {
+    clear();
+    setForm(EMPTY);
+  };
 
   const submit = async (e) => {
     e.preventDefault();
@@ -27,6 +44,7 @@ export default function NewPostPage() {
         reviewTone: form.reviewTone,
         reviewAspects: form.reviewAspects,
       });
+      clear(); // 投稿成功で下書きは不要
       navigate(`/posts/${post.id}`, { replace: true });
     } catch {
       setError('投稿に失敗しました');
@@ -39,6 +57,7 @@ export default function NewPostPage() {
     <main className="mx-auto max-w-2xl p-6">
       <h2 className="mb-4 text-lg font-bold text-gray-800">成果物を投稿</h2>
       <form onSubmit={submit} className="rounded-lg border border-gray-200 bg-white p-6">
+        {restored && <DraftNotice onDiscard={discardDraft} />}
         {error && <p className="mb-3 rounded bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
         <label className="mb-1 block text-sm text-gray-600">タイトル（必須）</label>
         <input required value={form.title} onChange={set('title')} className="mb-4 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none" />


### PR DESCRIPTION
## 関連 Issue

Closes #145

---

## 変更の概要

投稿フォーム・レビューフォームの入力を **localStorage** に自動保存し、再訪時に復元する（本人・デバイス内・backend なし）。

- `useDraft` フック：マウント時に復元／変更をデバウンス保存（300ms）／送信成功でクリア
- キーは **user 単位＋フォーム種別**で分離（レビューは postId 単位）→ 共有端末でのアカウント間・投稿間の混在を防止
- 復元時は「📝 前回の下書きを復元しました（破棄して新規作成）」バナーを表示
- **空フォームは保存しない**（「空の下書き復元」誤検知を防止）
- 既存コンテンツの編集（PostEditPage）は下書き対象外（保存済みデータの autosave は別物のため）

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（Chrome DevTools・コンソールエラーなし）
- [x] 既存の機能が壊れていないことを確認した（frontend lint・build OK／backend 変更なし）
- [x] `.env` ファイルやパスワードをコミットしていない

### 実機確認（Chrome DevTools）
- 投稿フォーム：入力→離脱→再訪で **復元**（タイトル/説明/トーン/観点まで）／**破棄**で空に戻りバナー消滅／破棄後の再訪で復元されない（localStorage 削除を確認）
- レビューフォーム：postId 単位で **復元**（良かった点＋観点別）／**破棄**動作

---

## レビュー時に特に確認してほしい点

- backend を使わず localStorage 主体にした判断（引き継ぎ書方針・規模「低」・認可面を増やさない）。サーバー横断の下書き同期は本実装移行時の検討余地として残す。
- 自動保存を「dirty 時のみ」に限定し、未入力の空下書きで誤って復元バナーが出るのを防いだ点。