### PR TITLE
feat: メンション通知（@ユーザーで名指し → 通知）

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/domain/notification/NotificationService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/notification/NotificationService.java
@@ -53,6 +53,23 @@ public class NotificationService {
         notificationRepository.save(n);
     }
 
+    /**
+     * F-MENTION：本文に含まれる `@表示名`（同 cohort メンバー）を解決し、その人へ MENTION 通知を作る。
+     * cohort メンバーのみ走査するため越境メンションは起きない。自己メンションは notify がスキップ。
+     * 表示名の完全一致（クローズドな少人数 cohort 前提・衝突時は該当者全員に通知）。
+     */
+    @Transactional
+    public void notifyMentions(String text, Long actorUserId, Long cohortId, Long postId, Long reviewId) {
+        if (text == null || text.indexOf('@') < 0) {
+            return;
+        }
+        for (User member : userRepository.findByCohortId(cohortId)) {
+            if (text.contains("@" + member.getDisplayName())) {
+                notify(member.getId(), actorUserId, NotificationType.MENTIONED, postId, reviewId);
+            }
+        }
+    }
+
     /** 自分の通知一覧（新着順）。actor 名は N+1 回避でまとめ引き。 */
     @Transactional(readOnly = true)
     public List<NotificationResponse> list(AuthPrincipal principal) {

--- a/review-board/backend/src/main/java/com/reviewboard/domain/notification/NotificationType.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/notification/NotificationType.java
@@ -7,5 +7,7 @@ public enum NotificationType {
     /** 自分の投稿にレビューが付いた（投稿者へ） */
     REVIEW_RECEIVED,
     /** 自分のレビューにありがとうが付いた（レビュアーへ） */
-    THANKS_RECEIVED
+    THANKS_RECEIVED,
+    /** レビュー本文・返信で @表示名 で名指しされた（メンションされた人へ） */
+    MENTIONED
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewService.java
@@ -90,6 +90,9 @@ public class ReviewService {
         // F-NOTIF-01：投稿者へ「レビューが付いた」通知（自己レビューは上で弾いている）
         notificationService.notify(post.getAuthorUserId(), principal.userId(),
                 NotificationType.REVIEW_RECEIVED, postId, review.getId());
+        // F-MENTION：レビュー本文（良かった点＋改善点）の @表示名 を同 cohort で解決し通知
+        notificationService.notifyMentions(req.good() + "\n" + req.improvement(),
+                principal.userId(), principal.cohortId(), postId, review.getId());
 
         User reviewer = userRepository.findById(principal.userId()).orElseThrow();
         return ReviewResponse.from(review, reviewer.getDisplayName(), reviewer.getRole(), axisComments);
@@ -219,6 +222,10 @@ public class ReviewService {
         replyRepository.save(reply);
 
         review.setRepliesCount(review.getRepliesCount() + 1); // 非正規化（母 S-3）
+
+        // F-MENTION：返信本文の @表示名 を同 cohort で解決し通知
+        notificationService.notifyMentions(body, principal.userId(), principal.cohortId(),
+                review.getPostId(), reviewId);
 
         User replier = userRepository.findById(principal.userId()).orElseThrow();
         return ReplyResponse.from(reply, replier.getDisplayName());

--- a/review-board/backend/src/main/java/com/reviewboard/domain/user/UserRepository.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/user/UserRepository.java
@@ -2,6 +2,7 @@ package com.reviewboard.domain.user;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -10,4 +11,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     /** cohort 境界での取得（IDOR 防止。プロフィール閲覧は同 cohort のみ） */
     Optional<User> findByIdAndCohortId(Long id, Long cohortId);
+
+    /** メンション解決用：同 cohort の全メンバー（越境メンションを防ぐ） */
+    List<User> findByCohortId(Long cohortId);
 }

--- a/review-board/backend/src/test/java/com/reviewboard/domain/notification/NotificationIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/notification/NotificationIntegrationTest.java
@@ -112,6 +112,39 @@ class NotificationIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(status().isUnauthorized());
     }
 
+    /** F-MENTION：レビュー本文で @表示名 を名指しすると、その人に MENTIONED 通知が届く。 */
+    @Test
+    void mention_in_review_notifies_the_named_member() throws Exception {
+        // reviewer が「author@example.com」の表示名（=メール）を @ で名指し
+        String mention = "@author@example.com 直しました。もう一度見てください";
+        mockMvc.perform(post("/api/posts/" + postId + "/reviews").cookie(login(reviewerEmail))
+                        .contentType("application/json")
+                        .content("{\"good\":\"" + mention + "\",\"improvement\":\"改善\"}"))
+                .andExpect(status().isCreated());
+
+        // author は REVIEW_RECEIVED ＋ MENTIONED の2件（新着順で MENTIONED が後勝ち=先頭）
+        mockMvc.perform(get("/api/notifications").cookie(login(authorEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.type=='MENTIONED')]").isNotEmpty());
+    }
+
+    /** ★越境しない：他 cohort のメンバー名を @ しても、その人には通知されない。 */
+    @Test
+    void mention_does_not_cross_cohort() throws Exception {
+        var cohortB = newCohort("B");
+        String outsider = newUser("outsider@example.com", UserRole.STUDENT, cohortB.getId()).getEmail();
+
+        // reviewer(cohortA) が cohortB の outsider を名指ししても、走査対象は自 cohort のみ
+        mockMvc.perform(post("/api/posts/" + postId + "/reviews").cookie(login(reviewerEmail))
+                        .contentType("application/json")
+                        .content("{\"good\":\"@outsider@example.com 見て\",\"improvement\":\"改善\"}"))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/notifications").cookie(login(outsider)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
     private long createPost(Cookie cookie) throws Exception {
         MvcResult res = mockMvc.perform(post("/api/posts").cookie(cookie)
                         .contentType("application/json").content("{\"title\":\"作品\",\"description\":\"説明\"}"))

--- a/review-board/frontend/src/pages/NotificationsPage.jsx
+++ b/review-board/frontend/src/pages/NotificationsPage.jsx
@@ -6,7 +6,10 @@ import { fetchNotifications, markNotificationRead, markAllNotificationsRead } fr
 const MESSAGE = {
   REVIEW_RECEIVED: (n) => `${n.actorDisplayName} さんがあなたの投稿にレビューしました`,
   THANKS_RECEIVED: (n) => `${n.actorDisplayName} さんがあなたのレビューに「ありがとう」を送りました`,
+  MENTIONED: (n) => `${n.actorDisplayName} さんがあなたを @ で名指ししました`,
 };
+
+const ICON = { THANKS_RECEIVED: '🙏 ', MENTIONED: '💬 ', REVIEW_RECEIVED: '📝 ' };
 
 export default function NotificationsPage() {
   const navigate = useNavigate();
@@ -59,7 +62,7 @@ export default function NotificationsPage() {
               >
                 {!n.read && <span className="mt-1 h-2 w-2 flex-shrink-0 rounded-full bg-blue-500" aria-label="未読" />}
                 <span className="flex-1 text-sm text-gray-700">
-                  {n.type === 'THANKS_RECEIVED' ? '🙏 ' : '📝 '}
+                  {ICON[n.type] ?? '🔔 '}
                   {(MESSAGE[n.type]?.(n)) ?? '新しい通知があります'}
                 </span>
               </button>


### PR DESCRIPTION
## 関連 Issue

Closes #153

---

## 変更の概要

レビュー本文・返信で `@表示名` で同 cohort のメンバーを名指しすると、その人に通知が届く（slack-board F-MENT を移植）。**成長ループ**（再レビュー依頼で「@さん もう一度見て」）を締める。

- `NotificationType.MENTIONED` を追加（直前の F-NOTIF 基盤に相乗り）
- `NotificationService.notifyMentions`：本文の `@表示名` を**同 cohort メンバーのみ**走査して解決し通知
- `ReviewService` のレビュー作成（良かった点＋改善点）・返信作成（本文）でフック
- 自己メンションはスキップ（既存 notify が recipient==actor を弾く）
- 通知センターに「💬 …があなたを @ で名指ししました」を表示

## 重点軸（認可）
- cohort メンバーのみ走査＝**越境メンション不可**
- 通知の閲覧・既読化は受信者本人のみ（既存 F-NOTIF の認可を継承）

## 変更の種別
- [x] feat（新機能の追加）

## 動作確認チェックリスト
- [x] ローカルで動作確認した（Chrome DevTools・コンソールエラーなし）
- [x] 既存の機能が壊れていないことを確認した（backend 全テスト green／frontend lint・build OK）
- [x] `.env` ファイルやパスワードをコミットしていない

### 実機確認（Chrome DevTools）
受講生が講師レビューへの返信で「@講師ティーチャー 修正しました、再確認お願いします」→ 講師の通知センターに「💬 …があなたを @ で名指ししました」（未読）

### 自動テスト（NotificationIntegrationTest 追加）
レビュー本文の @ で名指し→当人に MENTIONED 通知／**★越境しない**（他 cohort 名は通知されない）

---

## レビュー時に特に確認してほしい点
- マッチは表示名の完全一致（`text.contains("@"+displayName)`）。クローズドな少人数 cohort 前提で、表示名衝突時は該当者全員に通知。username 等の一意識別子導入は本実装移行時の検討余地。
- メンションの視覚ハイライト（@名を色付き表示）は今回未実装（通知が主目的）。follow-up 候補。