### PR TITLE
style: ヘッダーの通知ベルの位置・サイズをアバターに揃える

### DIFF
--- a/review-board/frontend/src/components/Header.jsx
+++ b/review-board/frontend/src/components/Header.jsx
@@ -38,7 +38,7 @@ export default function Header() {
       {user && (
         <div className="flex items-center gap-4 text-sm">
           <Link to="/notifications" className="relative text-gray-600 hover:text-gray-900" aria-label={`通知${unread > 0 ? `（未読 ${unread} 件）` : ''}`}>
-            <span className="text-lg">🔔</span>
+            <span className="relative top-1 inline-block text-xl leading-none">🔔</span>
             {unread > 0 && (
               <span className="absolute -right-2 -top-1 rounded-full bg-red-500 px-1.5 text-xs font-bold text-white">
                 {unread > 99 ? '99+' : unread}


### PR DESCRIPTION
## 関連 Issue

Closes #157

---

## 変更の概要

ヘッダーの通知ベル🔔がアバターより上に見え、サイズも小さかったため、縦位置とサイズを調整。

- 位置：`relative top-1` でアバター中心に揃える
- サイズ：`text-lg` → `text-xl`（アバターよりやや小さいバランス）

機能・挙動の変更なし（表示のみ）。

## 変更の種別
- [x] style（動作に影響しない変更：フォーマット等）

## 動作確認チェックリスト
- [x] ローカルで動作確認した（Chrome DevTools・ベルとアバターの縦位置/サイズが整列）
- [x] 既存の機能が壊れていないことを確認した（表示のみの変更）
- [x] `.env` ファイルやパスワードをコミットしていない