### PR TITLE
feat: 外部連携(A)・組み込み(B)の前方互換な仕込み（トークン認証口/CORS複数/埋め込みヘッダ/テナント抽象）

### DIFF
--- a/review-board/backend/.env.example
+++ b/review-board/backend/.env.example
@@ -19,3 +19,13 @@ S3_SECRET_KEY=minioadmin
 
 # --- CORS（フロント Vite。ポート 5175 固定。CLAUDE.md §10）---
 CORS_ALLOWED_ORIGIN=http://localhost:5175
+# 外部連携(A)/組み込み(B) で顧客オリジンを増やす場合のみ設定（カンマ区切り）。
+# 未設定なら CORS_ALLOWED_ORIGIN にフォールバック（既定は単一オリジン）。
+# CORS_ALLOWED_ORIGINS=http://localhost:5175,https://portal.example.com
+
+# --- 前方互換の継ぎ目（既定値＝現状の閉じた挙動。企業要望時のみ変更）---
+# Bearer ヘッダ認証の有効化（公開API/M2M/widget 用）。既定 false＝Cookie のみ。
+AUTH_BEARER_ENABLED=false
+# iframe 埋め込み許可オリジン（CSP frame-ancestors）。既定 'none'＝埋め込み拒否。
+# 例: EMBEDDING_FRAME_ANCESTORS=https://portal.example.com
+EMBEDDING_FRAME_ANCESTORS='none'

--- a/review-board/backend/src/main/java/com/reviewboard/common/tenant/TenantContext.java
+++ b/review-board/backend/src/main/java/com/reviewboard/common/tenant/TenantContext.java
@@ -1,0 +1,33 @@
+package com.reviewboard.common.tenant;
+
+import com.reviewboard.domain.auth.AuthPrincipal;
+import org.springframework.stereotype.Component;
+
+/**
+ * テナント境界の解決を1箇所に集約する<b>継ぎ目</b>（モデルB: マルチテナント化の起点）。
+ *
+ * <p>現状は単一テナント前提のため常に {@link TenantId#DEFAULT} を返す（挙動は現状と同一）。
+ * マルチテナント化の際は、ここだけを「principal が属する組織(tenant)を解決する」実装に差し替え、
+ * リポジトリ/サービスの境界条件に tenant を AND する。境界導出が散在しないよう、
+ * 将来の tenant 参照は必ず本クラス経由にする。
+ *
+ * <p>認可の主境界は引き続き cohort（{@link AuthPrincipal#cohortId()}）と所有者であり、
+ * tenant はその上位に被さる将来の枠（現状は無効化＝DEFAULT 固定）。
+ */
+@Component
+public class TenantContext {
+
+    /**
+     * 認証済み principal からテナントを解決する。
+     * 現状: 単一テナント運用のため {@link TenantId#DEFAULT}。
+     * 将来: principal.cohortId() の所有組織を解決して返す。
+     */
+    public TenantId resolve(AuthPrincipal principal) {
+        return TenantId.DEFAULT;
+    }
+
+    /** principal を持たない文脈（バッチ等）向け。現状は DEFAULT 固定。 */
+    public TenantId current() {
+        return TenantId.DEFAULT;
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/common/tenant/TenantId.java
+++ b/review-board/backend/src/main/java/com/reviewboard/common/tenant/TenantId.java
@@ -1,0 +1,17 @@
+package com.reviewboard.common.tenant;
+
+/**
+ * テナント（マルチテナントの単位＝1企業）の識別子。
+ *
+ * <p><b>継ぎ目（モデルB: 組み込み/マルチテナント）。</b>現状の review-board は単一テナント前提で
+ * 動作し、データ境界は cohort（受講期）と所有者で閉じている。複数企業へ提供/組み込みする段になったら、
+ * cohort を所有する「組織(tenant)」を導入し、本型が実値を運ぶ。今は {@link #DEFAULT} 固定。
+ *
+ * <p>schema は変更しない（DB に tenant 列は持たせない）。実体化時は cohorts に tenant_id を足し、
+ * {@link TenantContext#resolve} を配線するだけで全クエリの境界に乗せられる設計とする。
+ */
+public record TenantId(String value) {
+
+    /** 単一テナント運用時の既定テナント。マルチテナント化までは常にこれ。 */
+    public static final TenantId DEFAULT = new TenantId("default");
+}

--- a/review-board/backend/src/main/java/com/reviewboard/config/CorsConfig.java
+++ b/review-board/backend/src/main/java/com/reviewboard/config/CorsConfig.java
@@ -7,20 +7,32 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.cors.CorsConfigurationSource;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
  * CORS 設定。フロント（Vite）は localhost:5175 固定（CLAUDE.md §10）。
  * Cookie 認証のため allowCredentials=true。許可 origin は env で外部化（ハードコードしない）。
+ *
+ * <p><b>継ぎ目</b>：将来の外部連携(モデルA)・組み込み(モデルB)で顧客オリジンを足せるよう
+ * {@code app.cors.allowed-origins}（カンマ区切りリスト）を受ける。未指定時は旧
+ * {@code app.cors.allowed-origin}（単一）にフォールバックし、既定は現状の単一オリジンのまま。
+ * allowCredentials=true のため {@code "*"} は使えず、明示リストで運用する（仕様どおり）。
  */
 @Configuration
 public class CorsConfig {
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource(
-            @Value("${app.cors.allowed-origin}") String allowedOrigin) {
+            @Value("${app.cors.allowed-origins:${app.cors.allowed-origin:http://localhost:5175}}")
+            String allowedOrigins) {
+        List<String> origins = Arrays.stream(allowedOrigins.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of(allowedOrigin));
+        config.setAllowedOrigins(origins);
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);

--- a/review-board/backend/src/main/java/com/reviewboard/config/SecurityConfig.java
+++ b/review-board/backend/src/main/java/com/reviewboard/config/SecurityConfig.java
@@ -38,12 +38,25 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http, JwtAuthenticationFilter jwtFilter,
-                                           MdcLoggingFilter mdcFilter) throws Exception {
+                                           MdcLoggingFilter mdcFilter,
+                                           @org.springframework.beans.factory.annotation.Value(
+                                                   "${app.embedding.frame-ancestors:'none'}")
+                                           String frameAncestors) throws Exception {
         http
             .cors(Customizer.withDefaults())
             // JWT in HttpOnly Cookie + SameSite=Strict 方式。CSRF は SameSite で緩和する
             // （ステートレス API のため CSRF トークンは持たない。テスト計画書 §7）。
             .csrf(csrf -> csrf.disable())
+            // 組み込み(モデルB)の継ぎ目：既定は現状どおり frame 拒否（X-Frame-Options: DENY）。
+            // app.embedding.frame-ancestors に顧客オリジンを設定したときだけ、X-Frame-Options を外し
+            // CSP frame-ancestors で許可オリジンに限定して iframe 埋め込みを解放する。
+            .headers(h -> {
+                if (!isFramingLocked(frameAncestors)) {
+                    h.frameOptions(fo -> fo.disable())
+                     .contentSecurityPolicy(csp -> csp.policyDirectives("frame-ancestors " + frameAncestors));
+                }
+                // ロック時（既定）は Spring 既定の X-Frame-Options: DENY をそのまま維持する。
+            })
             .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 // health は監視プローブ用に開放（liveness/readiness）。
@@ -64,6 +77,15 @@ public class SecurityConfig {
             // jwt の後段で MDC に requestId/userId を載せる（SecurityContext 確立後）。
             .addFilterAfter(mdcFilter, JwtAuthenticationFilter.class);
         return http.build();
+    }
+
+    /** frame-ancestors が未設定または {@code 'none'} なら「埋め込み拒否（現状維持）」とみなす。 */
+    private boolean isFramingLocked(String frameAncestors) {
+        if (frameAncestors == null) {
+            return true;
+        }
+        String v = frameAncestors.trim();
+        return v.isEmpty() || v.equals("'none'") || v.equalsIgnoreCase("none");
     }
 
     private void writeError(jakarta.servlet.http.HttpServletResponse res, HttpStatus status,

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/JwtAuthenticationFilter.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/JwtAuthenticationFilter.java
@@ -16,17 +16,34 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * access トークン（HttpOnly Cookie）を検証して SecurityContext を確立する。
+ * access トークンを検証して SecurityContext を確立する。
  * トークンが無い/不正なら認証を設定しないだけ（認可は後段で 401/403 を返す）。
  * ロールは {@code ROLE_STUDENT} / {@code ROLE_TEACHER} の権限に写す（RBAC）。
+ *
+ * <p>トークン受け渡しは既定で <b>HttpOnly Cookie のみ</b>（ブラウザ SPA・SameSite=Strict）。
+ * 将来の外部連携(モデルA: 公開API/M2M)・組み込み(モデルB: widget)に備え、
+ * {@code app.auth.bearer-enabled=true} のときだけ {@code Authorization: Bearer} ヘッダも受理する
+ * <b>継ぎ目</b>を持つ（既定 false＝現状と完全に同一の挙動）。検証ロジックは Cookie と共通。
  */
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+    private static final String BEARER_PREFIX = "Bearer ";
+
     private final JwtService jwtService;
 
-    public JwtAuthenticationFilter(JwtService jwtService) {
+    /**
+     * Bearer ヘッダ認証の有効化フラグ（既定 false）。
+     * 外部連携/組み込みを解放する企業要望が来たときに ON にする継ぎ目。
+     * OFF の間は Authorization ヘッダを一切見ない（攻撃面を増やさない）。
+     */
+    private final boolean bearerEnabled;
+
+    public JwtAuthenticationFilter(JwtService jwtService,
+                                   @org.springframework.beans.factory.annotation.Value(
+                                           "${app.auth.bearer-enabled:false}") boolean bearerEnabled) {
         this.jwtService = jwtService;
+        this.bearerEnabled = bearerEnabled;
     }
 
     @Override
@@ -34,7 +51,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     @NonNull HttpServletResponse response,
                                     @NonNull FilterChain filterChain)
             throws ServletException, IOException {
-        String token = readAccessCookie(request);
+        String token = resolveToken(request);
         if (token != null && SecurityContextHolder.getContext().getAuthentication() == null) {
             try {
                 AuthPrincipal principal = jwtService.parse(token);
@@ -49,6 +66,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
+    /**
+     * トークンの取り出し。Cookie を優先し、{@code bearer-enabled} のときのみ
+     * {@code Authorization: Bearer} を補助的に見る（既定では Cookie のみ＝現状と同一）。
+     */
+    private String resolveToken(HttpServletRequest request) {
+        String cookieToken = readAccessCookie(request);
+        if (cookieToken != null) {
+            return cookieToken;
+        }
+        if (bearerEnabled) {
+            return readBearerHeader(request);
+        }
+        return null;
+    }
+
     private String readAccessCookie(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
         if (cookies == null) {
@@ -58,6 +90,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             if (AuthCookies.ACCESS.equals(c.getName())) {
                 return c.getValue();
             }
+        }
+        return null;
+    }
+
+    private String readBearerHeader(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (header != null && header.startsWith(BEARER_PREFIX)) {
+            String value = header.substring(BEARER_PREFIX.length()).trim();
+            return value.isEmpty() ? null : value;
         }
         return null;
     }

--- a/review-board/backend/src/main/resources/application.yml
+++ b/review-board/backend/src/main/resources/application.yml
@@ -56,8 +56,20 @@ app:
     access-ttl-seconds: 900       # 15 分（短命 access）
     refresh-ttl-seconds: 1209600  # 14 日（refresh、DB rotation）
     cookie-secure: ${JWT_COOKIE_SECURE:false}
+  # 認証の継ぎ目（外部連携A/組み込みB）。既定 false＝Cookie 認証のみ（現状と同一）。
+  # ON で Authorization: Bearer ヘッダ認証も受理（公開API/M2M/widget 向け）。
+  auth:
+    bearer-enabled: ${AUTH_BEARER_ENABLED:false}
+  # 組み込みの継ぎ目（モデルB）。既定 'none'＝iframe 拒否（X-Frame-Options: DENY 維持）。
+  # 顧客オリジンを設定すると CSP frame-ancestors で限定的に埋め込みを解放する。
+  embedding:
+    frame-ancestors: ${EMBEDDING_FRAME_ANCESTORS:'none'}
   cors:
+    # 単一オリジン（後方互換）。複数許可は allowed-origins（カンマ区切り）を使う。
     allowed-origin: ${CORS_ALLOWED_ORIGIN:http://localhost:5175}
+    # 連携/組み込みの継ぎ目：顧客オリジンを増やす場合はここにカンマ区切りで列挙。
+    # 未指定時は allowed-origin にフォールバック（既定は単一オリジンのまま）。
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:${CORS_ALLOWED_ORIGIN:http://localhost:5175}}
   storage:
     s3:
       endpoint: ${S3_ENDPOINT:http://localhost:9002}

--- a/review-board/backend/src/test/java/com/reviewboard/common/tenant/TenantContextTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/common/tenant/TenantContextTest.java
@@ -1,0 +1,26 @@
+package com.reviewboard.common.tenant;
+
+import com.reviewboard.domain.auth.AuthPrincipal;
+import com.reviewboard.domain.user.UserRole;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 継ぎ目テスト：現状は単一テナント運用のため、TenantContext は常に DEFAULT を返す。
+ * マルチテナント化(モデルB)の際は本クラスの resolve を差し替える、という配線点の固定化。
+ */
+class TenantContextTest {
+
+    private final TenantContext tenantContext = new TenantContext();
+
+    @Test
+    void resolve_returnsDefault_forAnyPrincipal_underSingleTenant() {
+        AuthPrincipal student = new AuthPrincipal(1L, 10L, UserRole.STUDENT);
+        AuthPrincipal teacher = new AuthPrincipal(2L, 20L, UserRole.TEACHER);
+
+        assertThat(tenantContext.resolve(student)).isEqualTo(TenantId.DEFAULT);
+        assertThat(tenantContext.resolve(teacher)).isEqualTo(TenantId.DEFAULT);
+        assertThat(tenantContext.current()).isEqualTo(TenantId.DEFAULT);
+    }
+}

--- a/review-board/backend/src/test/java/com/reviewboard/domain/auth/BearerSeamDisabledTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/auth/BearerSeamDisabledTest.java
@@ -1,0 +1,56 @@
+package com.reviewboard.domain.auth;
+
+import com.reviewboard.domain.cohort.Cohort;
+import com.reviewboard.domain.user.UserRole;
+import com.reviewboard.support.AbstractIntegrationTest;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 継ぎ目テスト：Bearer 認証が <b>既定（app.auth.bearer-enabled 未設定＝false）</b> では
+ * 一切効かず、現状（Cookie 認証のみ）と同一の挙動であることを保証する。
+ * 「外部に開く仕込みを入れても、フラグ OFF の間は攻撃面を増やさない」ことの担保。
+ */
+class BearerSeamDisabledTest extends AbstractIntegrationTest {
+
+    @BeforeEach
+    void seed() {
+        Cohort cohort = newCohort("seam cohort");
+        newUser("student@example.com", UserRole.STUDENT, cohort.getId());
+    }
+
+    private String loginAndGetAccessToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType("application/json")
+                        .content("{\"email\":\"student@example.com\",\"password\":\"" + PASSWORD + "\"}"))
+                .andExpect(status().isOk())
+                .andReturn();
+        return result.getResponse().getCookie(AuthCookies.ACCESS).getValue();
+    }
+
+    @Test
+    void bearerHeader_isIgnored_byDefault() throws Exception {
+        String token = loginAndGetAccessToken();
+        // Cookie を付けず、有効なトークンを Bearer ヘッダだけで送る。
+        // 既定では Authorization ヘッダを見ないため未認証＝401（現状の閉じた挙動）。
+        mockMvc.perform(get("/api/auth/me").header("Authorization", "Bearer " + token))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void cookie_stillAuthenticates_asBefore() throws Exception {
+        String token = loginAndGetAccessToken();
+        // Cookie 経路は従来どおり通る（後退が無いことの確認）。
+        Cookie access = new Cookie(AuthCookies.ACCESS, token);
+        mockMvc.perform(get("/api/auth/me").cookie(access))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.role").value("STUDENT"));
+    }
+}

--- a/review-board/backend/src/test/java/com/reviewboard/domain/auth/BearerSeamEnabledTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/auth/BearerSeamEnabledTest.java
@@ -1,0 +1,44 @@
+package com.reviewboard.domain.auth;
+
+import com.reviewboard.domain.cohort.Cohort;
+import com.reviewboard.domain.user.UserRole;
+import com.reviewboard.support.AbstractIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 継ぎ目テスト：{@code app.auth.bearer-enabled=true} に<b>切り替えたとき</b>、
+ * Cookie 無しでも Authorization: Bearer で認証できることを実証する。
+ * 外部連携(A)/組み込み(B) を「いつでも解放できる」状態であることの担保。
+ */
+@TestPropertySource(properties = "app.auth.bearer-enabled=true")
+class BearerSeamEnabledTest extends AbstractIntegrationTest {
+
+    @BeforeEach
+    void seed() {
+        Cohort cohort = newCohort("seam cohort");
+        newUser("student@example.com", UserRole.STUDENT, cohort.getId());
+    }
+
+    @Test
+    void bearerHeader_authenticates_whenEnabled() throws Exception {
+        MvcResult login = mockMvc.perform(post("/api/auth/login")
+                        .contentType("application/json")
+                        .content("{\"email\":\"student@example.com\",\"password\":\"" + PASSWORD + "\"}"))
+                .andExpect(status().isOk())
+                .andReturn();
+        String token = login.getResponse().getCookie(AuthCookies.ACCESS).getValue();
+
+        // Cookie を付けず Bearer のみ → フラグ ON のため認証成功（200）。
+        mockMvc.perform(get("/api/auth/me").header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.role").value("STUDENT"));
+    }
+}

--- a/review-board/docs/ADR/0001-外部連携と組み込みの前方互換設計.md
+++ b/review-board/docs/ADR/0001-外部連携と組み込みの前方互換設計.md
@@ -1,0 +1,82 @@
+# ADR-0001: 外部連携(A)・組み込み(B) の前方互換な「仕込み」
+
+- ステータス: Accepted（2026-05-24・Issue #168）
+- 関連: 機能一覧.md / 脅威モデリング.md / 付録A判定表.md / #161-165(post-deploy 予約)
+
+## 背景
+
+review-board(Ayumi) を企業に売り込むにあたり、将来2つの形態が要望されうる：
+
+- **モデルA（外部連携）**: 企業が Ayumi を SaaS として使い、SSO / 公開API / Webhook / 通知連携で
+  自社システムと繋ぐ。
+- **モデルB（組み込み）**: 企業の自社アプリ/ポータルに Ayumi を iframe / widget で埋め込む。
+  複数顧客への提供にはマルチテナントが要る。
+
+現状の設計は「閉じた自己完結アプリ」（JWT in HttpOnly Cookie + SameSite=Strict、単一オリジン CORS、
+X-Frame-Options DENY、cohort 境界の認可）であり、これは **S 軸（セキュリティ）の強み**。
+A/B はいずれも「閉じている」前提を開くため、本質的にこの強みと緊張する。
+
+実際に A/B を実装するかは**未定**。だが「A→B は増分で到達でき、その分岐点は
+*トークン認証とテナント抽象を最初から持つか*」であり、これらは**今やれば安く・後だと作り直し**になる。
+そこで **挙動を変えない継ぎ目（seam）だけ**を先に入れる。
+
+## 決定
+
+以下の継ぎ目を導入する。**すべて既定値は現状の閉じた挙動と完全に同一**で、企業要望時に
+フラグ/設定/局所的な追加実装で解放する。
+
+| # | 継ぎ目 | 設定キー（既定） | 解放方法 | 対象 |
+|---|---|---|---|---|
+| 1 | Bearer トークン認証の口 | `app.auth.bearer-enabled`（false） | true にする | A/B 両方の認証土台 |
+| 2 | CORS 複数オリジン | `app.cors.allowed-origins`（単一にフォールバック） | 顧客オリジンを列挙 | A/B |
+| 3 | 埋め込みヘッダ | `app.embedding.frame-ancestors`（`'none'`） | 顧客オリジンを設定 | B（iframe） |
+| 4 | テナント抽象 | （コードのみ・schema 変更なし） | `TenantContext.resolve` を配線 | B（マルチテナント） |
+
+### 1. Bearer トークン認証の口（既定 OFF）
+
+`JwtAuthenticationFilter` は Cookie を優先しつつ、`bearer-enabled=true` のときだけ
+`Authorization: Bearer` も受理する。**OFF の間は Authorization ヘッダを一切見ない**（攻撃面を増やさない）。
+JWT の検証ロジックは Cookie と共通。
+
+- 解放時にやること: API キー / OAuth2 client-credentials の発行・スコープ・**レート制限（未実装）**を併設。
+- テスト: 既定 OFF で Bearer は無視され 401（`BearerSeamDisabledTest`）、ON で認証成功
+  （`BearerSeamEnabledTest`）。
+
+### 2. CORS 複数オリジン（既定は単一）
+
+`CorsConfig` は `app.cors.allowed-origins`（カンマ区切り）を読み、未指定時は旧 `app.cors.allowed-origin`
+にフォールバック。`allowCredentials=true` のため `"*"` は使えず、明示リストで運用。
+
+### 3. 埋め込みヘッダ（既定は DENY 維持）
+
+`SecurityConfig` は `frame-ancestors='none'`（既定）のとき **X-Frame-Options: DENY を維持**（現状どおり）。
+顧客オリジンを設定したときだけ X-Frame-Options を外し、CSP `frame-ancestors` で許可オリジンに限定する。
+
+- 解放時の注意: iframe でセッションを維持するなら Cookie は `SameSite=None; Secure` が要り、
+  **現在の CSRF 防御（SameSite=Strict）が崩れる**。よって埋め込みは継ぎ目#1 の **Bearer トークン認証**で
+  行うのを基本とし、Cookie 埋め込みを採る場合のみ CSRF トークンを再導入する。
+
+### 4. テナント抽象（schema 変更なし）
+
+`TenantContext` / `TenantId` を導入。現状は単一テナント前提で常に `TenantId.DEFAULT` を返す
+（挙動は現状と同一）。認可の主境界は引き続き **cohort と所有者**。
+
+- マルチテナント化の手順（将来）:
+  1. `cohorts` に `tenant_id` 列を追加（migration）。組織(tenant)が cohort 群を所有するモデル。
+  2. `TenantContext.resolve` を「principal の cohort が属する tenant を返す」実装に差し替え。
+  3. リポジトリ/サービスの境界条件に tenant を AND（cohort 境界の上位として被せる）。
+- 境界導出を散在させないため、tenant 参照は必ず `TenantContext` 経由にする。
+
+## 帰結
+
+- **良い点**: A→B を増分で実装可能にしつつ、現在の閉じた強み・S 軸を一切損なわない。
+  解放はフラグ/設定変更が中心で、レビュー・撤回が容易。
+- **コスト**: 設定キーと薄い抽象が増える（複雑性は軽微）。
+- **未対応（解放時に別途必須）**: レート制限 / WAF / API バージョニング・OpenAPI / SCIM /
+  マルチテナントの実 schema。これらは企業モデル確定後に着手（#161-165 と同様 post-deploy）。
+
+## 代替案
+
+- **テナントに今 schema を入れる**: cohorts へ `tenant_id` 列を即追加する案も検討したが、
+  実際に B をやるか未定の段階での DB 変更はリスクが上回るため、**コード抽象のみ**を採用（本 ADR）。
+- **何も仕込まない**: A/B 要望時にゼロから着手だと、認証モデルとデータ境界の作り直しが発生するため不採用。


### PR DESCRIPTION
## 関連 Issue

Closes #168

---

## 変更の概要

企業導入で将来要望されうる **外部連携(モデルA)** と **組み込み(モデルB)** を、**いつでも実装着手できる継ぎ目(seam)だけ**先に仕込む。実装するかは未定のため、**現在の閉じた挙動（cohort境界・SameSite=Strict Cookie・単一オリジン・iframe拒否）は一切変えない**。

A→B は増分で到達でき、分岐点は「トークン認証＋テナント抽象を最初から持つか」。これを今、低コスト・可逆で入れる。

| 継ぎ目 | 設定（既定） | 解放方法 |
|---|---|---|
| Bearer 認証の口 | `app.auth.bearer-enabled`（false） | true で `Authorization: Bearer` も受理（A/B 認証土台） |
| CORS 複数オリジン | `app.cors.allowed-origins`（単一にフォールバック） | 顧客オリジンを列挙 |
| 埋め込みヘッダ | `app.embedding.frame-ancestors`（`'none'`） | 顧客オリジン設定で CSP frame-ancestors 解放 |
| テナント抽象 | コードのみ（schema 変更なし） | `TenantContext.resolve` を配線 |

ADR-0001 に戦略・各フラグの開き方・マルチテナント配線手順を記録。

## 変更の種別

- [x] feat（新機能の追加）※前方互換の継ぎ目
- [ ] chore

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（`./gradlew test` BUILD SUCCESSFUL）
  - `BearerSeamDisabledTest`: 既定 OFF では Bearer ヘッダを無視し **401**、Cookie は従来どおり **200**
  - `BearerSeamEnabledTest`: フラグ ON で Bearer のみで **200**（解放可能性の実証）
  - `TenantContextTest`: 常に `TenantId.DEFAULT`（単一テナント）
  - `AuthIntegrationTest`: 既存認証の回帰 green
- [x] 既存の機能が壊れていないことを確認した（既定値＝現状と同一・コンパイル/テスト green）
- [x] `.env` ファイルやパスワードをコミットしていない（gitleaks 誤検知ゼロ確認済み）

---

## レビュー時に特に確認してほしい点

- **「既定値＝現状の挙動」**の担保が主眼。Bearer は OFF 時に Authorization ヘッダを一切見ない（攻撃面を増やさない）。埋め込みは `'none'` 時に X-Frame-Options: DENY を維持。
- 解放時に別途必須となるもの（レート制限/WAF/OpenAPI/SCIM/マルチテナント実 schema）は本 PR の対象外で、ADR と #161-165 に整理済み。
