### PR TITLE
feat: 機密情報スキャンの多層防御（gitleaks: pre-commit + CI + 低エントロピー検知）を導入

### DIFF
--- a/.github/workflows/review-board-gitleaks.yml
+++ b/.github/workflows/review-board-gitleaks.yml
@@ -1,0 +1,73 @@
+name: review-board Secret Scan (gitleaks / S軸)
+
+# ============================================================
+# 機密情報の server-side スキャン（最後の防衛線）。
+#
+# 目的: ローカル pre-commit hook では防げないバイパス経路
+#       （GitHub Web 編集 / `git commit --no-verify`）を塞ぐ。
+# 背景: task-board で起きた application.yml への平文パスワード Public
+#       コミット事故（不可逆事故）と同型の再発を防ぐ。S軸（セキュリティ）の核。
+#
+# 方式: バージョン固定の gitleaks バイナリで review-board ツリーを走査。
+#       設定はリポジトリルートの .gitleaks.toml（デフォルトルール ＋
+#       低エントロピー password リテラル検知）。検知で fail。
+#
+# スコープ: 既存 review-board-* workflow 慣習に合わせ review-board/ に限定
+#          （他学習プロジェクトのノイズを排除）。ローカル防御は
+#          .pre-commit-config.yaml が repo 全体の staged 差分を担保。
+# ============================================================
+
+on:
+  pull_request:
+    paths:
+      - 'review-board/**'
+      - '.gitleaks.toml'
+      - '.github/workflows/review-board-gitleaks.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'review-board/**'
+      - '.gitleaks.toml'
+      - '.github/workflows/review-board-gitleaks.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: rb-gitleaks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  secret-scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    env:
+      GITLEAKS_VERSION: 8.30.1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: gitleaks をインストール（バージョン固定）
+        run: |
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /tmp gitleaks
+          sudo install /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: review-board を機密情報スキャン
+        run: |
+          # 検知時は gitleaks が exit 1 → step が fail。設定は repo ルートの .gitleaks.toml。
+          gitleaks dir review-board \
+            --config .gitleaks.toml \
+            --report-path gitleaks-report.json \
+            --report-format json \
+            --redact \
+            --verbose
+
+      - name: 検出レポートを artifact 化（失敗時のみ）
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gitleaks-report
+          path: gitleaks-report.json
+          retention-days: 7

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,107 @@
+# ============================================
+# .gitleaks.toml — gitleaks カスタムルール（hideharu-AI monorepo）
+# ============================================
+# 目的: gitleaks のデフォルトルールはエントロピーベースのため、低エントロピー secret
+#       （弱パスワード・短い単語・デフォルト値）を検知できない。これは task-board で
+#       起きた平文パスワード Public 流出事故（`password: taskboard` 同型）が再発しうる
+#       ことを意味する。本ファイルは低エントロピーパターンを追加検知する。
+#
+# 動作:
+#   - gitleaks がリポジトリルートの .gitleaks.toml を自動読み込み
+#   - extend.useDefault = true でデフォルトルールも維持
+#   - common-password-pattern ルールでキーワードベース検知を追加
+#   - allowlist で env 参照・テンプレ値・ローカル開発専用の既知 dev 値を除外
+#
+# 関連:
+#   - .pre-commit-config.yaml: ローカル commit 時に発火
+#   - .github/workflows/gitleaks.yml: server-side（push / PR）発火 ← 最後の防衛線
+#   - 出所: recipe-board の実績設定を本 monorepo 向けに移植（Issue #166）
+# ============================================
+
+[extend]
+useDefault = true
+
+# ============================================
+# カスタムルール: 低エントロピーパスワード検知
+# ============================================
+[[rules]]
+id = "common-password-pattern"
+description = "Low-entropy secret assigned as a QUOTED string literal (e.g. `password: \"taskboard\"`). Targets the task-board plaintext-credential incident class without matching code identifiers (`= var;`) or env refs (`${VAR}`)."
+# 値が「引用符で囲まれたリテラル」の場合のみ検知。
+#  ✅ password: "taskboard" / api_key = 'abc123'        ← 平文 secret リテラル
+#  ❌ String token = readAccessCookie(request);          ← 引用符なし（コード識別子）
+#  ❌ this.seedPassword = seedPassword;                  ← 引用符なし
+#  ❌ password: ${DB_PASSWORD}                            ← env 参照（allowlist でも除外）
+# 値先頭の [^"'$] で env 参照 ${...} を除外、{3,} で極端に短い値を除外。
+regex = '''(?i)(password|passwd|pwd|secret|api[_-]?key)["']?\s*[:=]\s*["'][^"'$\n]{3,}["']'''
+keywords = ["password", "passwd", "secret", "api_key", "api-key"]
+
+# このルールに対する allowlist（誤検知を抑制）
+# ※ paths はこの custom ルールのみに適用。gitleaks デフォルトの高エントロピー
+#    ルール（AWS キー等）は test/docs を含め全ファイルを走査し続ける（取りこぼし防止）。
+[rules.allowlist]
+regexTarget = "line"
+paths = [
+    '''.*src/test/.*''',      # JUnit テスト（偽 secret fixture）
+    '''.*Test\.java$''',
+    '''.*_test\.[a-z]+$''',   # *_test.rb / *_test.js 等
+    '''.*_spec\.[a-z]+$''',
+    '''.*/test/.*''',
+    '''.*/spec/.*''',
+    '''.*/e2e/.*''',          # E2E の偽資格情報
+    '''.*\.md$''',            # ドキュメントの例示（高エントロピールールは .md も走査継続）
+    '''.*\.example$''',       # .env.example / tfvars.example
+    '''.*/prototype/.*''',
+]
+regexes = [
+    # テンプレートプレースホルダー
+    '''CHANGE_ME''',
+    '''YOUR_[A-Z_]+''',
+    '''<[A-Z_]+>''',
+    '''XXX+''',
+    '''placeholder''',
+    '''example''',
+    '''dummy''',
+
+    # 環境変数参照（値ではなく参照）
+    '''\$\{[A-Z_a-z]+\}''',
+    '''\$ENV\[''',
+    '''ENV\[''',
+    '''process\.env\.''',
+    '''import\.meta\.env\.''',
+    '''System\.getenv''',
+    '''getenv\(''',
+    '''\$\{?[A-Z_]+_PASSWORD''',
+    '''\$\{?[A-Z_]+_SECRET''',
+
+    # Spring の property プレースホルダー（${VAR} / ${VAR:default}）
+    '''\$\{[a-zA-Z0-9_.]+(:[^}]*)?\}''',
+
+    # Terraform 変数参照（値ではなく参照）
+    '''\bvar\.[a-z_]+''',
+    '''data\.aws_ssm_parameter''',
+    '''aws_ssm_parameter''',
+
+    # ローカル開発専用の既知 dev 値（本番未使用・docker-compose / dev 起動手順 / docs に出現）
+    '''localtest''',          # dev DATABASE_PASSWORD
+    '''devpass12345''',       # dev SEED_PASSWORD（seed 専用）
+    '''minioadmin''',         # ローカル MinIO（S3 互換）既定資格情報
+    '''devsecret''',
+    '''local-?dev''',
+
+    # GitHub Actions の permission ディレクティブ（token: write 等は permission 名で機密ではない）
+    '''\b(id-token|packages|actions|checks|contents|deployments|issues|discussions|pages|pull-requests|repository-projects|security-events|statuses|attestations|models|metadata|environments):\s*(read|write|none)\b''',
+
+    # コメント・ドキュメント行頭
+    '''^\s*#''',
+    '''^\s*//''',
+    '''^\s*\*''',
+    '''^\s*-\s''',
+
+    # テストファイル（テスト中の偽 secret は許容）
+    '''test/''',
+    '''spec/''',
+    '''_test\.''',
+    '''_spec\.''',
+    '''Test\.java''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,45 @@
+# ============================================
+# .pre-commit-config.yaml — ローカル commit 時の機密情報ブロック
+# ============================================
+# 目的: パスワード・API キー・トークン等の誤コミットを commit 時点で自動ブロック。
+# 経緯: task-board で application.yml に DB パスワードを平文ハードコードして Public
+#       リポジトリに push した不可逆事故が発生。再発防止の第一防衛線（最後の砦は
+#       .github/workflows/review-board-gitleaks.yml の server-side スキャン）。
+#
+# 導入手順（任意・各開発者のローカル）:
+#   1. brew install pre-commit gitleaks
+#   2. pre-commit install        # リポジトリにフックを登録
+#   3. 以後、git commit 時に自動でスキャンが走る
+#
+# 緊急時の脱出口（誤検知の場合のみ・通常は使わない）:
+#   git commit --no-verify       # フックをバイパス（bypass 内容は別途レビュー必須）
+#
+# 設定: 機密検知ルールはリポジトリルートの .gitleaks.toml を参照。
+# CLAUDE.md §12-4 デプロイ前監査チェックリストと連動。
+# ============================================
+
+repos:
+  # gitleaks: 機密情報スキャン（staged 差分・.gitleaks.toml 準拠）
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.4
+    hooks:
+      - id: gitleaks
+        name: gitleaks（機密情報スキャン）
+        description: パスワード・API キー・トークン等の誤コミットを検知
+
+  # 標準的なファイルチェック
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+        name: 行末空白の削除
+      - id: end-of-file-fixer
+        name: ファイル末尾の改行確認
+      - id: check-yaml
+        name: YAML 構文チェック
+        args: ['--allow-multiple-documents']
+      - id: check-merge-conflict
+        name: マージコンフリクトマーカーの検知
+      - id: check-added-large-files
+        name: 大きすぎるファイルの検知
+        args: ['--maxkb=500']


### PR DESCRIPTION
## 関連 Issue

Closes #166

---

## 変更の概要

平文 secret の Public コミット（task-board 同型の**不可逆事故**）を防ぐ、重点軸（セキュリティ）の機密情報スキャン多層防御を3層導入。recipe-board の実績設定を本 monorepo 向けに移植・厳格化した。

- **`.gitleaks.toml`**: `extend.useDefault=true`（高エントロピー：AWS キー等）＋ 低エントロピー password リテラル検知ルール（`password: "taskboard"` 型）。custom ルールは test/docs/.example/e2e を **paths 除外**して誤検知ゼロ、**デフォルトルールは .md 含め全ファイル走査を維持**（本物の鍵の取りこぼし防止）。
- **`.github/workflows/review-board-gitleaks.yml`**: server-side スキャン（最後の防衛線）。バージョン固定（8.30.1）の gitleaks バイナリで review-board を走査、検知で fail、レポートを artifact 化。既存 `review-board-*` 慣習に合わせ review-board スコープ。
- **`.pre-commit-config.yaml`**: ローカル commit 時の第一防衛線（gitleaks ＋ 標準チェック）。

## 変更の種別

- [x] feat（新機能の追加）※セキュリティ防御層の追加
- [ ] chore（設定・ツール・依存関係の変更）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（gitleaks 8.30.1）
  - review-board 全ファイルで **誤検知ゼロ**（custom config 適用）
  - 機能テストで `password: "taskboard"` / quoted api_key / `sk_live_...` を**検知**、env 参照 `${VAR}`・コード識別子 `String token = ...` は**無視**を確認
  - monorepo 全88 commit 履歴をデフォルトルールでスキャン済（leak なし）
- [x] 既存の機能が壊れていないことを確認した（CI 追加のみ・既存コード無変更）
- [x] `.env` ファイルやパスワードをコミットしていない（本 PR がそれを恒久的に防ぐ仕組み）

---

## レビュー時に特に確認してほしい点

- custom 低エントロピールールの allowlist 範囲（test/docs/.example/e2e）が過剰な blind spot になっていないか。デフォルトの高エントロピールールはこれらも走査継続するため、本物の API キー流出は引き続き検知できる設計。
- hideharu-AI は PUBLIC のため gitleaks ライセンス不要。
