### PR TITLE
feat: プロフィールアバター画像（見た目の改善）

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/AuthController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/AuthController.java
@@ -4,6 +4,7 @@ import com.reviewboard.domain.auth.dto.LoginRequest;
 import com.reviewboard.domain.auth.dto.UserResponse;
 import com.reviewboard.domain.user.User;
 import com.reviewboard.domain.user.UserRepository;
+import com.reviewboard.storage.StorageService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
@@ -21,11 +22,14 @@ public class AuthController {
     private final AuthService authService;
     private final AuthCookies cookies;
     private final UserRepository userRepository;
+    private final StorageService storageService;
 
-    public AuthController(AuthService authService, AuthCookies cookies, UserRepository userRepository) {
+    public AuthController(AuthService authService, AuthCookies cookies, UserRepository userRepository,
+                          StorageService storageService) {
         this.authService = authService;
         this.cookies = cookies;
         this.userRepository = userRepository;
+        this.storageService = storageService;
     }
 
     /** F-AUTH-01 ログイン */
@@ -35,7 +39,7 @@ public class AuthController {
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, cookies.access(result.accessToken()).toString())
                 .header(HttpHeaders.SET_COOKIE, cookies.refresh(result.refreshToken()).toString())
-                .body(UserResponse.from(result.user()));
+                .body(UserResponse.from(result.user(), storageService.presignedGetUrl(result.user().getAvatarKey())));
     }
 
     /** F-AUTH-(extra) リフレッシュ（access 再発行 + refresh rotation） */
@@ -68,6 +72,6 @@ public class AuthController {
     public UserResponse me(@AuthenticationPrincipal AuthPrincipal principal) {
         User user = userRepository.findById(principal.userId())
                 .orElseThrow(() -> new IllegalStateException("authenticated user not found"));
-        return UserResponse.from(user);
+        return UserResponse.from(user, storageService.presignedGetUrl(user.getAvatarKey()));
     }
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/dto/UserResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/dto/UserResponse.java
@@ -3,10 +3,10 @@ package com.reviewboard.domain.auth.dto;
 import com.reviewboard.domain.user.User;
 import com.reviewboard.domain.user.UserRole;
 
-/** 認証後にフロントへ返す最小ユーザー情報（パスワード等は含めない）。 */
-public record UserResponse(Long id, String displayName, UserRole role, Long cohortId) {
+/** 認証後にフロントへ返す最小ユーザー情報（パスワード等は含めない）。avatarUrl は短命署名URL（null可）。 */
+public record UserResponse(Long id, String displayName, UserRole role, Long cohortId, String avatarUrl) {
 
-    public static UserResponse from(User user) {
-        return new UserResponse(user.getId(), user.getDisplayName(), user.getRole(), user.getCohortId());
+    public static UserResponse from(User user, String avatarUrl) {
+        return new UserResponse(user.getId(), user.getDisplayName(), user.getRole(), user.getCohortId(), avatarUrl);
     }
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/notification/NotificationService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/notification/NotificationService.java
@@ -26,11 +26,14 @@ public class NotificationService {
 
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
+    private final com.reviewboard.storage.StorageService storageService;
 
     public NotificationService(NotificationRepository notificationRepository,
-                               UserRepository userRepository) {
+                               UserRepository userRepository,
+                               com.reviewboard.storage.StorageService storageService) {
         this.notificationRepository = notificationRepository;
         this.userRepository = userRepository;
+        this.storageService = storageService;
     }
 
     /**
@@ -83,7 +86,9 @@ public class NotificationService {
                 .collect(Collectors.toMap(User::getId, Function.identity()));
         return items.stream().map(n -> {
             User actor = actors.get(n.getActorUserId());
-            return NotificationResponse.from(n, actor != null ? actor.getDisplayName() : "(不明)");
+            return NotificationResponse.from(n,
+                    actor != null ? actor.getDisplayName() : "(不明)",
+                    actor != null ? storageService.presignedGetUrl(actor.getAvatarKey()) : null);
         }).toList();
     }
 

--- a/review-board/backend/src/main/java/com/reviewboard/domain/notification/dto/NotificationResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/notification/dto/NotificationResponse.java
@@ -13,14 +13,15 @@ public record NotificationResponse(
         NotificationType type,
         Long actorUserId,
         String actorDisplayName,
+        String actorAvatarUrl,
         Long postId,
         Long reviewId,
         boolean read,
         OffsetDateTime createdAt) {
 
-    public static NotificationResponse from(Notification n, String actorDisplayName) {
+    public static NotificationResponse from(Notification n, String actorDisplayName, String actorAvatarUrl) {
         return new NotificationResponse(
-                n.getId(), n.getType(), n.getActorUserId(), actorDisplayName,
+                n.getId(), n.getType(), n.getActorUserId(), actorDisplayName, actorAvatarUrl,
                 n.getPostId(), n.getReviewId(), n.getReadAt() != null, n.getCreatedAt());
     }
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/profile/ProfileController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/profile/ProfileController.java
@@ -2,9 +2,13 @@ package com.reviewboard.domain.profile;
 
 import com.reviewboard.domain.auth.AuthPrincipal;
 import com.reviewboard.domain.profile.dto.ProfileResponse;
+import com.reviewboard.domain.profile.dto.ProfileUpdateRequest;
+import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -24,5 +28,12 @@ public class ProfileController {
     public ProfileResponse getProfile(@AuthenticationPrincipal AuthPrincipal principal,
                                       @PathVariable Long userId) {
         return profileService.getProfile(principal, userId);
+    }
+
+    /** F-PROF（S-04）プロフィール編集（本人のみ・bio＋アバター）。principal から導出するため他人は編集不可。 */
+    @PutMapping("/api/users/me/profile")
+    public ProfileResponse updateMyProfile(@AuthenticationPrincipal AuthPrincipal principal,
+                                           @Valid @RequestBody ProfileUpdateRequest request) {
+        return profileService.updateOwnProfile(principal, request.bio(), request.avatarKey());
     }
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/profile/ProfileService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/profile/ProfileService.java
@@ -40,13 +40,29 @@ public class ProfileService {
     private final PostRepository postRepository;
     private final ReviewRepository reviewRepository;
     private final EvaluationRepository evaluationRepository;
+    private final com.reviewboard.storage.StorageService storageService;
 
     public ProfileService(UserRepository userRepository, PostRepository postRepository,
-                         ReviewRepository reviewRepository, EvaluationRepository evaluationRepository) {
+                         ReviewRepository reviewRepository, EvaluationRepository evaluationRepository,
+                         com.reviewboard.storage.StorageService storageService) {
         this.userRepository = userRepository;
         this.postRepository = postRepository;
         this.reviewRepository = reviewRepository;
         this.evaluationRepository = evaluationRepository;
+        this.storageService = storageService;
+    }
+
+    /**
+     * F-PROF（S-04）プロフィール編集。★本人のみ（principal から導出するため他人は編集できない）。
+     * bio と avatarKey を更新し、更新後のプロフィールを返す。
+     */
+    @Transactional
+    public ProfileResponse updateOwnProfile(AuthPrincipal principal, String bio, String avatarKey) {
+        User me = userRepository.findById(principal.userId())
+                .orElseThrow(() -> new ResourceNotFoundException("user not found: " + principal.userId()));
+        me.setBio(bio);
+        me.setAvatarKey(avatarKey);
+        return getProfile(principal, principal.userId());
     }
 
     @Transactional(readOnly = true)
@@ -100,6 +116,7 @@ public class ProfileService {
 
         return new ProfileResponse(
                 target.getId(), target.getDisplayName(), target.getRole(), target.getBio(),
+                target.getAvatarKey(), storageService.presignedGetUrl(target.getAvatarKey()),
                 stats, streak, postEntries, received);
     }
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/profile/dto/ProfileResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/profile/dto/ProfileResponse.java
@@ -17,6 +17,8 @@ public record ProfileResponse(
         String displayName,
         UserRole role,
         String bio,
+        String avatarKey,
+        String avatarUrl,
         Stats stats,
         Streak streak,
         List<PostEntry> posts,

--- a/review-board/backend/src/main/java/com/reviewboard/domain/profile/dto/ProfileUpdateRequest.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/profile/dto/ProfileUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.reviewboard.domain.profile.dto;
+
+import jakarta.validation.constraints.Size;
+
+/**
+ * F-PROF（S-04）プロフィール編集リクエスト（本人のみ）。bio・avatarKey とも任意（null・空可）。
+ *
+ * @param bio       自己紹介（最大 500・列に合わせる）
+ * @param avatarKey アバターのアップロード済みオブジェクトキー（null は未設定に戻す）
+ */
+public record ProfileUpdateRequest(
+        @Size(max = 500) String bio,
+        @Size(max = 512) String avatarKey) {
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewService.java
@@ -42,6 +42,7 @@ public class ReviewService {
     private final UserRepository userRepository;
     private final AuditService auditService;
     private final NotificationService notificationService;
+    private final com.reviewboard.storage.StorageService storageService;
 
     public ReviewService(ReviewRepository reviewRepository,
                          ReviewAxisCommentRepository axisCommentRepository,
@@ -50,7 +51,8 @@ public class ReviewService {
                          PostRepository postRepository,
                          UserRepository userRepository,
                          AuditService auditService,
-                         NotificationService notificationService) {
+                         NotificationService notificationService,
+                         com.reviewboard.storage.StorageService storageService) {
         this.reviewRepository = reviewRepository;
         this.axisCommentRepository = axisCommentRepository;
         this.thanksRepository = thanksRepository;
@@ -59,6 +61,7 @@ public class ReviewService {
         this.userRepository = userRepository;
         this.auditService = auditService;
         this.notificationService = notificationService;
+        this.storageService = storageService;
     }
 
     /** F-REV-01 作成。同 cohort の投稿のみ・自己レビュー禁止。 */
@@ -95,7 +98,8 @@ public class ReviewService {
                 principal.userId(), principal.cohortId(), postId, review.getId());
 
         User reviewer = userRepository.findById(principal.userId()).orElseThrow();
-        return ReviewResponse.from(review, reviewer.getDisplayName(), reviewer.getRole(), axisComments);
+        return ReviewResponse.from(review, reviewer.getDisplayName(),
+                storageService.presignedGetUrl(reviewer.getAvatarKey()), reviewer.getRole(), axisComments);
     }
 
     /** F-REV-01/02 一覧。投稿が可視（同 cohort）でなければ 404。reviewer の role を含める。 */
@@ -118,6 +122,7 @@ public class ReviewService {
             User reviewer = reviewers.get(r.getReviewerUserId());
             return ReviewResponse.from(r,
                     reviewer != null ? reviewer.getDisplayName() : "(不明)",
+                    reviewer != null ? storageService.presignedGetUrl(reviewer.getAvatarKey()) : null,
                     reviewer != null ? reviewer.getRole() : null,
                     axisByReview.getOrDefault(r.getId(), List.of()));
         }).toList();
@@ -135,7 +140,8 @@ public class ReviewService {
         List<ReviewAxisComment> axisComments = saveAxisComments(reviewId, req.axisComments());
 
         User reviewer = userRepository.findById(principal.userId()).orElseThrow();
-        return ReviewResponse.from(review, reviewer.getDisplayName(), reviewer.getRole(), axisComments);
+        return ReviewResponse.from(review, reviewer.getDisplayName(),
+                storageService.presignedGetUrl(reviewer.getAvatarKey()), reviewer.getRole(), axisComments);
     }
 
     /** F-REV 論理削除（所有者のみ）。カウンタも戻す。 */
@@ -204,7 +210,8 @@ public class ReviewService {
 
         User reviewer = userRepository.findById(review.getReviewerUserId()).orElseThrow();
         List<ReviewAxisComment> axisComments = axisCommentRepository.findByReviewId(reviewId);
-        return ReviewResponse.from(review, reviewer.getDisplayName(), reviewer.getRole(), axisComments);
+        return ReviewResponse.from(review, reviewer.getDisplayName(),
+                storageService.presignedGetUrl(reviewer.getAvatarKey()), reviewer.getRole(), axisComments);
     }
 
     // ---- F-REV-04 返信（スレッド） ----

--- a/review-board/backend/src/main/java/com/reviewboard/domain/review/dto/ReviewResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/review/dto/ReviewResponse.java
@@ -19,6 +19,7 @@ public record ReviewResponse(
         Long postId,
         Long reviewerUserId,
         String reviewerDisplayName,
+        String reviewerAvatarUrl,
         UserRole reviewerRole,
         boolean teacherReview,
         String good,
@@ -36,11 +37,11 @@ public record ReviewResponse(
         }
     }
 
-    public static ReviewResponse from(Review r, String reviewerDisplayName, UserRole reviewerRole,
-                                      List<ReviewAxisComment> axisComments) {
+    public static ReviewResponse from(Review r, String reviewerDisplayName, String reviewerAvatarUrl,
+                                      UserRole reviewerRole, List<ReviewAxisComment> axisComments) {
         return new ReviewResponse(
                 r.getId(), r.getPostId(), r.getReviewerUserId(),
-                reviewerDisplayName, reviewerRole, reviewerRole == UserRole.TEACHER,
+                reviewerDisplayName, reviewerAvatarUrl, reviewerRole, reviewerRole == UserRole.TEACHER,
                 r.getGood(), r.getImprovement(), r.getThanksCount(), r.getRepliesCount(),
                 r.getGrowthStatus(), r.getBeforeAfter(),
                 axisComments.stream().map(AxisComment::from).toList(),

--- a/review-board/backend/src/main/java/com/reviewboard/domain/user/User.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/user/User.java
@@ -42,6 +42,10 @@ public class User {
     @Column(length = 500)
     private String bio;
 
+    /** プロフィールアバターの S3（MinIO）オブジェクトキー。表示は短命署名URLのみ（SEC-8）。未設定は null。 */
+    @Column(name = "avatar_key", length = 512)
+    private String avatarKey;
+
     // --- 非正規化カウンタ（書き込みと同一Txで増減 + 定期再計算で補正。母 S-3） ---
     @Column(name = "received_reviews_count", nullable = false)
     private int receivedReviewsCount = 0;

--- a/review-board/backend/src/main/resources/db/migration/V7__add_user_avatar.sql
+++ b/review-board/backend/src/main/resources/db/migration/V7__add_user_avatar.sql
@@ -1,0 +1,3 @@
+-- プロフィールアバター画像。SEC-8 と同じ private バケットのオブジェクトキーを保持（本体は DB に置かない）。
+-- 表示は短命の署名付き URL のみ（公開しない）。未設定は NULL。
+ALTER TABLE users ADD COLUMN avatar_key VARCHAR(512);

--- a/review-board/backend/src/test/java/com/reviewboard/domain/profile/ProfileAuthorizationIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/profile/ProfileAuthorizationIntegrationTest.java
@@ -89,6 +89,30 @@ class ProfileAuthorizationIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(status().isUnauthorized());
     }
 
+    /** F-PROF（S-04）プロフィール編集：本人の bio／avatar を更新でき、GET に反映される。 */
+    @Test
+    void owner_can_update_own_profile() throws Exception {
+        mockMvc.perform(put("/api/users/me/profile").cookie(login(authorEmail))
+                        .contentType("application/json")
+                        .content("{\"bio\":\"自己紹介を更新\",\"avatarKey\":null}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.bio").value("自己紹介を更新"))
+                .andExpect(jsonPath("$.userId").value((int) authorId));
+
+        // GET でも反映（principal 由来＝他人を編集する経路は無い）
+        mockMvc.perform(get("/api/users/" + authorId + "/profile").cookie(login(authorEmail)))
+                .andExpect(jsonPath("$.bio").value("自己紹介を更新"));
+    }
+
+    /** ★編集は /me（principal）に限定＝他人の userId を指定する経路が存在しない。未認証は 401。 */
+    @Test
+    void profile_update_requires_auth_returns401() throws Exception {
+        mockMvc.perform(put("/api/users/me/profile")
+                        .contentType("application/json")
+                        .content("{\"bio\":\"x\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
     // ---- helpers ----
 
     private long createPost(Cookie cookie, String title) throws Exception {

--- a/review-board/frontend/src/api/profile.js
+++ b/review-board/frontend/src/api/profile.js
@@ -3,3 +3,7 @@ import client from './client';
 // F-PROF 成長記録（同 cohort のみ閲覧可）
 export const fetchProfile = (userId) =>
   client.get(`/users/${userId}/profile`).then((r) => r.data);
+
+// F-PROF（S-04）プロフィール編集（本人のみ・bio＋avatarKey・backend が principal で本人限定）
+export const updateMyProfile = (data) =>
+  client.put('/users/me/profile', data).then((r) => r.data);

--- a/review-board/frontend/src/components/Avatar.jsx
+++ b/review-board/frontend/src/components/Avatar.jsx
@@ -1,0 +1,29 @@
+// プロフィールアバター。画像があれば丸く表示、無ければ頭文字のプレースホルダ。
+// url は短命の署名付き URL（SEC-8）。サイズは Tailwind クラスで指定。
+const SIZES = {
+  sm: 'h-6 w-6 text-xs',
+  md: 'h-9 w-9 text-sm',
+  lg: 'h-20 w-20 text-2xl',
+};
+
+export default function Avatar({ url, name = '', size = 'md', className = '' }) {
+  const dim = SIZES[size] ?? SIZES.md;
+  const initial = name.trim().charAt(0) || '?';
+  if (url) {
+    return (
+      <img
+        src={url}
+        alt={name ? `${name} のアバター` : 'アバター'}
+        className={`${dim} flex-shrink-0 rounded-full object-cover ${className}`}
+      />
+    );
+  }
+  return (
+    <span
+      aria-hidden="true"
+      className={`${dim} flex flex-shrink-0 items-center justify-center rounded-full bg-gray-200 font-medium text-gray-500 ${className}`}
+    >
+      {initial}
+    </span>
+  );
+}

--- a/review-board/frontend/src/components/Header.jsx
+++ b/review-board/frontend/src/components/Header.jsx
@@ -3,6 +3,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { ROLE_LABEL } from '../constants';
 import { fetchUnreadCount } from '../api/notifications';
+import Avatar from './Avatar';
 
 // F-NOTIF-01：未読通知数のポーリング間隔（WebSocket は使わない）。
 const POLL_MS = 30000;
@@ -44,9 +45,10 @@ export default function Header() {
               </span>
             )}
           </Link>
-          <span className="text-gray-600">
+          <span className="flex items-center gap-2 text-gray-600">
+            <Avatar url={user.avatarUrl} name={user.displayName} size="sm" />
             {user.displayName}
-            <span className="ml-2 rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-500">
+            <span className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-500">
               {ROLE_LABEL[user.role] ?? user.role}
             </span>
           </span>

--- a/review-board/frontend/src/components/ReviewItem.jsx
+++ b/review-board/frontend/src/components/ReviewItem.jsx
@@ -4,6 +4,7 @@ import { AXIS_LABEL, GROWTH_OPTIONS, GROWTH_MAP } from '../constants';
 import { sendThanks, updateReview, deleteReview, fetchReplies, createReply, deleteReply, updateReviewGrowth } from '../api/reviews';
 import { useAuth } from '../context/AuthContext';
 import MarkdownText from './MarkdownText';
+import Avatar from './Avatar';
 
 // 1 件のレビュー表示。講師レビューは特別表示（F-REV-02）。
 // 投稿者には「ありがとう」（F-REV-03）、レビュー所有者には編集/削除を出す（権限は backend が判定）。
@@ -121,6 +122,7 @@ export default function ReviewItem({ review, canThank, canManageGrowth, isOwner,
   return (
     <li className={`rounded-lg border p-4 ${isBest ? 'border-yellow-400 bg-yellow-50' : review.teacherReview ? 'border-amber-300 bg-amber-50' : 'border-gray-200 bg-white'}`}>
       <div className="mb-2 flex items-center gap-2 text-sm">
+        <Avatar url={review.reviewerAvatarUrl} name={review.reviewerDisplayName} size="sm" />
         <Link to={`/users/${review.reviewerUserId}/profile`} className="font-medium text-gray-800 hover:underline">
           {review.reviewerDisplayName}
         </Link>

--- a/review-board/frontend/src/pages/NotificationsPage.jsx
+++ b/review-board/frontend/src/pages/NotificationsPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { fetchNotifications, markNotificationRead, markAllNotificationsRead } from '../api/notifications';
+import Avatar from '../components/Avatar';
 
 // F-NOTIF-01 通知センター（S-03）。新着順に並べ、クリックで既読化＋該当投稿へ遷移。
 const MESSAGE = {
@@ -61,6 +62,7 @@ export default function NotificationsPage() {
                 className={`flex w-full items-start gap-3 rounded-lg border p-4 text-left hover:border-blue-300 ${n.read ? 'border-gray-200 bg-white' : 'border-blue-200 bg-blue-50'}`}
               >
                 {!n.read && <span className="mt-1 h-2 w-2 flex-shrink-0 rounded-full bg-blue-500" aria-label="未読" />}
+                <Avatar url={n.actorAvatarUrl} name={n.actorDisplayName} size="sm" />
                 <span className="flex-1 text-sm text-gray-700">
                   {ICON[n.type] ?? '🔔 '}
                   {(MESSAGE[n.type]?.(n)) ?? '新しい通知があります'}

--- a/review-board/frontend/src/pages/ProfilePage.jsx
+++ b/review-board/frontend/src/pages/ProfilePage.jsx
@@ -1,17 +1,23 @@
 import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { fetchProfile } from '../api/profile';
+import { fetchProfile, updateMyProfile } from '../api/profile';
 import { ROLE_LABEL, EVAL_LABEL } from '../constants';
+import { useAuth } from '../context/AuthContext';
+import Avatar from '../components/Avatar';
+import ScreenshotUploader from '../components/ScreenshotUploader';
 
-// F-PROF：成長記録ページ（本アプリの主役）。投稿履歴・もらったレビュー・実績・合格バッジ。
+// F-PROF：成長記録ページ（本アプリの主役）。投稿履歴・もらったレビュー・実績・合格バッジ・継続。
 export default function ProfilePage() {
   const { id } = useParams();
+  const { user } = useAuth();
   const [profile, setProfile] = useState(null);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(true);
+  const [editing, setEditing] = useState(false);
 
   useEffect(() => {
     setLoading(true);
+    setEditing(false);
     fetchProfile(id)
       .then(setProfile)
       .catch((e) => setError(e.response?.status === 404 ? 'この成長記録は閲覧できません' : '取得に失敗しました'))
@@ -21,20 +27,36 @@ export default function ProfilePage() {
   if (loading) return <p className="p-6 text-gray-500">読み込み中…</p>;
   if (error) return <p className="p-6 text-red-600">{error}</p>;
 
-  const { displayName, role, stats, streak, posts, receivedReviews } = profile;
+  const { displayName, role, bio, avatarUrl, stats, streak, posts, receivedReviews } = profile;
+  const isOwn = user?.id === profile.userId;
 
   return (
     <main className="mx-auto max-w-3xl space-y-6 p-6">
       <header className="rounded-lg border border-gray-200 bg-white p-6">
-        <h2 className="text-xl font-bold text-gray-800">
-          {displayName}
-          <span className="ml-2 rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-500">{ROLE_LABEL[role] ?? role}</span>
-        </h2>
-        <div className="mt-4 grid grid-cols-3 gap-4 text-center">
-          <Stat label="もらったレビュー" value={stats.receivedReviewsCount} />
-          <Stat label="したレビュー" value={stats.givenReviewsCount} />
-          <Stat label="もらった🙏" value={stats.thanksReceivedCount} />
-        </div>
+        {editing ? (
+          <ProfileEditor profile={profile} onSaved={(p) => { setProfile(p); setEditing(false); }} onCancel={() => setEditing(false)} />
+        ) : (
+          <>
+            <div className="flex items-start gap-4">
+              <Avatar url={avatarUrl} name={displayName} size="lg" />
+              <div className="flex-1">
+                <h2 className="text-xl font-bold text-gray-800">
+                  {displayName}
+                  <span className="ml-2 rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-500">{ROLE_LABEL[role] ?? role}</span>
+                </h2>
+                {bio && <p className="mt-1 whitespace-pre-wrap text-sm text-gray-600">{bio}</p>}
+              </div>
+              {isOwn && (
+                <button onClick={() => setEditing(true)} className="text-sm text-blue-600 hover:underline">プロフィール編集</button>
+              )}
+            </div>
+            <div className="mt-4 grid grid-cols-3 gap-4 text-center">
+              <Stat label="もらったレビュー" value={stats.receivedReviewsCount} />
+              <Stat label="したレビュー" value={stats.givenReviewsCount} />
+              <Stat label="もらった🙏" value={stats.thanksReceivedCount} />
+            </div>
+          </>
+        )}
       </header>
 
       {streak && <StreakCard streak={streak} />}
@@ -77,6 +99,57 @@ export default function ProfilePage() {
         )}
       </section>
     </main>
+  );
+}
+
+// F-PROF（S-04）プロフィール編集：アバター差し替え＋自己紹介。本人のみ（backend が principal で限定）。
+// avatarKey は現在値を初期値に持ち、差し替え時のみ更新。bio＋avatarKey を常に送って全置換する
+// （送らないと backend が null 扱いで既存アバターを消すため）。
+function ProfileEditor({ profile, onSaved, onCancel }) {
+  const [bio, setBio] = useState(profile.bio ?? '');
+  const [avatarKey, setAvatarKey] = useState(profile.avatarKey ?? null);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState('');
+
+  const save = async () => {
+    setBusy(true);
+    setErr('');
+    try {
+      const updated = await updateMyProfile({ bio: bio || null, avatarKey });
+      onSaved(updated);
+    } catch {
+      setErr('保存に失敗しました');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <h2 className="font-bold text-gray-800">プロフィール編集</h2>
+      {err && <p className="rounded bg-red-50 px-3 py-2 text-sm text-red-600">{err}</p>}
+      <div className="flex items-start gap-4">
+        <Avatar url={profile.avatarUrl} name={profile.displayName} size="lg" />
+        <div className="flex-1">
+          <p className="mb-1 text-sm text-gray-600">アバター画像（PNG/JPEG/WebP・5MB まで）</p>
+          <ScreenshotUploader initialUrl={profile.avatarUrl ?? ''} onChange={(key) => setAvatarKey(key)} />
+        </div>
+      </div>
+      <label className="block text-sm text-gray-600">自己紹介</label>
+      <textarea
+        value={bio}
+        onChange={(e) => setBio(e.target.value)}
+        rows={3}
+        maxLength={500}
+        className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+      />
+      <div className="flex gap-2">
+        <button onClick={save} disabled={busy} className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50">
+          {busy ? '保存中…' : '保存'}
+        </button>
+        <button onClick={onCancel} className="rounded border border-gray-300 px-4 py-2 text-sm text-gray-600 hover:bg-gray-50">キャンセル</button>
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## 関連 Issue

Closes #155

---

## 変更の概要

ユーザーがプロフィールにアバター画像を設定でき、**ヘッダー・レビュー・通知・成長記録**に丸アイコンで表示する（sns/slack F-USER-02 を移植）。SEC-8 のアップロード基盤を再利用。

- `users.avatar_key`（V7）。SEC-8 と同じ **private バケット＋magic byte 検証＋短命署名URL**（既存 `/api/uploads` を再利用）
- **プロフィール編集** `PUT /api/users/me/profile`（★本人のみ・bio＋avatarKey）→ 未実装だった **S-04 プロフィール編集**も同時に充足
- `avatarUrl`（署名URL・null可）を UserResponse(/me)・ProfileResponse・ReviewResponse・NotificationResponse に追加
- ProfileResponse は `avatarKey` も返す（PostResponse が screenshotKey を返すのと同様）→ bio だけ編集時も既存アバターを保つ全置換編集
- フロント：`Avatar`（画像 or 頭文字フォールバック）、プロフィール編集UI、ヘッダー/レビュー/通知に表示

## 重点軸（認可）
- プロフィール編集は **principal から導出＝本人のみ**（他人の userId を指定する経路が無い）
- アバターは private バケット・署名URLのみ公開（SEC-8 継承）

## 変更の種別
- [x] feat（新機能の追加）

## 動作確認チェックリスト
- [x] ローカルで動作確認した（Chrome DevTools・コンソールエラーなし）
- [x] 既存の機能が壊れていないことを確認した（backend 全テスト green／frontend lint・build OK／V7 migration 適用 v6→v7）
- [x] `.env` ファイルやパスワードをコミットしていない

### 実機確認（Chrome DevTools）
プロフィール編集でアバター画像アップロード＋自己紹介を保存 → プロフィール本体・**ヘッダー両方にアバター表示**、リロード後も保持（署名URL再生成）

### 自動テスト
`ProfileAuthorizationIntegrationTest`：本人の bio／avatar 更新が GET に反映／未認証 PUT は 401

---

## レビュー時に特に確認してほしい点
- avatar の表示は SEC-8 と同じ「private 保存＋短命署名URL」モデルを踏襲（公開バケットにしない）。
- 投稿一覧カードは著者名を表示していないため、今回アバターは載せず follow-up とした。
- 成長記録の「もらったレビュー」一覧は本文がプレーン表示のまま（マークダウン描画は PR #152 で投稿詳細のレビューに適用済み・プロフィール側は follow-up）。