### PR TITLE
feat: Phase2 通知（ポーリング）（F-NOTIF-01）

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/domain/notification/Notification.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/notification/Notification.java
@@ -1,0 +1,47 @@
+package com.reviewboard.domain.notification;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+
+/**
+ * F-NOTIF-01 通知。recipient（受信者）本人のみ閲覧・既読化できる（★S軸）。
+ * actor は通知を引き起こした相手、post_id/review_id は遷移先の手がかり。
+ */
+@Entity
+@Table(name = "notifications")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "recipient_user_id", nullable = false)
+    private Long recipientUserId;
+
+    @Column(name = "actor_user_id", nullable = false)
+    private Long actorUserId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private NotificationType type;
+
+    @Column(name = "post_id")
+    private Long postId;
+
+    @Column(name = "review_id")
+    private Long reviewId;
+
+    /** 既読時刻（null は未読）。 */
+    @Column(name = "read_at")
+    private OffsetDateTime readAt;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/notification/NotificationController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/notification/NotificationController.java
@@ -1,0 +1,51 @@
+package com.reviewboard.domain.notification;
+
+import com.reviewboard.domain.auth.AuthPrincipal;
+import com.reviewboard.domain.notification.dto.NotificationResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 通知 API（F-NOTIF-01）。すべて認証必須。閲覧・既読化は受信者本人のものに限る（Service で検証）。
+ */
+@RestController
+@RequestMapping("/api/notifications")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    public NotificationController(NotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    /** 自分の通知一覧（新着順） */
+    @GetMapping
+    public List<NotificationResponse> list(@AuthenticationPrincipal AuthPrincipal principal) {
+        return notificationService.list(principal);
+    }
+
+    /** 未読件数（ベルのバッジ用・ポーリング） */
+    @GetMapping("/unread-count")
+    public Map<String, Integer> unreadCount(@AuthenticationPrincipal AuthPrincipal principal) {
+        return Map.of("count", notificationService.unreadCount(principal));
+    }
+
+    /** 1件を既読化（自分の通知のみ・他人は 404） */
+    @PostMapping("/{id}/read")
+    public ResponseEntity<Void> markRead(@AuthenticationPrincipal AuthPrincipal principal,
+                                         @PathVariable Long id) {
+        notificationService.markRead(principal, id);
+        return ResponseEntity.noContent().build();
+    }
+
+    /** 自分の未読をすべて既読化 */
+    @PostMapping("/read-all")
+    public ResponseEntity<Void> markAllRead(@AuthenticationPrincipal AuthPrincipal principal) {
+        notificationService.markAllRead(principal);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/notification/NotificationRepository.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/notification/NotificationRepository.java
@@ -1,0 +1,28 @@
+package com.reviewboard.domain.notification;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    /** 受信者の通知一覧（新着順）。 */
+    List<Notification> findByRecipientUserIdOrderByCreatedAtDesc(Long recipientUserId);
+
+    /** 未読件数（ベルのバッジ用・ポーリングで頻繁に叩くため軽量）。 */
+    int countByRecipientUserIdAndReadAtIsNull(Long recipientUserId);
+
+    /** 単体取得（既読化の所有者検証に使う）。 */
+    Optional<Notification> findByIdAndRecipientUserId(Long id, Long recipientUserId);
+
+    /** 受信者の未読をまとめて既読化。 */
+    @Modifying
+    @Query("update Notification n set n.readAt = :now "
+            + "where n.recipientUserId = :recipientUserId and n.readAt is null")
+    int markAllRead(@Param("recipientUserId") Long recipientUserId, @Param("now") OffsetDateTime now);
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/notification/NotificationService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/notification/NotificationService.java
@@ -1,0 +1,94 @@
+package com.reviewboard.domain.notification;
+
+import com.reviewboard.common.ResourceNotFoundException;
+import com.reviewboard.domain.auth.AuthPrincipal;
+import com.reviewboard.domain.notification.dto.NotificationResponse;
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * F-NOTIF-01 通知のユースケース。★S軸：閲覧・既読化は受信者本人のものに限る（他人の通知は 404）。
+ *
+ * <p>生成（{@link #notify}）はレビュー作成・ありがとう等のドメイン処理から同一 TX で呼ばれる。
+ * 自分が自分に通知することはしない（recipient == actor はスキップ）。
+ */
+@Service
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
+
+    public NotificationService(NotificationRepository notificationRepository,
+                               UserRepository userRepository) {
+        this.notificationRepository = notificationRepository;
+        this.userRepository = userRepository;
+    }
+
+    /**
+     * 通知を1件作る。recipient と actor が同一なら作らない（自己通知の抑止）。
+     * 呼び出し元の TX に参加する（レビュー作成・ありがとうと原子的に確定）。
+     */
+    @Transactional
+    public void notify(Long recipientUserId, Long actorUserId, NotificationType type,
+                       Long postId, Long reviewId) {
+        if (recipientUserId == null || recipientUserId.equals(actorUserId)) {
+            return;
+        }
+        Notification n = new Notification();
+        n.setRecipientUserId(recipientUserId);
+        n.setActorUserId(actorUserId);
+        n.setType(type);
+        n.setPostId(postId);
+        n.setReviewId(reviewId);
+        n.setCreatedAt(OffsetDateTime.now());
+        notificationRepository.save(n);
+    }
+
+    /** 自分の通知一覧（新着順）。actor 名は N+1 回避でまとめ引き。 */
+    @Transactional(readOnly = true)
+    public List<NotificationResponse> list(AuthPrincipal principal) {
+        List<Notification> items = notificationRepository
+                .findByRecipientUserIdOrderByCreatedAtDesc(principal.userId());
+        if (items.isEmpty()) {
+            return List.of();
+        }
+        Set<Long> actorIds = items.stream().map(Notification::getActorUserId).collect(Collectors.toSet());
+        Map<Long, User> actors = userRepository.findAllById(actorIds).stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+        return items.stream().map(n -> {
+            User actor = actors.get(n.getActorUserId());
+            return NotificationResponse.from(n, actor != null ? actor.getDisplayName() : "(不明)");
+        }).toList();
+    }
+
+    /** 未読件数（ベルのバッジ用・ポーリングで頻繁に叩く軽量 API）。 */
+    @Transactional(readOnly = true)
+    public int unreadCount(AuthPrincipal principal) {
+        return notificationRepository.countByRecipientUserIdAndReadAtIsNull(principal.userId());
+    }
+
+    /** 1件を既読化。自分の通知でなければ 404（存在を漏らさない）。 */
+    @Transactional
+    public void markRead(AuthPrincipal principal, Long id) {
+        Notification n = notificationRepository.findByIdAndRecipientUserId(id, principal.userId())
+                .orElseThrow(() -> new ResourceNotFoundException("notification not found: " + id));
+        if (n.getReadAt() == null) {
+            n.setReadAt(OffsetDateTime.now());
+        }
+    }
+
+    /** 自分の未読をすべて既読化。 */
+    @Transactional
+    public void markAllRead(AuthPrincipal principal) {
+        notificationRepository.markAllRead(principal.userId(), OffsetDateTime.now());
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/notification/NotificationType.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/notification/NotificationType.java
@@ -1,0 +1,11 @@
+package com.reviewboard.domain.notification;
+
+/**
+ * F-NOTIF-01 通知の種別（要件§5）。リアルタイムは使わずポーリングで配信する。
+ */
+public enum NotificationType {
+    /** 自分の投稿にレビューが付いた（投稿者へ） */
+    REVIEW_RECEIVED,
+    /** 自分のレビューにありがとうが付いた（レビュアーへ） */
+    THANKS_RECEIVED
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/notification/dto/NotificationResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/notification/dto/NotificationResponse.java
@@ -1,0 +1,26 @@
+package com.reviewboard.domain.notification.dto;
+
+import com.reviewboard.domain.notification.Notification;
+import com.reviewboard.domain.notification.NotificationType;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 通知1件のレスポンス。actor の表示名は呼び出し側でまとめ引きして渡す（N+1回避）。
+ */
+public record NotificationResponse(
+        Long id,
+        NotificationType type,
+        Long actorUserId,
+        String actorDisplayName,
+        Long postId,
+        Long reviewId,
+        boolean read,
+        OffsetDateTime createdAt) {
+
+    public static NotificationResponse from(Notification n, String actorDisplayName) {
+        return new NotificationResponse(
+                n.getId(), n.getType(), n.getActorUserId(), actorDisplayName,
+                n.getPostId(), n.getReviewId(), n.getReadAt() != null, n.getCreatedAt());
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewService.java
@@ -6,6 +6,8 @@ import com.reviewboard.domain.audit.AuditAction;
 import com.reviewboard.domain.audit.AuditService;
 import com.reviewboard.domain.audit.AuditTargetType;
 import com.reviewboard.domain.auth.AuthPrincipal;
+import com.reviewboard.domain.notification.NotificationService;
+import com.reviewboard.domain.notification.NotificationType;
 import com.reviewboard.domain.post.Post;
 import com.reviewboard.domain.post.PostRepository;
 import com.reviewboard.domain.review.dto.ReplyResponse;
@@ -39,6 +41,7 @@ public class ReviewService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
     private final AuditService auditService;
+    private final NotificationService notificationService;
 
     public ReviewService(ReviewRepository reviewRepository,
                          ReviewAxisCommentRepository axisCommentRepository,
@@ -46,7 +49,8 @@ public class ReviewService {
                          ReviewReplyRepository replyRepository,
                          PostRepository postRepository,
                          UserRepository userRepository,
-                         AuditService auditService) {
+                         AuditService auditService,
+                         NotificationService notificationService) {
         this.reviewRepository = reviewRepository;
         this.axisCommentRepository = axisCommentRepository;
         this.thanksRepository = thanksRepository;
@@ -54,6 +58,7 @@ public class ReviewService {
         this.postRepository = postRepository;
         this.userRepository = userRepository;
         this.auditService = auditService;
+        this.notificationService = notificationService;
     }
 
     /** F-REV-01 作成。同 cohort の投稿のみ・自己レビュー禁止。 */
@@ -81,6 +86,10 @@ public class ReviewService {
         adjustCount(post.getAuthorUserId(), +1, 0);        // author の「もらったレビュー」
 
         auditService.record(principal, AuditAction.REVIEW_CREATED, AuditTargetType.REVIEW, review.getId());
+
+        // F-NOTIF-01：投稿者へ「レビューが付いた」通知（自己レビューは上で弾いている）
+        notificationService.notify(post.getAuthorUserId(), principal.userId(),
+                NotificationType.REVIEW_RECEIVED, postId, review.getId());
 
         User reviewer = userRepository.findById(principal.userId()).orElseThrow();
         return ReviewResponse.from(review, reviewer.getDisplayName(), reviewer.getRole(), axisComments);
@@ -165,6 +174,10 @@ public class ReviewService {
         review.setThanksCount(review.getThanksCount() + 1);
         adjustThanksReceived(review.getReviewerUserId(), +1);
         auditService.record(principal, AuditAction.THANKS_SENT, AuditTargetType.REVIEW, reviewId);
+
+        // F-NOTIF-01：レビュアーへ「ありがとうが付いた」通知（自己通知は notify がスキップ）
+        notificationService.notify(review.getReviewerUserId(), principal.userId(),
+                NotificationType.THANKS_RECEIVED, review.getPostId(), reviewId);
     }
 
     /**

--- a/review-board/backend/src/main/resources/db/migration/V6__add_notifications.sql
+++ b/review-board/backend/src/main/resources/db/migration/V6__add_notifications.sql
@@ -1,0 +1,16 @@
+-- F-NOTIF-01 通知（ポーリング・WebSocket不使用）。受信者本人のみが閲覧・既読化できる。
+-- type：REVIEW_RECEIVED（自分の投稿にレビュー）／THANKS_RECEIVED（自分のレビューにありがとう）。
+CREATE TABLE notifications (
+    id                BIGSERIAL PRIMARY KEY,
+    recipient_user_id BIGINT      NOT NULL REFERENCES users (id),
+    actor_user_id     BIGINT      NOT NULL REFERENCES users (id),
+    type              VARCHAR(30) NOT NULL,
+    post_id           BIGINT,
+    review_id         BIGINT,
+    read_at           TIMESTAMPTZ,
+    created_at        TIMESTAMPTZ NOT NULL
+);
+
+-- ベルの未読数・一覧は受信者で引く。未読の数え上げを速くするため部分インデックス。
+CREATE INDEX idx_notifications_recipient ON notifications (recipient_user_id, created_at DESC);
+CREATE INDEX idx_notifications_unread ON notifications (recipient_user_id) WHERE read_at IS NULL;

--- a/review-board/backend/src/test/java/com/reviewboard/domain/notification/NotificationIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/notification/NotificationIntegrationTest.java
@@ -1,0 +1,128 @@
+package com.reviewboard.domain.notification;
+
+import com.reviewboard.domain.user.UserRole;
+import com.reviewboard.support.AbstractIntegrationTest;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * F-NOTIF-01 通知の生成・取得・既読化・認可テスト（S軸標準：受信者本人のみ＋拒否系）。
+ */
+class NotificationIntegrationTest extends AbstractIntegrationTest {
+
+    private String authorEmail;     // 投稿者（レビューを受ける＝REVIEW_RECEIVED の受信者）
+    private String reviewerEmail;   // レビュアー（ありがとうを受ける＝THANKS_RECEIVED の受信者）
+    private long postId;
+    private long reviewId;
+
+    @BeforeEach
+    void seed() throws Exception {
+        var cohort = newCohort("A");
+        authorEmail = newUser("author@example.com", UserRole.STUDENT, cohort.getId()).getEmail();
+        reviewerEmail = newUser("reviewer@example.com", UserRole.STUDENT, cohort.getId()).getEmail();
+        postId = createPost(login(authorEmail));
+        reviewId = createReview(login(reviewerEmail), postId);
+    }
+
+    /** レビュー作成で投稿者に REVIEW_RECEIVED 通知が1件付く。 */
+    @Test
+    void review_creates_notification_for_author() throws Exception {
+        mockMvc.perform(get("/api/notifications").cookie(login(authorEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].type").value("REVIEW_RECEIVED"))
+                .andExpect(jsonPath("$[0].postId").value((int) postId))
+                .andExpect(jsonPath("$[0].read").value(false));
+
+        mockMvc.perform(get("/api/notifications/unread-count").cookie(login(authorEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.count").value(1));
+    }
+
+    /** ありがとうでレビュアーに THANKS_RECEIVED 通知が付く。 */
+    @Test
+    void thanks_creates_notification_for_reviewer() throws Exception {
+        mockMvc.perform(post("/api/reviews/" + reviewId + "/thanks").cookie(login(authorEmail)))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/notifications").cookie(login(reviewerEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.type=='THANKS_RECEIVED')].length()").exists())
+                .andExpect(jsonPath("$[0].type").value("THANKS_RECEIVED"))
+                .andExpect(jsonPath("$[0].reviewId").value((int) reviewId));
+    }
+
+    /** 自分の投稿に自己レビューはできないため、自己通知は発生しない（recipient==actor のスキップは notify 側でも担保）。 */
+    @Test
+    void reviewer_has_no_notification_from_own_action() throws Exception {
+        // レビュアー自身には REVIEW_RECEIVED は来ない（来るのは投稿者）
+        mockMvc.perform(get("/api/notifications").cookie(login(reviewerEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    /** 既読化すると未読数が減る。自分の通知のみ。 */
+    @Test
+    void mark_read_decrements_unread() throws Exception {
+        Cookie author = login(authorEmail);
+        MvcResult res = mockMvc.perform(get("/api/notifications").cookie(author))
+                .andExpect(status().isOk()).andReturn();
+        long notifId = com.jayway.jsonpath.JsonPath.parse(res.getResponse().getContentAsString())
+                .read("$[0].id", Integer.class).longValue();
+
+        mockMvc.perform(post("/api/notifications/" + notifId + "/read").cookie(author))
+                .andExpect(status().isNoContent());
+        mockMvc.perform(get("/api/notifications/unread-count").cookie(author))
+                .andExpect(jsonPath("$.count").value(0));
+    }
+
+    /** ★他人の通知は既読化できない（存在を漏らさず 404）。 */
+    @Test
+    void cannot_mark_others_notification_returns404() throws Exception {
+        MvcResult res = mockMvc.perform(get("/api/notifications").cookie(login(authorEmail)))
+                .andExpect(status().isOk()).andReturn();
+        long authorsNotif = com.jayway.jsonpath.JsonPath.parse(res.getResponse().getContentAsString())
+                .read("$[0].id", Integer.class).longValue();
+
+        // レビュアーが投稿者の通知を既読化しようとする → 404
+        mockMvc.perform(post("/api/notifications/" + authorsNotif + "/read").cookie(login(reviewerEmail)))
+                .andExpect(status().isNotFound());
+    }
+
+    /** read-all で自分の未読が全て既読になる。 */
+    @Test
+    void mark_all_read() throws Exception {
+        Cookie author = login(authorEmail);
+        mockMvc.perform(post("/api/notifications/read-all").cookie(author))
+                .andExpect(status().isNoContent());
+        mockMvc.perform(get("/api/notifications/unread-count").cookie(author))
+                .andExpect(jsonPath("$.count").value(0));
+    }
+
+    @Test
+    void unauthenticated_is_rejected_returns401() throws Exception {
+        mockMvc.perform(get("/api/notifications"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    private long createPost(Cookie cookie) throws Exception {
+        MvcResult res = mockMvc.perform(post("/api/posts").cookie(cookie)
+                        .contentType("application/json").content("{\"title\":\"作品\",\"description\":\"説明\"}"))
+                .andExpect(status().isCreated()).andReturn();
+        return readId(res);
+    }
+
+    private long createReview(Cookie cookie, long pid) throws Exception {
+        MvcResult res = mockMvc.perform(post("/api/posts/" + pid + "/reviews").cookie(cookie)
+                        .contentType("application/json").content("{\"good\":\"良い\",\"improvement\":\"改善\"}"))
+                .andExpect(status().isCreated()).andReturn();
+        return readId(res);
+    }
+}

--- a/review-board/backend/src/test/java/com/reviewboard/support/AbstractIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/support/AbstractIntegrationTest.java
@@ -6,6 +6,7 @@ import com.reviewboard.domain.auth.RefreshTokenRepository;
 import com.reviewboard.domain.cohort.Cohort;
 import com.reviewboard.domain.cohort.CohortRepository;
 import com.reviewboard.domain.evaluation.EvaluationRepository;
+import com.reviewboard.domain.notification.NotificationRepository;
 import com.reviewboard.domain.post.PostRepository;
 import com.reviewboard.domain.review.ReviewAxisCommentRepository;
 import com.reviewboard.domain.review.ReviewReplyRepository;
@@ -85,6 +86,7 @@ public abstract class AbstractIntegrationTest {
     @Autowired protected ThanksRepository thanksRepository;
     @Autowired protected ReviewReplyRepository replyRepository;
     @Autowired protected EvaluationRepository evaluationRepository;
+    @Autowired protected NotificationRepository notificationRepository;
     @Autowired protected AuditLogRepository auditLogRepository;
     @Autowired protected RefreshTokenRepository refreshTokenRepository;
     @Autowired protected org.springframework.security.crypto.password.PasswordEncoder passwordEncoder;
@@ -93,6 +95,7 @@ public abstract class AbstractIntegrationTest {
     @BeforeEach
     void cleanDatabase() {
         auditLogRepository.deleteAll();
+        notificationRepository.deleteAll();
         replyRepository.deleteAll();
         thanksRepository.deleteAll();
         axisCommentRepository.deleteAll();

--- a/review-board/frontend/src/App.jsx
+++ b/review-board/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import NewPostPage from './pages/NewPostPage';
 import PostEditPage from './pages/PostEditPage';
 import PostDetailPage from './pages/PostDetailPage';
 import ProfilePage from './pages/ProfilePage';
+import NotificationsPage from './pages/NotificationsPage';
 
 // 認証必須ページの共通レイアウト（ヘッダー＋本文）。
 function Shell({ children }) {
@@ -31,6 +32,7 @@ export default function App() {
         <Route path="/posts/:id/edit" element={<Shell><PostEditPage /></Shell>} />
         <Route path="/posts/:id" element={<Shell><PostDetailPage /></Shell>} />
         <Route path="/users/:id/profile" element={<Shell><ProfilePage /></Shell>} />
+        <Route path="/notifications" element={<Shell><NotificationsPage /></Shell>} />
       </Routes>
     </AuthProvider>
   );

--- a/review-board/frontend/src/api/notifications.js
+++ b/review-board/frontend/src/api/notifications.js
@@ -1,0 +1,16 @@
+import client from './client';
+
+// F-NOTIF-01 通知（ポーリング・WebSocket不使用）。すべて受信者本人のもののみ。
+
+// 通知一覧（新着順）
+export const fetchNotifications = () => client.get('/notifications').then((r) => r.data);
+
+// 未読件数（ベルのバッジ用・ポーリングで頻繁に叩く軽量 API）
+export const fetchUnreadCount = () =>
+  client.get('/notifications/unread-count').then((r) => r.data.count);
+
+// 1件を既読化（自分の通知のみ・backend が他人を 404）
+export const markNotificationRead = (id) => client.post(`/notifications/${id}/read`);
+
+// 未読をすべて既読化
+export const markAllNotificationsRead = () => client.post('/notifications/read-all');

--- a/review-board/frontend/src/components/Header.jsx
+++ b/review-board/frontend/src/components/Header.jsx
@@ -1,9 +1,27 @@
-import { Link } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { Link, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { ROLE_LABEL } from '../constants';
+import { fetchUnreadCount } from '../api/notifications';
+
+// F-NOTIF-01：未読通知数のポーリング間隔（WebSocket は使わない）。
+const POLL_MS = 30000;
 
 export default function Header() {
   const { user, logout } = useAuth();
+  const location = useLocation();
+  const [unread, setUnread] = useState(0);
+
+  // ログイン中だけポーリング。画面遷移のたびにも即時更新（通知センターで既読化した直後の反映用）。
+  useEffect(() => {
+    if (!user) return undefined;
+    let alive = true;
+    const tick = () => fetchUnreadCount().then((c) => { if (alive) setUnread(c); }).catch(() => {});
+    tick();
+    const id = setInterval(tick, POLL_MS);
+    return () => { alive = false; clearInterval(id); };
+  }, [user, location.pathname]);
+
   return (
     <header className="flex items-center justify-between border-b border-gray-200 bg-white px-6 py-3">
       <div className="flex items-center gap-6">
@@ -18,6 +36,14 @@ export default function Header() {
       </div>
       {user && (
         <div className="flex items-center gap-4 text-sm">
+          <Link to="/notifications" className="relative text-gray-600 hover:text-gray-900" aria-label={`通知${unread > 0 ? `（未読 ${unread} 件）` : ''}`}>
+            <span className="text-lg">🔔</span>
+            {unread > 0 && (
+              <span className="absolute -right-2 -top-1 rounded-full bg-red-500 px-1.5 text-xs font-bold text-white">
+                {unread > 99 ? '99+' : unread}
+              </span>
+            )}
+          </Link>
           <span className="text-gray-600">
             {user.displayName}
             <span className="ml-2 rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-500">

--- a/review-board/frontend/src/pages/NotificationsPage.jsx
+++ b/review-board/frontend/src/pages/NotificationsPage.jsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { fetchNotifications, markNotificationRead, markAllNotificationsRead } from '../api/notifications';
+
+// F-NOTIF-01 通知センター（S-03）。新着順に並べ、クリックで既読化＋該当投稿へ遷移。
+const MESSAGE = {
+  REVIEW_RECEIVED: (n) => `${n.actorDisplayName} さんがあなたの投稿にレビューしました`,
+  THANKS_RECEIVED: (n) => `${n.actorDisplayName} さんがあなたのレビューに「ありがとう」を送りました`,
+};
+
+export default function NotificationsPage() {
+  const navigate = useNavigate();
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const load = () =>
+    fetchNotifications()
+      .then(setItems)
+      .catch(() => setError('通知の取得に失敗しました'))
+      .finally(() => setLoading(false));
+
+  useEffect(() => { load(); }, []);
+
+  const open = async (n) => {
+    try {
+      if (!n.read) await markNotificationRead(n.id);
+    } finally {
+      if (n.postId) navigate(`/posts/${n.postId}`);
+    }
+  };
+
+  const readAll = async () => {
+    await markAllNotificationsRead();
+    load();
+  };
+
+  if (loading) return <p className="p-6 text-gray-500">読み込み中…</p>;
+  if (error) return <p className="p-6 text-red-600">{error}</p>;
+
+  return (
+    <main className="mx-auto max-w-2xl p-6">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-lg font-bold text-gray-800">通知</h2>
+        {items.some((n) => !n.read) && (
+          <button onClick={readAll} className="text-sm text-blue-600 hover:underline">すべて既読にする</button>
+        )}
+      </div>
+
+      {items.length === 0 ? (
+        <p className="text-gray-500">通知はまだありません。</p>
+      ) : (
+        <ul className="space-y-2">
+          {items.map((n) => (
+            <li key={n.id}>
+              <button
+                onClick={() => open(n)}
+                className={`flex w-full items-start gap-3 rounded-lg border p-4 text-left hover:border-blue-300 ${n.read ? 'border-gray-200 bg-white' : 'border-blue-200 bg-blue-50'}`}
+              >
+                {!n.read && <span className="mt-1 h-2 w-2 flex-shrink-0 rounded-full bg-blue-500" aria-label="未読" />}
+                <span className="flex-1 text-sm text-gray-700">
+                  {n.type === 'THANKS_RECEIVED' ? '🙏 ' : '📝 '}
+                  {(MESSAGE[n.type]?.(n)) ?? '新しい通知があります'}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## 関連 Issue

Closes #149

---

## 変更の概要

ログインユーザーに通知を届ける（**ポーリング・WebSocket不使用**）。Phase 2 最後の機能。

- **通知種別**（要件§5）：レビューが付いた(REVIEW_RECEIVED)／ありがとうが付いた(THANKS_RECEIVED)
- **生成**：`ReviewService.create`→投稿者へ／`thank`→レビュアーへ（同一 TX・自己通知はスキップ）
- **API**：一覧 `GET /api/notifications`／未読数 `GET /api/notifications/unread-count`（ベル用・軽量）／既読化 `POST {id}/read`／全既読 `POST read-all`
- **UI**：ヘッダーに🔔＋未読バッジ（30秒ポーリング）、通知センター（S-03）。クリックで既読化＋該当投稿へ遷移

### 重点軸（認可）
新規エンドポイント追加につき 重点軸標準：
- 通知は**受信者本人のもののみ**閲覧・既読化可（他人の通知は **404**）／未認証 **401**

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（Chrome DevTools・通知系 API 全て 200/204・コンソールエラーなし）
- [x] 既存の機能が壊れていないことを確認した（backend 全テスト green／frontend lint・build OK／V6 migration 適用 v5→v6）
- [x] `.env` ファイルやパスワードをコミットしていない

### 実機確認（Chrome DevTools・end-to-end）
- 講師が student の投稿をレビュー → student のベルに未読1・通知センターに「📝 …レビューしました」→ クリックで既読化＋投稿へ遷移・バッジ消滅
- student が講師レビューに「ありがとう」→ 講師のベルに未読1・「🙏 …ありがとうを送りました」→「すべて既読にする」で既読化

### 自動テスト（NotificationIntegrationTest）
レビューで投稿者へ生成／ありがとうでレビュアーへ生成／自己通知なし／既読化で未読数減/全既読／**他人の通知は404**／未認証401

---

## レビュー時に特に確認してほしい点

- ポーリング設計：未読数は専用の軽量エンドポイントを 30 秒間隔で叩く。WebSocket は要件§5 で対象外。
- 「すべて既読」直後、ヘッダーのバッジは次回ポーリング/画面遷移まで最大 30 秒残る（ポーリング設計上の許容範囲・遷移で即時解消）。
- 通知種別は要件で定義済みの 2 種に限定（返信・再レビュー依頼への通知拡張は follow-up 候補。enum で拡張可能）。