### PR TITLE
feat: 成果物の「AI使用状況」開示タグ（AI不使用/一部/使用）を追加

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/AiUsage.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/AiUsage.java
@@ -1,0 +1,15 @@
+package com.reviewboard.domain.post;
+
+/**
+ * 成果物の「AI使用状況」開示タグ（単一選択・未設定は null）。
+ * エンジニアスクールの学習・評価の透明性のため、投稿者が任意で申告する。
+ * レビュアーも前提（手書きか AI 補助か）が分かりレビューしやすくなる。
+ */
+public enum AiUsage {
+    /** AI不使用：AI ツールを使わずに開発 */
+    NONE,
+    /** AI一部使用：一部に AI 補助を利用 */
+    PARTIAL,
+    /** AI使用：AI を活用して開発 */
+    USED
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/Post.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/Post.java
@@ -64,6 +64,11 @@ public class Post {
     @Column(name = "review_tone", length = 20)
     private ReviewTone reviewTone;
 
+    /** AI使用状況の開示タグ（単一・未設定は null・Issue #172）。 */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "ai_usage", length = 20)
+    private AiUsage aiUsage;
+
     /**
      * F-REQ-01 観点別レビュー依頼：募集したい観点（多値）。投稿削除で子行も自動削除。
      * EAGER ＋ BatchSize で詳細取得時の遅延初期化を避けつつ一覧の N+1 を1クエリに束ねる。

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/PostService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/PostService.java
@@ -56,7 +56,7 @@ public class PostService {
         post.setDemoUrl(req.demoUrl());
         post.setScreenshotKey(req.screenshotKey());
         post.setRecruitStatus(RecruitStatus.OPEN);
-        applyReviewPreferences(post, req.reviewTone(), req.reviewAspects());
+        applyReviewPreferences(post, req.reviewTone(), req.reviewAspects(), req.aiUsage());
         post.setCreatedAt(now);
         post.setUpdatedAt(now);
         postRepository.save(post);
@@ -100,7 +100,7 @@ public class PostService {
         post.setRepoUrl(req.repoUrl());
         post.setDemoUrl(req.demoUrl());
         post.setScreenshotKey(req.screenshotKey());
-        applyReviewPreferences(post, req.reviewTone(), req.reviewAspects());
+        applyReviewPreferences(post, req.reviewTone(), req.reviewAspects(), req.aiUsage());
         post.setUpdatedAt(OffsetDateTime.now());
         auditService.record(principal, AuditAction.POST_UPDATED, AuditTargetType.POST, postId);
         return post;
@@ -140,8 +140,9 @@ public class PostService {
      * tone は null で未設定に戻る。aspects は送られた集合で全置換（null は空集合扱い）。
      * 設定主体は所有者に限る（呼び出し元の create/loadOwned で担保。★S軸）。
      */
-    private void applyReviewPreferences(Post post, ReviewTone tone, Set<ReviewAspect> aspects) {
+    private void applyReviewPreferences(Post post, ReviewTone tone, Set<ReviewAspect> aspects, AiUsage aiUsage) {
         post.setReviewTone(tone);
+        post.setAiUsage(aiUsage);
         post.getReviewAspects().clear();
         if (aspects != null) {
             post.getReviewAspects().addAll(aspects);

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostCreateRequest.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostCreateRequest.java
@@ -1,5 +1,6 @@
 package com.reviewboard.domain.post.dto;
 
+import com.reviewboard.domain.post.AiUsage;
 import com.reviewboard.domain.post.ReviewAspect;
 import com.reviewboard.domain.post.ReviewTone;
 import jakarta.validation.constraints.NotBlank;
@@ -13,6 +14,7 @@ import java.util.Set;
  *
  * @param reviewTone    F-SAFE-01 希望トーン（任意・null は未設定）
  * @param reviewAspects F-REQ-01 募集観点（任意・Set で重複排除。不正な enum 値は 400）
+ * @param aiUsage       AI使用状況の開示タグ（任意・null は未申告・Issue #172）
  */
 public record PostCreateRequest(
         @NotBlank @Size(max = 100) String title,
@@ -21,5 +23,6 @@ public record PostCreateRequest(
         @Size(max = 512) String demoUrl,
         @Size(max = 512) String screenshotKey,
         ReviewTone reviewTone,
-        Set<ReviewAspect> reviewAspects) {
+        Set<ReviewAspect> reviewAspects,
+        AiUsage aiUsage) {
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostResponse.java
@@ -1,5 +1,6 @@
 package com.reviewboard.domain.post.dto;
 
+import com.reviewboard.domain.post.AiUsage;
 import com.reviewboard.domain.post.Post;
 import com.reviewboard.domain.post.RecruitStatus;
 import com.reviewboard.domain.post.ReviewAspect;
@@ -27,6 +28,7 @@ public record PostResponse(
         Long bestReviewId,
         ReviewTone reviewTone,
         List<ReviewAspect> reviewAspects,
+        AiUsage aiUsage,
         OffsetDateTime createdAt,
         OffsetDateTime updatedAt) {
 
@@ -40,6 +42,6 @@ public record PostResponse(
                 p.getTitle(), p.getDescription(), p.getRepoUrl(), p.getDemoUrl(),
                 p.getScreenshotKey(), screenshotUrl, p.getRecruitStatus(), p.getReviewCount(),
                 p.getBestReviewId(), p.getReviewTone(), new ArrayList<>(p.getReviewAspects()),
-                p.getCreatedAt(), p.getUpdatedAt());
+                p.getAiUsage(), p.getCreatedAt(), p.getUpdatedAt());
     }
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostSummaryResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostSummaryResponse.java
@@ -1,5 +1,6 @@
 package com.reviewboard.domain.post.dto;
 
+import com.reviewboard.domain.post.AiUsage;
 import com.reviewboard.domain.post.Post;
 import com.reviewboard.domain.post.RecruitStatus;
 import com.reviewboard.domain.post.ReviewAspect;
@@ -21,12 +22,13 @@ public record PostSummaryResponse(
         int reviewCount,
         ReviewTone reviewTone,
         List<ReviewAspect> reviewAspects,
+        AiUsage aiUsage,
         OffsetDateTime createdAt) {
 
     public static PostSummaryResponse from(Post p) {
         return new PostSummaryResponse(
                 p.getId(), p.getAuthorUserId(), p.getTitle(),
                 p.getRecruitStatus(), p.getReviewCount(),
-                p.getReviewTone(), new ArrayList<>(p.getReviewAspects()), p.getCreatedAt());
+                p.getReviewTone(), new ArrayList<>(p.getReviewAspects()), p.getAiUsage(), p.getCreatedAt());
     }
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostUpdateRequest.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.reviewboard.domain.post.dto;
 
+import com.reviewboard.domain.post.AiUsage;
 import com.reviewboard.domain.post.ReviewAspect;
 import com.reviewboard.domain.post.ReviewTone;
 import jakarta.validation.constraints.NotBlank;
@@ -12,6 +13,7 @@ import java.util.Set;
  *
  * @param reviewTone    F-SAFE-01 希望トーン（任意・null は未設定に戻す）
  * @param reviewAspects F-REQ-01 募集観点（任意・送られた集合で全置換）
+ * @param aiUsage       AI使用状況の開示タグ（任意・null は未申告に戻す・Issue #172）
  */
 public record PostUpdateRequest(
         @NotBlank @Size(max = 100) String title,
@@ -20,5 +22,6 @@ public record PostUpdateRequest(
         @Size(max = 512) String demoUrl,
         @Size(max = 512) String screenshotKey,
         ReviewTone reviewTone,
-        Set<ReviewAspect> reviewAspects) {
+        Set<ReviewAspect> reviewAspects,
+        AiUsage aiUsage) {
 }

--- a/review-board/backend/src/main/resources/db/migration/V9__add_post_ai_usage.sql
+++ b/review-board/backend/src/main/resources/db/migration/V9__add_post_ai_usage.sql
@@ -1,0 +1,4 @@
+-- 成果物の「AI使用状況」開示タグ（Issue #172）。
+-- 値は AiUsage（NONE/PARTIAL/USED）。未設定は NULL。
+-- review_tone（V4）と同様に CHECK 制約は付けず、値の妥当性はアプリ層（enum）で担保する。
+ALTER TABLE posts ADD COLUMN ai_usage VARCHAR(20);

--- a/review-board/backend/src/test/java/com/reviewboard/domain/post/PostReviewPreferenceIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/post/PostReviewPreferenceIntegrationTest.java
@@ -96,6 +96,45 @@ class PostReviewPreferenceIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(status().isNotFound());
     }
 
+    /** AI使用状況タグ（#172）：作成で設定でき詳細で返り、更新で変更・null で未申告に戻せる。 */
+    @Test
+    void aiUsage_create_persists_update_and_clear() throws Exception {
+        MvcResult res = mockMvc.perform(post("/api/posts").cookie(login(authorEmail))
+                        .contentType("application/json")
+                        .content("{\"title\":\"作品\",\"description\":\"説明\",\"aiUsage\":\"NONE\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.aiUsage").value("NONE"))
+                .andReturn();
+        long id = readId(res);
+
+        // 詳細取得で返る
+        mockMvc.perform(get("/api/posts/" + id).cookie(login(authorEmail)))
+                .andExpect(jsonPath("$.aiUsage").value("NONE"));
+
+        // 更新で変更できる
+        mockMvc.perform(put("/api/posts/" + id).cookie(login(authorEmail))
+                        .contentType("application/json")
+                        .content("{\"title\":\"作品\",\"description\":\"説明\",\"aiUsage\":\"PARTIAL\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.aiUsage").value("PARTIAL"));
+
+        // null（未指定）で未申告に戻る
+        mockMvc.perform(put("/api/posts/" + id).cookie(login(authorEmail))
+                        .contentType("application/json")
+                        .content("{\"title\":\"作品\",\"description\":\"説明\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.aiUsage").doesNotExist());
+    }
+
+    /** 不正な aiUsage enum 値は 400。 */
+    @Test
+    void invalid_aiUsage_value_returns400() throws Exception {
+        mockMvc.perform(post("/api/posts").cookie(login(authorEmail))
+                        .contentType("application/json")
+                        .content("{\"title\":\"作品\",\"description\":\"説明\",\"aiUsage\":\"NOPE\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
     /** 不正な enum 値（観点）は 400（HttpMessageNotReadable → InvalidRequest）。 */
     @Test
     void invalid_aspect_value_returns400() throws Exception {

--- a/review-board/frontend/src/components/ReviewPrefBadges.jsx
+++ b/review-board/frontend/src/components/ReviewPrefBadges.jsx
@@ -1,9 +1,9 @@
-import { TONE_LABEL, ASPECT_LABEL } from '../constants/reviewPrefs';
+import { TONE_LABEL, ASPECT_LABEL, AI_USAGE_LABEL } from '../constants/reviewPrefs';
 
-// F-SAFE-01 / F-REQ-01：投稿のトーン希望・募集観点をバッジ表示する（読み取り専用）。
-// reviewers が「どんなレビューが歓迎か」を一目で把握できるようにする。
-export default function ReviewPrefBadges({ tone, aspects = [], className = '' }) {
-  if (!tone && (!aspects || aspects.length === 0)) return null;
+// F-SAFE-01 / F-REQ-01 / AI使用状況(#172)：投稿のトーン希望・募集観点・AI使用状況をバッジ表示（読み取り専用）。
+// reviewers が「どんなレビューが歓迎か」「AI をどの程度使ったか」を一目で把握できるようにする。
+export default function ReviewPrefBadges({ tone, aspects = [], aiUsage = null, className = '' }) {
+  if (!tone && (!aspects || aspects.length === 0) && !aiUsage) return null;
   return (
     <div className={`flex flex-wrap items-center gap-2 ${className}`}>
       {tone && (
@@ -16,6 +16,11 @@ export default function ReviewPrefBadges({ tone, aspects = [], className = '' })
           🔍 {ASPECT_LABEL[a] ?? a}
         </span>
       ))}
+      {aiUsage && (
+        <span className="rounded-full bg-emerald-50 px-2.5 py-0.5 text-xs font-medium text-emerald-700 ring-1 ring-emerald-200">
+          🤖 {AI_USAGE_LABEL[aiUsage] ?? aiUsage}
+        </span>
+      )}
     </div>
   );
 }

--- a/review-board/frontend/src/components/ReviewPrefFields.jsx
+++ b/review-board/frontend/src/components/ReviewPrefFields.jsx
@@ -1,8 +1,10 @@
-import { TONE_OPTIONS, ASPECT_OPTIONS } from '../constants/reviewPrefs';
+import { TONE_OPTIONS, ASPECT_OPTIONS, AI_USAGE_OPTIONS } from '../constants/reviewPrefs';
 
-// F-SAFE-01 / F-REQ-01：投稿フォームのトーン（単一）・募集観点（多値）入力。
-// props: tone(string|null), aspects(string[]), onToneChange, onAspectsChange。
-export default function ReviewPrefFields({ tone, aspects = [], onToneChange, onAspectsChange }) {
+// F-SAFE-01 / F-REQ-01 / AI使用状況(#172)：投稿フォームのトーン（単一）・募集観点（多値）・AI使用状況（単一）入力。
+// props: tone(string|null), aspects(string[]), aiUsage(string|null), onToneChange, onAspectsChange, onAiUsageChange。
+export default function ReviewPrefFields({
+  tone, aspects = [], aiUsage = null, onToneChange, onAspectsChange, onAiUsageChange,
+}) {
   const toggleAspect = (value) => {
     onAspectsChange(aspects.includes(value) ? aspects.filter((a) => a !== value) : [...aspects, value]);
   };
@@ -26,10 +28,24 @@ export default function ReviewPrefFields({ tone, aspects = [], onToneChange, onA
       </div>
 
       <p className="mb-1 text-sm text-gray-600">特に見てほしい観点（複数選択可）</p>
-      <div className="flex flex-wrap gap-3">
+      <div className="mb-4 flex flex-wrap gap-3">
         {ASPECT_OPTIONS.map((o) => (
           <label key={o.value} className="flex cursor-pointer items-center gap-1.5 text-sm text-gray-700">
             <input type="checkbox" checked={aspects.includes(o.value)} onChange={() => toggleAspect(o.value)} />
+            {o.label}
+          </label>
+        ))}
+      </div>
+
+      <p className="mb-1 text-sm text-gray-600">この成果物の AI 使用状況（任意）</p>
+      <div className="flex flex-wrap gap-3" role="radiogroup" aria-label="AI使用状況">
+        <label className="flex cursor-pointer items-center gap-1.5 text-sm text-gray-700">
+          <input type="radio" name="aiUsage" checked={!aiUsage} onChange={() => onAiUsageChange(null)} />
+          指定しない
+        </label>
+        {AI_USAGE_OPTIONS.map((o) => (
+          <label key={o.value} className="flex cursor-pointer items-center gap-1.5 text-sm text-gray-700" title={o.hint}>
+            <input type="radio" name="aiUsage" checked={aiUsage === o.value} onChange={() => onAiUsageChange(o.value)} />
             {o.label}
           </label>
         ))}

--- a/review-board/frontend/src/constants/reviewPrefs.js
+++ b/review-board/frontend/src/constants/reviewPrefs.js
@@ -20,3 +20,12 @@ export const ASPECT_OPTIONS = [
 ];
 
 export const ASPECT_LABEL = Object.fromEntries(ASPECT_OPTIONS.map((o) => [o.value, o.label]));
+
+// AI使用状況の開示タグ（単一選択。未設定は null）。backend の enum 名（AiUsage）と一致させること。
+export const AI_USAGE_OPTIONS = [
+  { value: 'NONE', label: 'AI不使用', hint: 'AI ツールを使わずに開発' },
+  { value: 'PARTIAL', label: 'AI一部使用', hint: '一部に AI 補助を利用' },
+  { value: 'USED', label: 'AI使用', hint: 'AI を活用して開発' },
+];
+
+export const AI_USAGE_LABEL = Object.fromEntries(AI_USAGE_OPTIONS.map((o) => [o.value, o.label]));

--- a/review-board/frontend/src/pages/NewPostPage.jsx
+++ b/review-board/frontend/src/pages/NewPostPage.jsx
@@ -6,7 +6,7 @@ import ReviewPrefFields from '../components/ReviewPrefFields';
 import DraftNotice from '../components/DraftNotice';
 import { useDraft } from '../hooks/useDraft';
 
-const EMPTY = { title: '', description: '', repoUrl: '', demoUrl: '', screenshotKey: null, reviewTone: null, reviewAspects: [] };
+const EMPTY = { title: '', description: '', repoUrl: '', demoUrl: '', screenshotKey: null, reviewTone: null, reviewAspects: [], aiUsage: null };
 
 // F-POST-01：成果物の投稿（タイトル/説明は必須、URL・スクショは任意）。
 // F-DRAFT-01：入力を localStorage に自動保存し、再訪時に復元する。
@@ -20,7 +20,7 @@ export default function NewPostPage() {
   const { restored, save, clear } = useDraft('post-new', (draft) => setForm((p) => ({ ...p, ...draft })));
   // 空フォームは保存しない（「空の下書き復元」誤検知を防ぐ）。
   const dirty = !!(form.title || form.description || form.repoUrl || form.demoUrl
-    || form.screenshotKey || form.reviewTone || form.reviewAspects.length);
+    || form.screenshotKey || form.reviewTone || form.reviewAspects.length || form.aiUsage);
   useEffect(() => { if (dirty) save(form); }, [form, dirty, save]);
 
   const set = (k) => (e) => setForm((p) => ({ ...p, [k]: e.target.value }));
@@ -43,6 +43,7 @@ export default function NewPostPage() {
         screenshotKey: form.screenshotKey || null,
         reviewTone: form.reviewTone,
         reviewAspects: form.reviewAspects,
+        aiUsage: form.aiUsage,
       });
       clear(); // 投稿成功で下書きは不要
       navigate(`/posts/${post.id}`, { replace: true });
@@ -71,8 +72,10 @@ export default function NewPostPage() {
         <ReviewPrefFields
           tone={form.reviewTone}
           aspects={form.reviewAspects}
+          aiUsage={form.aiUsage}
           onToneChange={(v) => setForm((p) => ({ ...p, reviewTone: v }))}
           onAspectsChange={(v) => setForm((p) => ({ ...p, reviewAspects: v }))}
+          onAiUsageChange={(v) => setForm((p) => ({ ...p, aiUsage: v }))}
         />
         <button type="submit" disabled={busy} className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50">
           {busy ? '投稿中…' : '投稿する'}

--- a/review-board/frontend/src/pages/PostDetailPage.jsx
+++ b/review-board/frontend/src/pages/PostDetailPage.jsx
@@ -75,7 +75,7 @@ export default function PostDetailPage() {
             </div>
           )}
         </div>
-        <ReviewPrefBadges tone={post.reviewTone} aspects={post.reviewAspects} className="mt-3" />
+        <ReviewPrefBadges tone={post.reviewTone} aspects={post.reviewAspects} aiUsage={post.aiUsage} className="mt-3" />
         <MarkdownText className="mt-3">{post.description}</MarkdownText>
         {post.screenshotUrl && (
           <img src={post.screenshotUrl} alt={`${post.title} のスクリーンショット`} className="mt-4 max-h-96 rounded border border-gray-200" />

--- a/review-board/frontend/src/pages/PostEditPage.jsx
+++ b/review-board/frontend/src/pages/PostEditPage.jsx
@@ -25,6 +25,7 @@ export default function PostEditPage() {
           screenshotKey: p.screenshotKey ?? null,
           reviewTone: p.reviewTone ?? null,
           reviewAspects: p.reviewAspects ?? [],
+          aiUsage: p.aiUsage ?? null,
         });
         setScreenshotUrl(p.screenshotUrl ?? '');
       })
@@ -46,6 +47,7 @@ export default function PostEditPage() {
         screenshotKey: form.screenshotKey || null,
         reviewTone: form.reviewTone,
         reviewAspects: form.reviewAspects,
+        aiUsage: form.aiUsage,
       });
       navigate(`/posts/${id}`, { replace: true });
     } catch (err) {
@@ -75,8 +77,10 @@ export default function PostEditPage() {
         <ReviewPrefFields
           tone={form.reviewTone}
           aspects={form.reviewAspects}
+          aiUsage={form.aiUsage}
           onToneChange={(v) => setForm((p) => ({ ...p, reviewTone: v }))}
           onAspectsChange={(v) => setForm((p) => ({ ...p, reviewAspects: v }))}
+          onAiUsageChange={(v) => setForm((p) => ({ ...p, aiUsage: v }))}
         />
         <div className="flex gap-3">
           <button type="submit" disabled={busy} className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50">

--- a/review-board/frontend/src/pages/PostsPage.jsx
+++ b/review-board/frontend/src/pages/PostsPage.jsx
@@ -98,7 +98,7 @@ export default function PostsPage() {
                     {RECRUIT_LABEL[p.recruitStatus] ?? p.recruitStatus}
                   </span>
                 </div>
-                <ReviewPrefBadges tone={p.reviewTone} aspects={p.reviewAspects} className="mt-2" />
+                <ReviewPrefBadges tone={p.reviewTone} aspects={p.reviewAspects} aiUsage={p.aiUsage} className="mt-2" />
                 <p className="mt-1 text-sm text-gray-500">レビュー {p.reviewCount} 件</p>
               </Link>
             </li>


### PR DESCRIPTION
## 関連 Issue

Closes #172

---

## 変更の概要

成果物の **「AI使用状況」開示タグ**（AI不使用 / AI一部使用 / AI使用）を追加。エンジニアスクールの学習・評価の透明性に直結し、レビュアーも前提（手書きか AI 補助か）が分かりレビューしやすくなる。既存の `review_tone` と同型で実装。

- `AiUsage` enum（NONE/PARTIAL/USED）。**V9** で `posts.ai_usage` 追加（nullable・`review_tone` と同様 CHECK 無し＝アプリ層 enum で妥当性担保）
- Post / PostCreateRequest / PostUpdateRequest / PostResponse / PostSummaryResponse に `aiUsage` を追加。**新エンドポイント無し＝既存 POST/PUT /api/posts に相乗り**（cohort 境界・所有者認可は据え置き）
- フロント：投稿作成/編集フォームに選択 UI（ReviewPrefFields）、一覧/詳細にバッジ表示（ReviewPrefBadges 🤖）

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した
  - backend: 作成で設定→詳細で返る→更新で変更→null で未申告に戻る / 不正 enum 値 **400**（`PostReviewPreferenceIntegrationTest` 追加）。認可テスト含め green
  - frontend: lint **0 error**（既存 AuthContext 警告1件のみ）・`npm run build` OK
- [x] 既存の機能が壊れていないことを確認した（任意項目・既存投稿は null・review_tone と同型で相乗り）
- [x] `.env` ファイルやパスワードをコミットしていない（gitleaks：tracked 0 件）

---

## レビュー時に特に確認してほしい点

- 任意項目（未申告のまま投稿可）。`review_tone` の実装・テストに完全に倣っている。
- 非スコープ：AI使用状況での絞り込み検索（将来）・技術スタックタグ（別件）。
