### PR TITLE
feat: 通知イベントの拡充（評価結果・返信・再レビュー依頼・ベスト選択）

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/domain/evaluation/EvaluationService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/evaluation/EvaluationService.java
@@ -6,6 +6,8 @@ import com.reviewboard.domain.audit.AuditService;
 import com.reviewboard.domain.audit.AuditTargetType;
 import com.reviewboard.domain.auth.AuthPrincipal;
 import com.reviewboard.domain.evaluation.dto.EvaluationRequest;
+import com.reviewboard.domain.notification.NotificationService;
+import com.reviewboard.domain.notification.NotificationType;
 import com.reviewboard.domain.post.Post;
 import com.reviewboard.domain.post.PostRepository;
 import org.springframework.stereotype.Service;
@@ -25,12 +27,14 @@ public class EvaluationService {
     private final EvaluationRepository evaluationRepository;
     private final PostRepository postRepository;
     private final AuditService auditService;
+    private final NotificationService notificationService;
 
     public EvaluationService(EvaluationRepository evaluationRepository, PostRepository postRepository,
-                             AuditService auditService) {
+                             AuditService auditService, NotificationService notificationService) {
         this.evaluationRepository = evaluationRepository;
         this.postRepository = postRepository;
         this.auditService = auditService;
+        this.notificationService = notificationService;
     }
 
     /**
@@ -57,6 +61,10 @@ public class EvaluationService {
         AuditAction action = req.result() == EvaluationResult.APPROVED
                 ? AuditAction.EVALUATION_APPROVED : AuditAction.EVALUATION_RETURNED;
         auditService.record(principal, action, AuditTargetType.EVALUATION, eval.getId());
+
+        // 投稿者へ「評価結果が付いた」通知（自己評価は通常起きないが notify が recipient==actor をスキップ）
+        notificationService.notify(post.getAuthorUserId(), principal.userId(),
+                NotificationType.EVALUATION_RESULT, post.getId(), null);
         return eval;
     }
 

--- a/review-board/backend/src/main/java/com/reviewboard/domain/notification/NotificationType.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/notification/NotificationType.java
@@ -9,5 +9,13 @@ public enum NotificationType {
     /** 自分のレビューにありがとうが付いた（レビュアーへ） */
     THANKS_RECEIVED,
     /** レビュー本文・返信で @表示名 で名指しされた（メンションされた人へ） */
-    MENTIONED
+    MENTIONED,
+    /** 自分の投稿に講師の評価（合格/差し戻し）が付いた（投稿者へ） */
+    EVALUATION_RESULT,
+    /** 自分のレビューに返信が付いた（レビュアーへ） */
+    REPLY_RECEIVED,
+    /** 投稿者が対応状態を「再レビュー依頼」にした（レビュアーへ） */
+    RE_REVIEW_REQUESTED,
+    /** 自分のレビューがベストレビューに選ばれた（レビュアーへ） */
+    BEST_REVIEW_SELECTED
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/PostService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/PostService.java
@@ -32,12 +32,15 @@ public class PostService {
     private final PostRepository postRepository;
     private final ReviewRepository reviewRepository;
     private final AuditService auditService;
+    private final com.reviewboard.domain.notification.NotificationService notificationService;
 
     public PostService(PostRepository postRepository, ReviewRepository reviewRepository,
-                       AuditService auditService) {
+                       AuditService auditService,
+                       com.reviewboard.domain.notification.NotificationService notificationService) {
         this.postRepository = postRepository;
         this.reviewRepository = reviewRepository;
         this.auditService = auditService;
+        this.notificationService = notificationService;
     }
 
     /** F-POST-01 作成。cohort と author は principal（検証済み）から導出する。 */
@@ -117,6 +120,10 @@ public class PostService {
         }
         post.setBestReviewId(reviewId);
         post.setUpdatedAt(OffsetDateTime.now());
+        // ベストに選ばれたレビュアーへ通知（自分のレビューを選ぶことは自己レビュー禁止により起きない）
+        notificationService.notify(review.getReviewerUserId(), principal.userId(),
+                com.reviewboard.domain.notification.NotificationType.BEST_REVIEW_SELECTED,
+                postId, reviewId);
         return post;
     }
 

--- a/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewService.java
@@ -208,6 +208,12 @@ public class ReviewService {
         review.setUpdatedAt(OffsetDateTime.now());
         auditService.record(principal, AuditAction.REVIEW_GROWTH_UPDATED, AuditTargetType.REVIEW, reviewId);
 
+        // 「再レビュー依頼」に切り替えたら、レビュアーへ通知して成長ループを締める
+        if (status == GrowthStatus.RE_REVIEW_REQUESTED) {
+            notificationService.notify(review.getReviewerUserId(), principal.userId(),
+                    NotificationType.RE_REVIEW_REQUESTED, review.getPostId(), reviewId);
+        }
+
         User reviewer = userRepository.findById(review.getReviewerUserId()).orElseThrow();
         List<ReviewAxisComment> axisComments = axisCommentRepository.findByReviewId(reviewId);
         return ReviewResponse.from(review, reviewer.getDisplayName(),
@@ -230,6 +236,9 @@ public class ReviewService {
 
         review.setRepliesCount(review.getRepliesCount() + 1); // 非正規化（母 S-3）
 
+        // レビュアー本人へ「返信が付いた」通知（自己返信は notify がスキップ）
+        notificationService.notify(review.getReviewerUserId(), principal.userId(),
+                NotificationType.REPLY_RECEIVED, review.getPostId(), reviewId);
         // F-MENTION：返信本文の @表示名 を同 cohort で解決し通知
         notificationService.notifyMentions(body, principal.userId(), principal.cohortId(),
                 review.getPostId(), reviewId);

--- a/review-board/backend/src/test/java/com/reviewboard/domain/notification/NotificationIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/notification/NotificationIntegrationTest.java
@@ -9,6 +9,7 @@ import org.springframework.test.web.servlet.MvcResult;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -143,6 +144,58 @@ class NotificationIntegrationTest extends AbstractIntegrationTest {
         mockMvc.perform(get("/api/notifications").cookie(login(outsider)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    /** 講師の評価で投稿者に EVALUATION_RESULT 通知が届く。 */
+    @Test
+    void evaluation_notifies_post_author() throws Exception {
+        var cohort = cohortRepository.findAll().iterator().next();
+        String teacher = newUser("teacher@example.com", UserRole.TEACHER, cohort.getId()).getEmail();
+        mockMvc.perform(post("/api/posts/" + postId + "/evaluation").cookie(login(teacher))
+                        .contentType("application/json")
+                        .content("{\"result\":\"APPROVED\",\"comment\":\"合格です\"}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/notifications").cookie(login(authorEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.type=='EVALUATION_RESULT')]").isNotEmpty());
+    }
+
+    /** レビューへの返信で、レビュー主（reviewer）に REPLY_RECEIVED 通知が届く。 */
+    @Test
+    void reply_notifies_review_owner() throws Exception {
+        mockMvc.perform(post("/api/reviews/" + reviewId + "/replies").cookie(login(authorEmail))
+                        .contentType("application/json").content("{\"body\":\"ありがとうございます\"}"))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/notifications").cookie(login(reviewerEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.type=='REPLY_RECEIVED')]").isNotEmpty());
+    }
+
+    /** 対応状態を「再レビュー依頼」にすると、レビュアーに RE_REVIEW_REQUESTED 通知が届く。 */
+    @Test
+    void re_review_request_notifies_reviewer() throws Exception {
+        mockMvc.perform(put("/api/reviews/" + reviewId + "/growth").cookie(login(authorEmail))
+                        .contentType("application/json")
+                        .content("{\"status\":\"RE_REVIEW_REQUESTED\",\"beforeAfter\":\"直しました\"}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/notifications").cookie(login(reviewerEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.type=='RE_REVIEW_REQUESTED')]").isNotEmpty());
+    }
+
+    /** ベストレビュー選択で、選ばれたレビュアーに BEST_REVIEW_SELECTED 通知が届く。 */
+    @Test
+    void best_review_notifies_reviewer() throws Exception {
+        mockMvc.perform(put("/api/posts/" + postId + "/best-review").cookie(login(authorEmail))
+                        .contentType("application/json").content("{\"reviewId\":" + reviewId + "}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/notifications").cookie(login(reviewerEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.type=='BEST_REVIEW_SELECTED')]").isNotEmpty());
     }
 
     private long createPost(Cookie cookie) throws Exception {

--- a/review-board/frontend/src/pages/NotificationsPage.jsx
+++ b/review-board/frontend/src/pages/NotificationsPage.jsx
@@ -8,9 +8,21 @@ const MESSAGE = {
   REVIEW_RECEIVED: (n) => `${n.actorDisplayName} さんがあなたの投稿にレビューしました`,
   THANKS_RECEIVED: (n) => `${n.actorDisplayName} さんがあなたのレビューに「ありがとう」を送りました`,
   MENTIONED: (n) => `${n.actorDisplayName} さんがあなたを @ で名指ししました`,
+  EVALUATION_RESULT: (n) => `${n.actorDisplayName} さんがあなたの投稿を評価しました`,
+  REPLY_RECEIVED: (n) => `${n.actorDisplayName} さんがあなたのレビューに返信しました`,
+  RE_REVIEW_REQUESTED: (n) => `${n.actorDisplayName} さんが再レビューを依頼しました`,
+  BEST_REVIEW_SELECTED: (n) => `${n.actorDisplayName} さんがあなたのレビューをベストに選びました`,
 };
 
-const ICON = { THANKS_RECEIVED: '🙏 ', MENTIONED: '💬 ', REVIEW_RECEIVED: '📝 ' };
+const ICON = {
+  THANKS_RECEIVED: '🙏 ',
+  MENTIONED: '💬 ',
+  REVIEW_RECEIVED: '📝 ',
+  EVALUATION_RESULT: '🏅 ',
+  REPLY_RECEIVED: '↩️ ',
+  RE_REVIEW_REQUESTED: '🔁 ',
+  BEST_REVIEW_SELECTED: '⭐ ',
+};
 
 export default function NotificationsPage() {
   const navigate = useNavigate();


### PR DESCRIPTION
## 関連 Issue

Closes #159

---

## 変更の概要

既存機能はあるのに通知が鳴らず「気づけない」結線の穴を埋め、成長ループの完成度を上げる（企業導入に向けた品質向上）。

追加した通知イベント（既存 F-NOTIF 基盤に相乗り）：
- **EVALUATION_RESULT**：講師が評価（合格/差し戻し）→ 投稿者へ
- **REPLY_RECEIVED**：自分のレビューに返信が付いた → レビュアーへ
- **RE_REVIEW_REQUESTED**：投稿者が対応状態を「再レビュー依頼」に → レビュアーへ
- **BEST_REVIEW_SELECTED**：ベストレビューに選ばれた → レビュアーへ

フック：`EvaluationService.evaluate` / `ReviewService.createReply` / `ReviewService.updateGrowth`（RE_REVIEW_REQUESTED時）/ `PostService.selectBestReview`。EvaluationService・PostService に NotificationService を注入。自己通知は既存 `notify(recipient==actor)` でスキップ。

## 重点軸
- 受信者本人のみ可視（既存 F-NOTIF の認可を継承）。新規エンドポイントなし。

## 変更の種別
- [x] feat（新機能の追加）

## 動作確認チェックリスト
- [x] ローカルで動作確認した（Chrome DevTools・コンソールエラーなし）
- [x] 既存の機能が壊れていないことを確認した（backend 全テスト green／frontend lint・build OK）
- [x] `.env` ファイルやパスワードをコミットしていない

### 実機確認（Chrome DevTools）
講師が投稿を評価 → 投稿者（受講生）の通知センターに「🏅 …があなたの投稿を評価しました」（未読）が表示。

### 自動テスト（NotificationIntegrationTest 追加）
評価→投稿者に EVALUATION_RESULT／返信→レビュアーに REPLY_RECEIVED／再レビュー依頼→レビュアーに RE_REVIEW_REQUESTED／ベスト選択→レビュアーに BEST_REVIEW_SELECTED

---

## 補足（環境メモ）
本実装中に iCloud デスクトップ同期由来のビルド残骸（重複 .class）でテストが一時失敗しましたが、`gradlew clean` で解消。ソースに重複は無く、影響はビルド成果物のみでした。