### PR TITLE
feat: UI全面刷新（案L）＋いいね/ランキング・多値トーン/観点検索・アバター切り抜き

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/Post.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/Post.java
@@ -55,14 +55,24 @@ public class Post {
     @Column(name = "review_count", nullable = false)
     private int reviewCount = 0;
 
+    /** いいね数（非正規化カウンタ。いいね/解除と同一Txで増減）。ランキング基準。 */
+    @Column(name = "like_count", nullable = false)
+    private int likeCount = 0;
+
     /** F-REV-05 ベストレビュー：投稿者が選んだ最も役立ったレビューの ID（未選択は null）。 */
     @Column(name = "best_review_id")
     private Long bestReviewId;
 
-    /** F-SAFE-01 心理的安全設定：投稿者が希望するレビューのトーン（単一・未設定は null）。 */
+    /**
+     * F-SAFE-01 心理的安全設定：投稿者が歓迎するレビューのトーン（多値・未設定は空）。
+     * 観点と同じく正規化テーブルで保持。EAGER ＋ BatchSize で一覧の N+1 を束ねる。
+     */
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "post_review_tones", joinColumns = @JoinColumn(name = "post_id"))
+    @Column(name = "tone", length = 20)
     @Enumerated(EnumType.STRING)
-    @Column(name = "review_tone", length = 20)
-    private ReviewTone reviewTone;
+    @BatchSize(size = 50)
+    private Set<ReviewTone> reviewTones = new LinkedHashSet<>();
 
     /** AI使用状況の開示タグ（単一・未設定は null・Issue #172）。 */
     @Enumerated(EnumType.STRING)

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/PostController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/PostController.java
@@ -2,10 +2,13 @@ package com.reviewboard.domain.post;
 
 import com.reviewboard.domain.auth.AuthPrincipal;
 import com.reviewboard.domain.post.dto.BestReviewRequest;
+import com.reviewboard.domain.post.dto.LikeResponse;
 import com.reviewboard.domain.post.dto.PostCreateRequest;
 import com.reviewboard.domain.post.dto.PostResponse;
 import com.reviewboard.domain.post.dto.PostSummaryResponse;
 import com.reviewboard.domain.post.dto.PostUpdateRequest;
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRepository;
 import com.reviewboard.storage.StorageService;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Pageable;
@@ -16,6 +19,9 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * 投稿 API（F-POST）。すべて認証必須（SecurityConfig の anyRequest().authenticated()）。
@@ -27,15 +33,24 @@ public class PostController {
 
     private final PostService postService;
     private final StorageService storageService;
+    private final UserRepository userRepository;
+    private final PostLikeService postLikeService;
+    private final PostLikeRepository postLikeRepository;
 
-    public PostController(PostService postService, StorageService storageService) {
+    public PostController(PostService postService, StorageService storageService,
+                          UserRepository userRepository, PostLikeService postLikeService,
+                          PostLikeRepository postLikeRepository) {
         this.postService = postService;
         this.storageService = storageService;
+        this.userRepository = userRepository;
+        this.postLikeService = postLikeService;
+        this.postLikeRepository = postLikeRepository;
     }
 
-    /** screenshotKey から表示用の署名付き URL を補って詳細レスポンスを組み立てる（SEC-8）。 */
-    private PostResponse toResponse(Post post) {
-        return PostResponse.from(post, storageService.presignedGetUrl(post.getScreenshotKey()));
+    /** screenshotKey から署名付き URL を補い、閲覧者のいいね状態を添えて詳細レスポンスを組み立てる（SEC-8）。 */
+    private PostResponse toResponse(Post post, AuthPrincipal principal) {
+        boolean liked = postLikeRepository.existsByPostIdAndUserId(post.getId(), principal.userId());
+        return PostResponse.from(post, storageService.presignedGetUrl(post.getScreenshotKey()), liked);
     }
 
     /** F-POST-01 作成 */
@@ -44,7 +59,7 @@ public class PostController {
                                                @Valid @RequestBody PostCreateRequest request) {
         Post post = postService.create(principal, request);
         return ResponseEntity.created(URI.create("/api/posts/" + post.getId()))
-                .body(toResponse(post));
+                .body(toResponse(post, principal));
     }
 
     /**
@@ -54,19 +69,44 @@ public class PostController {
     @GetMapping
     public Slice<PostSummaryResponse> list(@AuthenticationPrincipal AuthPrincipal principal,
                                            @RequestParam(required = false) String q,
+                                           @RequestParam(required = false) java.util.List<ReviewAspect> aspects,
+                                           @RequestParam(required = false) java.util.List<ReviewTone> tones,
                                            @RequestParam(required = false) RecruitStatus status,
                                            @RequestParam(defaultValue = "false") boolean unreviewed,
                                            @RequestParam(defaultValue = "newest") String sort,
                                            @PageableDefault(size = 20) Pageable pageable) {
-        return postService.search(principal, q, status, unreviewed, sort, pageable)
-                .map(PostSummaryResponse::from);
+        Slice<Post> slice = postService.search(principal, q, aspects, tones, status, unreviewed, sort, pageable);
+        java.util.List<Long> ids = slice.getContent().stream().map(Post::getId).toList();
+        // 著者名・いいね済み集合はバッチ解決（N+1 回避）。スクショ URL は短命署名で都度補う（SEC-8）。
+        Map<Long, String> authorNames = userRepository.findAllById(
+                        slice.getContent().stream().map(Post::getAuthorUserId).collect(Collectors.toSet()))
+                .stream().collect(Collectors.toMap(User::getId, User::getDisplayName, (a, b) -> a));
+        Set<Long> likedPostIds = ids.isEmpty() ? Set.of()
+                : postLikeRepository.findByUserIdAndPostIdIn(principal.userId(), ids)
+                    .stream().map(PostLike::getPostId).collect(Collectors.toSet());
+        return slice.map(p -> PostSummaryResponse.from(
+                p, authorNames.get(p.getAuthorUserId()),
+                storageService.presignedGetUrl(p.getScreenshotKey()),
+                likedPostIds.contains(p.getId())));
     }
 
     /** F-POST-03 単体取得 */
     @GetMapping("/{id}")
     public PostResponse get(@AuthenticationPrincipal AuthPrincipal principal,
                             @PathVariable Long id) {
-        return toResponse(postService.get(principal, id));
+        return toResponse(postService.get(principal, id), principal);
+    }
+
+    /** いいね（👍）を付ける。更新後のいいね数＋押下状態を返す。 */
+    @PostMapping("/{id}/like")
+    public LikeResponse like(@AuthenticationPrincipal AuthPrincipal principal, @PathVariable Long id) {
+        return new LikeResponse(postLikeService.like(principal, id), true);
+    }
+
+    /** いいね（👍）を外す。 */
+    @DeleteMapping("/{id}/like")
+    public LikeResponse unlike(@AuthenticationPrincipal AuthPrincipal principal, @PathVariable Long id) {
+        return new LikeResponse(postLikeService.unlike(principal, id), false);
     }
 
     /** F-POST-02 編集（所有者のみ） */
@@ -74,7 +114,7 @@ public class PostController {
     public PostResponse update(@AuthenticationPrincipal AuthPrincipal principal,
                                @PathVariable Long id,
                                @Valid @RequestBody PostUpdateRequest request) {
-        return toResponse(postService.update(principal, id, request));
+        return toResponse(postService.update(principal, id, request), principal);
     }
 
     /** F-POST-02 論理削除（所有者のみ） */
@@ -90,6 +130,6 @@ public class PostController {
     public PostResponse selectBestReview(@AuthenticationPrincipal AuthPrincipal principal,
                                          @PathVariable Long id,
                                          @Valid @RequestBody BestReviewRequest request) {
-        return toResponse(postService.selectBestReview(principal, id, request.reviewId()));
+        return toResponse(postService.selectBestReview(principal, id, request.reviewId()), principal);
     }
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/PostLike.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/PostLike.java
@@ -1,0 +1,32 @@
+package com.reviewboard.domain.post;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+
+/**
+ * いいね（👍）：ユーザーが成果物に付ける「いいね」。1 ユーザー 1 投稿につき 1 件（UNIQUE）。
+ */
+@Entity
+@Table(name = "post_likes", uniqueConstraints = @UniqueConstraint(columnNames = {"post_id", "user_id"}))
+@Getter
+@Setter
+@NoArgsConstructor
+public class PostLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "post_id", nullable = false)
+    private Long postId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/PostLikeRepository.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/PostLikeRepository.java
@@ -1,0 +1,19 @@
+package com.reviewboard.domain.post;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+
+    Optional<PostLike> findByPostIdAndUserId(Long postId, Long userId);
+
+    boolean existsByPostIdAndUserId(Long postId, Long userId);
+
+    /** 一覧で「自分がいいね済みの投稿」をまとめて判定（N+1 回避）。 */
+    List<PostLike> findByUserIdAndPostIdIn(Long userId, List<Long> postIds);
+
+    /** 再計算（S-3 権威ソース）：投稿のいいね数。 */
+    int countByPostId(Long postId);
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/PostLikeService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/PostLikeService.java
@@ -1,0 +1,55 @@
+package com.reviewboard.domain.post;
+
+import com.reviewboard.common.ResourceNotFoundException;
+import com.reviewboard.domain.auth.AuthPrincipal;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+
+/**
+ * いいね（👍）のユースケース。★S軸：対象投稿は同 cohort・未削除に限る（他は 404）。
+ * いいね数は Post の非正規化カウンタを同一Txで増減する（一覧・ランキングの軽量化）。
+ */
+@Service
+public class PostLikeService {
+
+    private final PostRepository postRepository;
+    private final PostLikeRepository postLikeRepository;
+
+    public PostLikeService(PostRepository postRepository, PostLikeRepository postLikeRepository) {
+        this.postRepository = postRepository;
+        this.postLikeRepository = postLikeRepository;
+    }
+
+    /** いいねを付ける（冪等：既にあれば数は変えない）。更新後のいいね数を返す。 */
+    @Transactional
+    public int like(AuthPrincipal principal, Long postId) {
+        Post post = load(principal, postId);
+        if (!postLikeRepository.existsByPostIdAndUserId(postId, principal.userId())) {
+            PostLike like = new PostLike();
+            like.setPostId(postId);
+            like.setUserId(principal.userId());
+            like.setCreatedAt(OffsetDateTime.now());
+            postLikeRepository.save(like);
+            post.setLikeCount(post.getLikeCount() + 1);
+        }
+        return post.getLikeCount();
+    }
+
+    /** いいねを外す（冪等：無ければ何もしない）。更新後のいいね数を返す。 */
+    @Transactional
+    public int unlike(AuthPrincipal principal, Long postId) {
+        Post post = load(principal, postId);
+        postLikeRepository.findByPostIdAndUserId(postId, principal.userId()).ifPresent((existing) -> {
+            postLikeRepository.delete(existing);
+            post.setLikeCount(Math.max(0, post.getLikeCount() - 1));
+        });
+        return post.getLikeCount();
+    }
+
+    private Post load(AuthPrincipal principal, Long postId) {
+        return postRepository.findByIdAndCohortIdAndDeletedAtIsNull(postId, principal.cohortId())
+                .orElseThrow(() -> new ResourceNotFoundException("post not found: " + postId));
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/PostRepository.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/PostRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,11 +18,16 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     /** 成長記録（F-PROF-01）：あるユーザーの投稿履歴（未削除・新しい順） */
     List<Post> findByAuthorUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long authorUserId);
 
+    /** ランディング統計：cohort 内の未削除投稿（集計の母集合）。 */
+    List<Post> findByCohortIdAndDeletedAtIsNull(Long cohortId);
+
     /**
      * 一覧・検索・絞り込み（F-POST-03 / F-SEARCH-01 / F-FILTER-01）。
      * ★cohort 境界（IDOR 遮断）は常に効かせたまま、任意条件を AND で重ねる。
      * <ul>
      *   <li>{@code q}：タイトル/説明の部分一致（大文字小文字無視）。null/空なら無視。</li>
+     *   <li>{@code aspects}/{@code tones}：キーワードから解決した観点・トーン。投稿のタグに一致すれば
+     *       本文に無くてもヒットさせる（F-SEARCH-01「観点から探す」）。空集合なら一致しない。</li>
      *   <li>{@code status}：募集状態（OPEN/CLOSED）。null なら無視。</li>
      *   <li>{@code unreviewedOnly}：true なら未レビュー（review_count = 0）のみ。</li>
      * </ul>
@@ -32,12 +38,16 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             where p.cohortId = :cohortId and p.deletedAt is null
               and (cast(:q as string) is null
                    or lower(p.title) like lower(concat('%', cast(:q as string), '%'))
-                   or lower(p.description) like lower(concat('%', cast(:q as string), '%')))
+                   or lower(p.description) like lower(concat('%', cast(:q as string), '%'))
+                   or exists (select 1 from p.reviewAspects asp where asp in :aspects)
+                   or exists (select 1 from p.reviewTones tn where tn in :tones))
               and (:status is null or p.recruitStatus = :status)
               and (:unreviewedOnly = false or p.reviewCount = 0)
             """)
     Slice<Post> search(@Param("cohortId") Long cohortId,
                        @Param("q") String q,
+                       @Param("aspects") Collection<ReviewAspect> aspects,
+                       @Param("tones") Collection<ReviewTone> tones,
                        @Param("status") RecruitStatus status,
                        @Param("unreviewedOnly") boolean unreviewedOnly,
                        Pageable pageable);

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/PostService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/PostService.java
@@ -56,7 +56,7 @@ public class PostService {
         post.setDemoUrl(req.demoUrl());
         post.setScreenshotKey(req.screenshotKey());
         post.setRecruitStatus(RecruitStatus.OPEN);
-        applyReviewPreferences(post, req.reviewTone(), req.reviewAspects(), req.aiUsage());
+        applyReviewPreferences(post, req.reviewTones(), req.reviewAspects(), req.aiUsage());
         post.setCreatedAt(now);
         post.setUpdatedAt(now);
         postRepository.save(post);
@@ -76,19 +76,29 @@ public class PostService {
      * 自 cohort・未削除のみ（IDOR 遮断は Repository クエリで常時担保）。ページネーション（母 P-2）。
      *
      * @param q             キーワード（タイトル/説明の部分一致。空/ null は無視）
+     * @param aspects       キーワードから解決した観点（タグ一致でヒット。null/空は無視）
+     * @param tones         キーワードから解決したトーン（タグ一致でヒット。null/空は無視）
      * @param status        募集状態フィルタ（null は無視）
      * @param unreviewedOnly 未レビュー（review_count=0）のみに絞る
      * @param sort          並び順："reviews"（レビュー数降順）／それ以外は新着降順
      */
     @Transactional(readOnly = true)
-    public Slice<Post> search(AuthPrincipal principal, String q, RecruitStatus status,
+    public Slice<Post> search(AuthPrincipal principal, String q,
+                              java.util.Collection<ReviewAspect> aspects,
+                              java.util.Collection<ReviewTone> tones,
+                              RecruitStatus status,
                               boolean unreviewedOnly, String sort, Pageable pageable) {
         String keyword = (q == null || q.isBlank()) ? null : q.trim();
-        Sort order = "reviews".equals(sort)
-                ? Sort.by(Sort.Direction.DESC, "reviewCount").and(Sort.by(Sort.Direction.DESC, "createdAt"))
-                : Sort.by(Sort.Direction.DESC, "createdAt");
+        // 空集合は IN 句が常に偽になり「一致なし」として扱われる（Hibernate 6）。
+        java.util.Collection<ReviewAspect> asp = aspects == null ? java.util.List.of() : aspects;
+        java.util.Collection<ReviewTone> tn = tones == null ? java.util.List.of() : tones;
+        Sort order = switch (sort == null ? "" : sort) {
+            case "reviews" -> Sort.by(Sort.Direction.DESC, "reviewCount").and(Sort.by(Sort.Direction.DESC, "createdAt"));
+            case "likes" -> Sort.by(Sort.Direction.DESC, "likeCount").and(Sort.by(Sort.Direction.DESC, "createdAt"));
+            default -> Sort.by(Sort.Direction.DESC, "createdAt");
+        };
         Pageable sorted = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), order);
-        return postRepository.search(principal.cohortId(), keyword, status, unreviewedOnly, sorted);
+        return postRepository.search(principal.cohortId(), keyword, asp, tn, status, unreviewedOnly, sorted);
     }
 
     /** F-POST-02 編集。所有者のみ（不一致・他 cohort・削除済みは 404）。 */
@@ -100,7 +110,7 @@ public class PostService {
         post.setRepoUrl(req.repoUrl());
         post.setDemoUrl(req.demoUrl());
         post.setScreenshotKey(req.screenshotKey());
-        applyReviewPreferences(post, req.reviewTone(), req.reviewAspects(), req.aiUsage());
+        applyReviewPreferences(post, req.reviewTones(), req.reviewAspects(), req.aiUsage());
         post.setUpdatedAt(OffsetDateTime.now());
         auditService.record(principal, AuditAction.POST_UPDATED, AuditTargetType.POST, postId);
         return post;
@@ -140,9 +150,12 @@ public class PostService {
      * tone は null で未設定に戻る。aspects は送られた集合で全置換（null は空集合扱い）。
      * 設定主体は所有者に限る（呼び出し元の create/loadOwned で担保。★S軸）。
      */
-    private void applyReviewPreferences(Post post, ReviewTone tone, Set<ReviewAspect> aspects, AiUsage aiUsage) {
-        post.setReviewTone(tone);
+    private void applyReviewPreferences(Post post, Set<ReviewTone> tones, Set<ReviewAspect> aspects, AiUsage aiUsage) {
         post.setAiUsage(aiUsage);
+        post.getReviewTones().clear();
+        if (tones != null) {
+            post.getReviewTones().addAll(tones);
+        }
         post.getReviewAspects().clear();
         if (aspects != null) {
             post.getReviewAspects().addAll(aspects);

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/ReviewAspect.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/ReviewAspect.java
@@ -6,7 +6,11 @@ package com.reviewboard.domain.post;
 public enum ReviewAspect {
     DB,
     UI,
+    UX,
     CODE,
+    ARCHITECTURE,
+    TESTING,
     SECURITY,
-    PERFORMANCE
+    PERFORMANCE,
+    ACCESSIBILITY
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/ReviewTone.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/ReviewTone.java
@@ -10,5 +10,9 @@ public enum ReviewTone {
     /** 辛口OK：厳しめの指摘を歓迎 */
     HARSH_OK,
     /** 優しめ希望：言葉選びに配慮してほしい */
-    GENTLE
+    GENTLE,
+    /** じっくり詳しく：時間をかけて深く見てほしい */
+    DETAILED,
+    /** ざっくりでOK：要点だけ手早く見てほしい */
+    QUICK_OK
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/LikeResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/LikeResponse.java
@@ -1,0 +1,7 @@
+package com.reviewboard.domain.post.dto;
+
+/**
+ * いいね操作後の状態。フロントのボタン表示（押下状態＋件数）を即時更新するために返す。
+ */
+public record LikeResponse(int likeCount, boolean liked) {
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostCreateRequest.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostCreateRequest.java
@@ -12,7 +12,7 @@ import java.util.Set;
  * 投稿作成リクエスト（F-POST-01）。タイトルと説明は必須、URL/スクショキーは任意。
  * cohort_id・author は principal（検証済み JWT）から導出し、クライアント入力は信用しない（★S軸）。
  *
- * @param reviewTone    F-SAFE-01 希望トーン（任意・null は未設定）
+ * @param reviewTones   F-SAFE-01 歓迎トーン（任意・多値・Set で重複排除。空は未設定）
  * @param reviewAspects F-REQ-01 募集観点（任意・Set で重複排除。不正な enum 値は 400）
  * @param aiUsage       AI使用状況の開示タグ（任意・null は未申告・Issue #172）
  */
@@ -22,7 +22,7 @@ public record PostCreateRequest(
         @Size(max = 512) String repoUrl,
         @Size(max = 512) String demoUrl,
         @Size(max = 512) String screenshotKey,
-        ReviewTone reviewTone,
+        Set<ReviewTone> reviewTones,
         Set<ReviewAspect> reviewAspects,
         AiUsage aiUsage) {
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostResponse.java
@@ -25,8 +25,10 @@ public record PostResponse(
         String screenshotUrl,
         RecruitStatus recruitStatus,
         int reviewCount,
+        int likeCount,
+        boolean liked,
         Long bestReviewId,
-        ReviewTone reviewTone,
+        List<ReviewTone> reviewTones,
         List<ReviewAspect> reviewAspects,
         AiUsage aiUsage,
         OffsetDateTime createdAt,
@@ -35,13 +37,15 @@ public record PostResponse(
     /**
      * @param screenshotUrl 表示用の署名付き GET URL（SEC-8：private 保存・短命 URL のみ公開）。
      *                      key が無ければ null。生成は {@code StorageService} が担い、Controller で渡す。
+     * @param liked         閲覧者がこの投稿にいいね済みか（ボタンの押下状態用）。
      */
-    public static PostResponse from(Post p, String screenshotUrl) {
+    public static PostResponse from(Post p, String screenshotUrl, boolean liked) {
         return new PostResponse(
                 p.getId(), p.getAuthorUserId(), p.getCohortId(),
                 p.getTitle(), p.getDescription(), p.getRepoUrl(), p.getDemoUrl(),
                 p.getScreenshotKey(), screenshotUrl, p.getRecruitStatus(), p.getReviewCount(),
-                p.getBestReviewId(), p.getReviewTone(), new ArrayList<>(p.getReviewAspects()),
+                p.getLikeCount(), liked,
+                p.getBestReviewId(), new ArrayList<>(p.getReviewTones()), new ArrayList<>(p.getReviewAspects()),
                 p.getAiUsage(), p.getCreatedAt(), p.getUpdatedAt());
     }
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostSummaryResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostSummaryResponse.java
@@ -17,18 +17,27 @@ import java.util.List;
 public record PostSummaryResponse(
         Long id,
         Long authorUserId,
+        String authorDisplayName,
         String title,
         RecruitStatus recruitStatus,
         int reviewCount,
-        ReviewTone reviewTone,
+        int likeCount,
+        boolean liked,
+        List<ReviewTone> reviewTones,
         List<ReviewAspect> reviewAspects,
         AiUsage aiUsage,
+        String screenshotUrl,
         OffsetDateTime createdAt) {
 
-    public static PostSummaryResponse from(Post p) {
+    /**
+     * 一覧カード表示（案L の WORKS / RANKING）用に著者名・スクショ URL・いいね状態を補って組み立てる。
+     * 著者名・URL・liked は呼び出し側でバッチ解決して渡す（N+1 回避・SEC-8）。
+     */
+    public static PostSummaryResponse from(Post p, String authorDisplayName, String screenshotUrl, boolean liked) {
         return new PostSummaryResponse(
-                p.getId(), p.getAuthorUserId(), p.getTitle(),
-                p.getRecruitStatus(), p.getReviewCount(),
-                p.getReviewTone(), new ArrayList<>(p.getReviewAspects()), p.getAiUsage(), p.getCreatedAt());
+                p.getId(), p.getAuthorUserId(), authorDisplayName, p.getTitle(),
+                p.getRecruitStatus(), p.getReviewCount(), p.getLikeCount(), liked,
+                new ArrayList<>(p.getReviewTones()), new ArrayList<>(p.getReviewAspects()), p.getAiUsage(),
+                screenshotUrl, p.getCreatedAt());
     }
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostUpdateRequest.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/dto/PostUpdateRequest.java
@@ -11,7 +11,7 @@ import java.util.Set;
 /**
  * 投稿更新リクエスト（F-POST-02）。所有者のみ実行可（Service で検証、不一致は 404）。
  *
- * @param reviewTone    F-SAFE-01 希望トーン（任意・null は未設定に戻す）
+ * @param reviewTones   F-SAFE-01 歓迎トーン（任意・多値・送られた集合で全置換）
  * @param reviewAspects F-REQ-01 募集観点（任意・送られた集合で全置換）
  * @param aiUsage       AI使用状況の開示タグ（任意・null は未申告に戻す・Issue #172）
  */
@@ -21,7 +21,7 @@ public record PostUpdateRequest(
         @Size(max = 512) String repoUrl,
         @Size(max = 512) String demoUrl,
         @Size(max = 512) String screenshotKey,
-        ReviewTone reviewTone,
+        Set<ReviewTone> reviewTones,
         Set<ReviewAspect> reviewAspects,
         AiUsage aiUsage) {
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/stats/StatsController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/stats/StatsController.java
@@ -1,0 +1,28 @@
+package com.reviewboard.domain.stats;
+
+import com.reviewboard.domain.auth.AuthPrincipal;
+import com.reviewboard.domain.stats.dto.LandingStatsResponse;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 集計 API。認証必須・cohort 境界は {@link StatsService} に集約（★S軸）。
+ */
+@RestController
+@RequestMapping("/api/stats")
+public class StatsController {
+
+    private final StatsService statsService;
+
+    public StatsController(StatsService statsService) {
+        this.statsService = statsService;
+    }
+
+    /** トップpage（案L ランディング）の統計＋実績ユーザ（同 cohort 内）。 */
+    @GetMapping("/landing")
+    public LandingStatsResponse landing(@AuthenticationPrincipal AuthPrincipal principal) {
+        return statsService.landing(principal);
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/stats/StatsService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/stats/StatsService.java
@@ -1,0 +1,83 @@
+package com.reviewboard.domain.stats;
+
+import com.reviewboard.domain.auth.AuthPrincipal;
+import com.reviewboard.domain.evaluation.Evaluation;
+import com.reviewboard.domain.evaluation.EvaluationRepository;
+import com.reviewboard.domain.evaluation.EvaluationResult;
+import com.reviewboard.domain.post.Post;
+import com.reviewboard.domain.post.PostRepository;
+import com.reviewboard.domain.review.ReviewRepository;
+import com.reviewboard.domain.stats.dto.LandingStatsResponse;
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * トップページの集計（案L ランディング）。★S軸：集計は閲覧者の cohort 内に閉じる。
+ * 母集合（cohort の投稿）を一度引いて、件数・合格・実績をメモリ上で束ねる（cohort 規模は小さい・母 P-3）。
+ */
+@Service
+public class StatsService {
+
+    /** ヒーロー右側に出す実績ユーザの最大数。 */
+    private static final int FEATURED_LIMIT = 3;
+
+    private final PostRepository postRepository;
+    private final ReviewRepository reviewRepository;
+    private final EvaluationRepository evaluationRepository;
+    private final UserRepository userRepository;
+
+    public StatsService(PostRepository postRepository, ReviewRepository reviewRepository,
+                        EvaluationRepository evaluationRepository, UserRepository userRepository) {
+        this.postRepository = postRepository;
+        this.reviewRepository = reviewRepository;
+        this.evaluationRepository = evaluationRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public LandingStatsResponse landing(AuthPrincipal principal) {
+        Long cohortId = principal.cohortId();
+
+        List<Post> posts = postRepository.findByCohortIdAndDeletedAtIsNull(cohortId);
+        List<Long> postIds = posts.stream().map(Post::getId).toList();
+
+        long reviewsCount = postIds.isEmpty() ? 0
+                : reviewRepository.findByPostIdInAndDeletedAtIsNull(postIds).size();
+
+        // 最新評価が「合格」の投稿（合格バッジ数＋実績ユーザの合格判定に使う）。
+        List<Evaluation> approved = postIds.isEmpty() ? List.of()
+                : evaluationRepository.findByPostIdInAndLatestIsTrue(postIds).stream()
+                    .filter(e -> e.getResult() == EvaluationResult.APPROVED)
+                    .toList();
+
+        Map<Long, Long> authorByPost = posts.stream()
+                .collect(Collectors.toMap(Post::getId, Post::getAuthorUserId));
+        Set<Long> approvedAuthorIds = approved.stream()
+                .map(e -> authorByPost.get(e.getPostId()))
+                .collect(Collectors.toSet());
+        Map<Long, Long> postsByAuthor = posts.stream()
+                .collect(Collectors.groupingBy(Post::getAuthorUserId, Collectors.counting()));
+
+        // 実績ユーザ：投稿を持つ同 cohort メンバーを受領レビュー数の多い順に最大 N 名。
+        List<LandingStatsResponse.FeaturedUser> featured = userRepository.findByCohortId(cohortId).stream()
+                .filter(u -> postsByAuthor.containsKey(u.getId()))
+                .sorted(Comparator.comparingInt(User::getReceivedReviewsCount).reversed())
+                .limit(FEATURED_LIMIT)
+                .map(u -> new LandingStatsResponse.FeaturedUser(
+                        u.getId(), u.getDisplayName(), u.getRole(),
+                        postsByAuthor.getOrDefault(u.getId(), 0L).intValue(),
+                        u.getReceivedReviewsCount(),
+                        approvedAuthorIds.contains(u.getId())))
+                .toList();
+
+        return new LandingStatsResponse(posts.size(), reviewsCount, approved.size(), featured);
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/stats/dto/LandingStatsResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/stats/dto/LandingStatsResponse.java
@@ -1,0 +1,36 @@
+package com.reviewboard.domain.stats.dto;
+
+import com.reviewboard.domain.user.UserRole;
+
+import java.util.List;
+
+/**
+ * トップページ（案L ランディング）の集計。すべて閲覧者の cohort 内に閉じた実データ（★S軸）。
+ *
+ * @param postsCount         cohort 内の未削除投稿数
+ * @param reviewsCount       それらに付いた未削除レビュー数
+ * @param approvedBadgesCount 最新評価が「合格」の投稿数（＝合格バッジ数）
+ * @param featured           実績の見えるメンバー（受領レビュー数の多い順・最大3名）
+ */
+public record LandingStatsResponse(
+        long postsCount,
+        long reviewsCount,
+        long approvedBadgesCount,
+        List<FeaturedUser> featured) {
+
+    /**
+     * ヒーロー右側の実績カード用。
+     *
+     * @param postsCount   その人の cohort 内投稿数
+     * @param reviewsCount 受領レビュー数（非正規化カウンタ）
+     * @param approved     合格バッジ（投稿のいずれかが「合格」）
+     */
+    public record FeaturedUser(
+            Long userId,
+            String displayName,
+            UserRole role,
+            int postsCount,
+            int reviewsCount,
+            boolean approved) {
+    }
+}

--- a/review-board/backend/src/main/resources/db/migration/V10__review_tone_multi.sql
+++ b/review-board/backend/src/main/resources/db/migration/V10__review_tone_multi.sql
@@ -1,0 +1,14 @@
+-- F-SAFE-01：レビューの希望トーンを「単一」→「多値」へ変更（複数歓迎を表現できるように）。
+-- 観点（post_review_aspects）と同じく正規化テーブルにする。
+CREATE TABLE post_review_tones (
+    post_id BIGINT      NOT NULL REFERENCES posts (id),
+    tone    VARCHAR(20) NOT NULL,
+    PRIMARY KEY (post_id, tone)
+);
+
+-- 既存の単一トーンを保全（NULL 以外を 1 行ずつ移送）。
+INSERT INTO post_review_tones (post_id, tone)
+SELECT id, review_tone FROM posts WHERE review_tone IS NOT NULL;
+
+-- 旧・単一列を撤去。
+ALTER TABLE posts DROP COLUMN review_tone;

--- a/review-board/backend/src/main/resources/db/migration/V11__add_post_likes.sql
+++ b/review-board/backend/src/main/resources/db/migration/V11__add_post_likes.sql
@@ -1,0 +1,13 @@
+-- いいね（👍）：成果物への「いいね」。ランキング（いいね数順）の基準。
+-- 1 ユーザー 1 投稿につき 1 件（UNIQUE）。投稿削除で子行も消す。
+CREATE TABLE post_likes (
+    id         BIGSERIAL PRIMARY KEY,
+    post_id    BIGINT      NOT NULL REFERENCES posts (id),
+    user_id    BIGINT      NOT NULL REFERENCES users (id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (post_id, user_id)
+);
+CREATE INDEX idx_post_likes_post ON post_likes (post_id);
+
+-- 非正規化カウンタ（一覧・ランキングの軽量化。書き込みと同一Txで増減・母 S-3）。
+ALTER TABLE posts ADD COLUMN like_count INTEGER NOT NULL DEFAULT 0;

--- a/review-board/backend/src/test/java/com/reviewboard/domain/post/PostReviewPreferenceIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/post/PostReviewPreferenceIntegrationTest.java
@@ -33,56 +33,55 @@ class PostReviewPreferenceIntegrationTest extends AbstractIntegrationTest {
         otherEmail = newUser("other@example.com", UserRole.STUDENT, cohortId).getEmail();
     }
 
-    /** 作成時にトーン・観点を設定でき、詳細取得で返る。 */
+    /** 作成時にトーン（複数可）・観点を設定でき、詳細取得で返る。 */
     @Test
-    void create_with_tone_and_aspects_persists() throws Exception {
+    void create_with_tones_and_aspects_persists() throws Exception {
         MvcResult res = mockMvc.perform(post("/api/posts").cookie(login(authorEmail))
                         .contentType("application/json")
-                        .content("{\"title\":\"作品\",\"description\":\"説明\",\"reviewTone\":\"GENTLE\",\"reviewAspects\":[\"DB\",\"SECURITY\"]}"))
+                        .content("{\"title\":\"作品\",\"description\":\"説明\",\"reviewTones\":[\"GENTLE\",\"DETAILED\"],\"reviewAspects\":[\"DB\",\"SECURITY\"]}"))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.reviewTone").value("GENTLE"))
+                .andExpect(jsonPath("$.reviewTones", org.hamcrest.Matchers.containsInAnyOrder("GENTLE", "DETAILED")))
                 .andExpect(jsonPath("$.reviewAspects", org.hamcrest.Matchers.containsInAnyOrder("DB", "SECURITY")))
                 .andReturn();
         long id = readId(res);
 
         mockMvc.perform(get("/api/posts/" + id).cookie(login(authorEmail)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.reviewTone").value("GENTLE"))
+                .andExpect(jsonPath("$.reviewTones", org.hamcrest.Matchers.containsInAnyOrder("GENTLE", "DETAILED")))
                 .andExpect(jsonPath("$.reviewAspects", org.hamcrest.Matchers.containsInAnyOrder("DB", "SECURITY")));
     }
 
-    /** 未指定なら未設定（null）・空配列で作成できる。 */
+    /** 未指定なら未設定（空配列）で作成できる。 */
     @Test
     void create_without_preferences_defaults_to_unset() throws Exception {
-        MvcResult res = mockMvc.perform(post("/api/posts").cookie(login(authorEmail))
+        mockMvc.perform(post("/api/posts").cookie(login(authorEmail))
                         .contentType("application/json")
                         .content("{\"title\":\"作品\",\"description\":\"説明\"}"))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.reviewTone").doesNotExist())
-                .andExpect(jsonPath("$.reviewAspects").isEmpty())
-                .andReturn();
+                .andExpect(jsonPath("$.reviewTones").isEmpty())
+                .andExpect(jsonPath("$.reviewAspects").isEmpty());
     }
 
-    /** 所有者は更新で全置換できる（トーン変更・観点入れ替え）。 */
+    /** 所有者は更新で全置換できる（トーン複数入れ替え・観点入れ替え）。 */
     @Test
     void owner_can_update_preferences() throws Exception {
-        long id = createPost(login(authorEmail), "{\"title\":\"作品\",\"description\":\"説明\",\"reviewTone\":\"HARSH_OK\",\"reviewAspects\":[\"CODE\"]}");
+        long id = createPost(login(authorEmail), "{\"title\":\"作品\",\"description\":\"説明\",\"reviewTones\":[\"HARSH_OK\"],\"reviewAspects\":[\"CODE\"]}");
 
         mockMvc.perform(put("/api/posts/" + id).cookie(login(authorEmail))
                         .contentType("application/json")
-                        .content("{\"title\":\"作品\",\"description\":\"説明\",\"reviewTone\":\"WELCOME_BEGINNER\",\"reviewAspects\":[\"UI\",\"PERFORMANCE\"]}"))
+                        .content("{\"title\":\"作品\",\"description\":\"説明\",\"reviewTones\":[\"WELCOME_BEGINNER\",\"QUICK_OK\"],\"reviewAspects\":[\"UI\",\"PERFORMANCE\"]}"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.reviewTone").value("WELCOME_BEGINNER"))
+                .andExpect(jsonPath("$.reviewTones", org.hamcrest.Matchers.containsInAnyOrder("WELCOME_BEGINNER", "QUICK_OK")))
                 .andExpect(jsonPath("$.reviewAspects", org.hamcrest.Matchers.containsInAnyOrder("UI", "PERFORMANCE")));
     }
 
     /** ★非所有者は更新できない（存在を漏らさず 404）。 */
     @Test
     void non_owner_cannot_update_returns404() throws Exception {
-        long id = createPost(login(authorEmail), "{\"title\":\"作品\",\"description\":\"説明\",\"reviewTone\":\"GENTLE\"}");
+        long id = createPost(login(authorEmail), "{\"title\":\"作品\",\"description\":\"説明\",\"reviewTones\":[\"GENTLE\"]}");
         mockMvc.perform(put("/api/posts/" + id).cookie(login(otherEmail))
                         .contentType("application/json")
-                        .content("{\"title\":\"乗っ取り\",\"description\":\"説明\",\"reviewTone\":\"HARSH_OK\"}"))
+                        .content("{\"title\":\"乗っ取り\",\"description\":\"説明\",\"reviewTones\":[\"HARSH_OK\"]}"))
                 .andExpect(status().isNotFound());
     }
 

--- a/review-board/frontend/src/App.jsx
+++ b/review-board/frontend/src/App.jsx
@@ -1,4 +1,5 @@
-import { Routes, Route } from 'react-router-dom';
+import { useEffect } from 'react';
+import { Routes, Route, useLocation } from 'react-router-dom';
 import { AuthProvider } from './context/AuthContext';
 import ProtectedRoute from './components/ProtectedRoute';
 import Header from './components/Header';
@@ -10,11 +11,21 @@ import PostDetailPage from './pages/PostDetailPage';
 import ProfilePage from './pages/ProfilePage';
 import NotificationsPage from './pages/NotificationsPage';
 
+// ページ（パス）が切り替わったらスクロール位置を先頭へ戻す。
+// React Router は既定でスクロールを復元しないため、長いページから遷移すると
+// 前ページのスクロール量が残り「自動スクロール」のように見えるのを防ぐ。
+// 同一パス内の遷移（トップ "/" → "/?q=..."）では発火しないので、PostsPage の WORKS スクロールには干渉しない。
+function ScrollToTop() {
+  const { pathname } = useLocation();
+  useEffect(() => { window.scrollTo(0, 0); }, [pathname]);
+  return null;
+}
+
 // 認証必須ページの共通レイアウト（ヘッダー＋本文）。
 function Shell({ children }) {
   return (
     <ProtectedRoute>
-      <div className="min-h-screen bg-gray-50">
+      <div className="min-h-screen">
         <Header />
         {children}
       </div>
@@ -25,6 +36,7 @@ function Shell({ children }) {
 export default function App() {
   return (
     <AuthProvider>
+      <ScrollToTop />
       <Routes>
         <Route path="/login" element={<LoginPage />} />
         <Route path="/" element={<Shell><PostsPage /></Shell>} />

--- a/review-board/frontend/src/api/posts.js
+++ b/review-board/frontend/src/api/posts.js
@@ -1,10 +1,13 @@
 import client from './client';
 
 // F-POST-03 一覧 ＋ F-SEARCH-01 検索 ＋ F-FILTER-01 絞り込み/並び替え。
-// opts: { q, status, unreviewed, sort }（すべて任意）。Spring の Slice 形（content[]）を返す。
+// opts: { q, aspects[], tones[], status, unreviewed, sort }（すべて任意）。Spring の Slice 形（content[]）を返す。
 export const fetchPosts = (opts = {}, page = 0, size = 20) => {
   const params = { page, size };
   if (opts.q) params.q = opts.q;
+  // 観点・トーンはキーワードから解決した enum 配列。Spring の List<Enum> はカンマ区切りで束ねる。
+  if (opts.aspects?.length) params.aspects = opts.aspects.join(',');
+  if (opts.tones?.length) params.tones = opts.tones.join(',');
   if (opts.status) params.status = opts.status;
   if (opts.unreviewed) params.unreviewed = true;
   if (opts.sort) params.sort = opts.sort;
@@ -26,3 +29,7 @@ export const deletePost = (id) => client.delete(`/posts/${id}`);
 // F-REV-05 ベストレビュー選択（投稿者のみ・backend が非所有者を 404）
 export const selectBestReview = (postId, reviewId) =>
   client.put(`/posts/${postId}/best-review`, { reviewId }).then((r) => r.data);
+
+// いいね（👍）。{likeCount, liked} を返す。
+export const likePost = (id) => client.post(`/posts/${id}/like`).then((r) => r.data);
+export const unlikePost = (id) => client.delete(`/posts/${id}/like`).then((r) => r.data);

--- a/review-board/frontend/src/api/stats.js
+++ b/review-board/frontend/src/api/stats.js
@@ -1,0 +1,4 @@
+import client from './client';
+
+// トップページ（案L ランディング）の統計＋実績ユーザ（同 cohort 内の実データ）。
+export const fetchLandingStats = () => client.get('/stats/landing').then((r) => r.data);

--- a/review-board/frontend/src/components/AppShot.jsx
+++ b/review-board/frontend/src/components/AppShot.jsx
@@ -1,0 +1,147 @@
+// プレビュー用：投稿された「WEB アプリのトップページ」を実スクショ風に描いたミニ画面。
+// 本実装では post.screenshotUrl（アップロード済みスクショ）を <img> 表示に置き換える。
+// ここでは種別ごとに“それっぽい本物のサイト”を縮小描画し、撮影したスクショのように見せる。
+
+function Todo() {
+  const items = [['UI を整える', true], ['Firestore ルール見直し', true], ['テストを書く', false], ['デプロイ設定', false]];
+  return (
+    <div className="h-full bg-white px-2.5 py-2 text-gray-800">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-[9px] font-bold">✓ My Tasks</span>
+        <span className="rounded bg-sky-500 px-1.5 py-0.5 text-[7px] font-semibold text-white">＋ 追加</span>
+      </div>
+      <div className="space-y-1.5">
+        {items.map(([t, done]) => (
+          <div key={t} className="flex items-center gap-1.5 rounded bg-gray-50 px-1.5 py-1">
+            <span className={`flex h-2.5 w-2.5 items-center justify-center rounded-[3px] text-[6px] text-white ${done ? 'bg-sky-500' : 'border border-gray-300'}`}>{done ? '✓' : ''}</span>
+            <span className={`text-[7.5px] ${done ? 'text-gray-400 line-through' : 'text-gray-700'}`}>{t}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Portfolio() {
+  return (
+    <div className="flex h-full flex-col bg-white">
+      <div className="flex items-center justify-between border-b border-gray-100 px-2.5 py-1.5">
+        <span className="text-[8px] font-bold text-gray-900">SORA.dev</span>
+        <span className="flex gap-1.5 text-[6.5px] text-gray-500"><span>Works</span><span>About</span><span>Contact</span></span>
+      </div>
+      <div className="bg-gradient-to-br from-rose-50 to-pink-100 px-2.5 py-2.5">
+        <div className="text-[10px] font-extrabold leading-tight text-gray-900">Web Developer</div>
+        <div className="mt-0.5 text-[6.5px] text-gray-500">作品を通して学んでいます</div>
+        <span className="mt-1.5 inline-block rounded-full bg-rose-500 px-2 py-0.5 text-[6.5px] font-semibold text-white">View Works</span>
+      </div>
+      <div className="grid flex-1 grid-cols-3 gap-1 p-1.5">
+        {['from-sky-200 to-sky-300', 'from-amber-200 to-orange-300', 'from-violet-200 to-purple-300'].map((g) => (
+          <span key={g} className={`rounded bg-gradient-to-br ${g}`} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Api() {
+  const lines = [
+    [['@RestController', '#c792ea']],
+    [['@RequestMapping(', '#82aaff'], ['"/api/posts"', '#c3e88d'], [')', '#82aaff']],
+    [['public class ', '#89ddff'], ['PostController', '#ffcb6b'], [' {', '#89ddff']],
+    [['  @GetMapping', '#c792ea']],
+    [['  List<Post> ', '#89ddff'], ['list', '#82aaff'], ['() {', '#89ddff']],
+    [['    return ', '#c792ea'], ['service', '#f07178'], ['.findAll();', '#a6accd']],
+    [['  }', '#89ddff']],
+  ];
+  return (
+    <div className="h-full bg-slate-800 px-2 py-1.5 font-mono">
+      {lines.map((tokens, i) => (
+        <div key={i} className="flex items-center gap-1 leading-[1.35]">
+          <span className="w-2 text-right text-[6px] text-slate-600">{i + 1}</span>
+          <span className="text-[7px]" style={{ whiteSpace: 'pre' }}>
+            {tokens.map(([t, c], j) => <span key={j} style={{ color: c }}>{t}</span>)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function Weather() {
+  const days = [['月', '24°'], ['火', '22°'], ['水', '19°'], ['木', '26°']];
+  return (
+    <div className="flex h-full flex-col bg-gradient-to-b from-sky-400 to-sky-200 px-2.5 py-2 text-white">
+      <div className="text-[8px] font-semibold">東京</div>
+      <div className="flex items-center gap-1">
+        <span className="text-[26px] font-light leading-none">23°</span>
+        <span className="text-2xl">☀️</span>
+      </div>
+      <div className="text-[6.5px] opacity-90">晴れ・降水確率 10%</div>
+      <div className="mt-auto flex justify-between rounded-lg bg-white/20 px-2 py-1">
+        {days.map(([d, t]) => (
+          <span key={d} className="flex flex-col items-center text-[6.5px]"><span>{d}</span><span className="font-semibold">{t}</span></span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Chat() {
+  const msgs = [['A', '高橋', 'おはようございます！', false], ['そ', '田中', '再接続の実装できた？', true], ['A', '高橋', 'テスト中です👍', false]];
+  return (
+    <div className="flex h-full bg-white">
+      <div className="flex w-1/3 flex-col gap-1 bg-slate-800 px-1.5 py-1.5 text-white">
+        <span className="text-[7px] font-bold">review-board</span>
+        <span className="rounded bg-white/15 px-1 text-[6.5px]"># general</span>
+        <span className="px-1 text-[6.5px] text-slate-300"># random</span>
+        <span className="px-1 text-[6.5px] text-slate-300"># dev</span>
+      </div>
+      <div className="flex flex-1 flex-col gap-1.5 px-2 py-1.5">
+        {msgs.map(([ini, name, text, me], i) => (
+          <div key={i} className="flex items-start gap-1">
+            <span className={`flex h-3 w-3 items-center justify-center rounded-full text-[5px] text-white ${me ? 'bg-sky-500' : 'bg-emerald-500'}`}>{ini}</span>
+            <div><div className="text-[6px] font-semibold text-gray-700">{name}</div><div className="text-[6.5px] text-gray-600">{text}</div></div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Dashboard() {
+  return (
+    <div className="flex h-full flex-col bg-white px-2.5 py-2">
+      <div className="flex items-center justify-between">
+        <span className="text-[8px] font-bold text-gray-900">家計簿</span>
+        <span className="text-[6.5px] text-gray-400">2026年5月</span>
+      </div>
+      <div className="mt-1 flex gap-1.5">
+        <div className="flex-1 rounded bg-fuchsia-50 px-1.5 py-1"><div className="text-[6px] text-gray-500">支出</div><div className="text-[8px] font-bold text-fuchsia-600">¥82,400</div></div>
+        <div className="flex-1 rounded bg-emerald-50 px-1.5 py-1"><div className="text-[6px] text-gray-500">残高</div><div className="text-[8px] font-bold text-emerald-600">¥41,600</div></div>
+      </div>
+      <div className="mt-auto flex items-end gap-1 pt-1">
+        {[45, 70, 35, 85, 55, 60, 40].map((h, i) => (
+          <span key={i} className="flex-1 rounded-t bg-gradient-to-t from-fuchsia-400 to-purple-400" style={{ height: `${h}%` }} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const SCREENS = { todo: Todo, portfolio: Portfolio, api: Api, weather: Weather, chat: Chat, dashboard: Dashboard };
+
+export default function AppShot({ kind, className = '' }) {
+  const Screen = SCREENS[kind] || (() => <div className="h-full bg-gray-100" />);
+  return (
+    <div className={`flex h-full flex-col overflow-hidden bg-white ${className}`}>
+      {/* ブラウザ枠（撮影したスクショ風） */}
+      <div className="flex items-center gap-1 bg-gray-200/80 px-1.5 py-1">
+        <span className="h-1.5 w-1.5 rounded-full bg-red-400" />
+        <span className="h-1.5 w-1.5 rounded-full bg-amber-400" />
+        <span className="h-1.5 w-1.5 rounded-full bg-green-400" />
+        <span className="ml-1 flex h-2.5 flex-1 items-center rounded-full bg-white/90 px-1.5 text-[5.5px] text-gray-400">https://app.example.com</span>
+      </div>
+      <div className="min-h-0 flex-1"><Screen /></div>
+    </div>
+  );
+}

--- a/review-board/frontend/src/components/AvatarCropper.jsx
+++ b/review-board/frontend/src/components/AvatarCropper.jsx
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+// アバター切り抜き（正方形固定＋ズーム/移動・円プレビュー）。
+// 選択画像を canvas で正方形に書き出し、cropped File を onCropped に渡す（アップロードは親が担当）。
+// ライブラリ非依存：表示は object URL、出力は toBlob('image/jpeg')。
+const VIEW = 320; // 切り抜き枠（正方形）の表示サイズ(px)
+const OUT = 384; // 出力解像度（正方形・px）
+const MAX_ZOOM = 3;
+
+export default function AvatarCropper({ file, onCancel, onCropped }) {
+  const [img, setImg] = useState(null); // HTMLImageElement
+  const [zoom, setZoom] = useState(1);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const [busy, setBusy] = useState(false);
+  const drag = useRef(null);
+
+  // ファイル → object URL → Image（読み込み後に状態へ）。URL は解放する。
+  useEffect(() => {
+    const url = URL.createObjectURL(file);
+    const im = new Image();
+    im.onload = () => setImg(im);
+    im.src = url;
+    return () => URL.revokeObjectURL(url);
+  }, [file]);
+
+  // zoom=1 で短辺が枠いっぱい（cover）。
+  const coverScale = img ? VIEW / Math.min(img.naturalWidth, img.naturalHeight) : 1;
+  const scale = coverScale * zoom;
+  const dw = img ? img.naturalWidth * scale : 0;
+  const dh = img ? img.naturalHeight * scale : 0;
+
+  // 画像が常に枠を覆うよう offset を制限。
+  const clamp = useCallback((o) => {
+    const mx = Math.max(0, (dw - VIEW) / 2);
+    const my = Math.max(0, (dh - VIEW) / 2);
+    return { x: Math.min(mx, Math.max(-mx, o.x)), y: Math.min(my, Math.max(-my, o.y)) };
+  }, [dw, dh]);
+
+  useEffect(() => { setOffset((o) => clamp(o)); }, [zoom, clamp]);
+
+  const onPointerDown = (e) => {
+    drag.current = { x: e.clientX, y: e.clientY, ox: offset.x, oy: offset.y };
+    e.currentTarget.setPointerCapture(e.pointerId);
+  };
+  const onPointerMove = (e) => {
+    if (!drag.current) return;
+    setOffset(clamp({
+      x: drag.current.ox + (e.clientX - drag.current.x),
+      y: drag.current.oy + (e.clientY - drag.current.y),
+    }));
+  };
+  const onPointerUp = () => { drag.current = null; };
+
+  // 枠内の正方形を元画像座標へ写し、OUT×OUT に書き出す。
+  const confirm = () => {
+    if (!img) return;
+    setBusy(true);
+    const left = VIEW / 2 - dw / 2 + offset.x;
+    const top = VIEW / 2 - dh / 2 + offset.y;
+    const srcX = -left / scale;
+    const srcY = -top / scale;
+    const srcSize = VIEW / scale;
+
+    const canvas = document.createElement('canvas');
+    canvas.width = OUT;
+    canvas.height = OUT;
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(img, srcX, srcY, srcSize, srcSize, 0, 0, OUT, OUT);
+    canvas.toBlob(
+      (blob) => {
+        setBusy(false);
+        if (!blob) { onCancel(); return; }
+        onCropped(new File([blob], 'avatar.jpg', { type: 'image/jpeg' }));
+      },
+      'image/jpeg',
+      0.9,
+    );
+  };
+
+  const left = VIEW / 2 - dw / 2 + offset.x;
+  const top = VIEW / 2 - dh / 2 + offset.y;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" role="dialog" aria-modal="true" aria-label="アバターを切り抜き">
+      <div className="mac-card w-full max-w-sm p-6">
+        <h3 className="mac-h mb-1 text-lg">アバターを切り抜き</h3>
+        <p className="mb-4 text-xs text-gray-500">ドラッグで位置調整・スライダーで拡大。円の内側が表示されます。</p>
+
+        {/* 切り抜きビュー（正方形・円マスクで仕上がりを示す） */}
+        <div
+          className="relative mx-auto touch-none select-none overflow-hidden rounded-xl bg-gray-100"
+          style={{ width: VIEW, height: VIEW, cursor: drag.current ? 'grabbing' : 'grab' }}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerUp}
+        >
+          {img && (
+            <img
+              src={img.src}
+              alt=""
+              draggable="false"
+              style={{ position: 'absolute', left, top, width: dw, height: dh, maxWidth: 'none' }}
+            />
+          )}
+          {/* 円マスク（外側を黒く覆って隠し、円の内側だけを見せる） */}
+          <div
+            className="pointer-events-none absolute inset-0"
+            style={{ boxShadow: 'inset 0 0 0 9999px rgba(0,0,0,0.72)', WebkitMaskImage: 'radial-gradient(circle closest-side at center, transparent 99%, #000 100%)', maskImage: 'radial-gradient(circle closest-side at center, transparent 99%, #000 100%)' }}
+          />
+          <div className="pointer-events-none absolute inset-0 rounded-full ring-2 ring-black/80" />
+        </div>
+
+        {/* ズーム */}
+        <label className="mt-4 block">
+          <span className="mac-label">拡大</span>
+          <input
+            type="range"
+            min="1"
+            max={MAX_ZOOM}
+            step="0.01"
+            value={zoom}
+            onChange={(e) => setZoom(Number(e.target.value))}
+            className="w-full accent-navy-700"
+            aria-label="拡大率"
+          />
+        </label>
+
+        <div className="mt-4 flex justify-end gap-2">
+          <button type="button" onClick={onCancel} className="mac-btn-ghost">キャンセル</button>
+          <button type="button" onClick={confirm} disabled={!img || busy} className="mac-btn-navy">
+            {busy ? '処理中…' : 'この範囲で決定'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/review-board/frontend/src/components/AvatarUploader.jsx
+++ b/review-board/frontend/src/components/AvatarUploader.jsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import { uploadScreenshot } from '../api/uploads';
+import AvatarCropper from './AvatarCropper';
+
+// アバター選択 → 正方形に切り抜き → アップロード（SEC-8：返った key を onChange で親へ）。
+// プレビューは署名付き URL（private 保存・URL 経由でのみ表示）。
+// ファイル選択は <label>＋視覚的に隠した input で行う（display:none の input への JS click は
+// Safari/WebKit でブロックされるため。label 経由なら全ブラウザでネイティブに開く）。
+export default function AvatarUploader({ initialUrl = '', onChange }) {
+  const [preview, setPreview] = useState(initialUrl);
+  const [pending, setPending] = useState(null); // 切り抜き対象の元ファイル
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  const onSelect = (e) => {
+    const file = e.target.files?.[0];
+    if (file) { setError(''); setPending(file); }
+    e.target.value = ''; // 同じファイルを選び直せるようにリセット
+  };
+
+  const onCropped = async (croppedFile) => {
+    setPending(null);
+    setBusy(true);
+    try {
+      const { key, url } = await uploadScreenshot(croppedFile);
+      setPreview(url);
+      onChange(key);
+    } catch (err) {
+      setError(err.response?.data?.message || 'アップロードに失敗しました（PNG/JPEG/WebP・5MB まで）');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div>
+      <div className="flex items-center gap-4">
+        {preview
+          ? <img src={preview} alt="アバタープレビュー" className="h-24 w-24 rounded-full border border-black/5 object-cover shadow-mac-sm" />
+          : <span className="flex h-24 w-24 items-center justify-center rounded-full bg-gray-100 text-3xl text-gray-400">🙂</span>}
+        <label className={`mac-btn-ghost cursor-pointer ${busy ? 'pointer-events-none opacity-50' : ''}`}>
+          {busy ? 'アップロード中…' : preview ? '画像を変更' : '画像を選ぶ'}
+          <input
+            type="file"
+            accept="image/png,image/jpeg,image/webp"
+            onChange={onSelect}
+            className="sr-only"
+          />
+        </label>
+      </div>
+      {error && <p className="mt-1 text-sm text-red-600">{error}</p>}
+
+      {pending && (
+        <AvatarCropper file={pending} onCancel={() => setPending(null)} onCropped={onCropped} />
+      )}
+    </div>
+  );
+}

--- a/review-board/frontend/src/components/EvaluationPanel.jsx
+++ b/review-board/frontend/src/components/EvaluationPanel.jsx
@@ -26,12 +26,12 @@ export default function EvaluationPanel({ postId, evaluation, isTeacher, onEvalu
   };
 
   return (
-    <section className="rounded-lg border border-gray-200 bg-white p-4">
-      <h3 className="mb-3 font-medium text-gray-800">講師による最終評価</h3>
+    <section className="mac-card p-5">
+      <h3 className="mac-h mb-3 text-base">講師による最終評価</h3>
 
       {evaluation ? (
-        <div className={`mb-3 rounded p-3 text-sm ${evaluation.approved ? 'bg-green-50 text-green-700' : 'bg-orange-50 text-orange-700'}`}>
-          <span className="font-medium">
+        <div className={`mb-3 rounded-xl p-3 text-sm ${evaluation.approved ? 'bg-green-50 text-green-700' : 'bg-orange-50 text-orange-700'}`}>
+          <span className="font-semibold">
             {evaluation.approved ? '🏅 合格' : '↩ 差し戻し'}
           </span>
           <p className="mt-1 text-gray-600">{evaluation.comment}</p>
@@ -41,8 +41,8 @@ export default function EvaluationPanel({ postId, evaluation, isTeacher, onEvalu
       )}
 
       {isTeacher && (
-        <form onSubmit={submit} className="border-t border-gray-100 pt-3">
-          {error && <p className="mb-2 rounded bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+        <form onSubmit={submit} className="border-t border-black/5 pt-3">
+          {error && <p className="mb-2 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
           <div className="mb-2 flex gap-4 text-sm">
             {['APPROVED', 'RETURNED'].map((r) => (
               <label key={r} className="flex items-center gap-1">
@@ -56,14 +56,10 @@ export default function EvaluationPanel({ postId, evaluation, isTeacher, onEvalu
             value={comment}
             onChange={(e) => setComment(e.target.value)}
             placeholder="評価コメント"
-            className="mb-2 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            className="mac-input mb-2"
             rows={2}
           />
-          <button
-            type="submit"
-            disabled={busy}
-            className="rounded bg-amber-600 px-4 py-2 text-sm font-medium text-white hover:bg-amber-700 disabled:opacity-50"
-          >
+          <button type="submit" disabled={busy} className="mac-btn-navy">
             {busy ? '送信中…' : '評価を確定'}
           </button>
         </form>

--- a/review-board/frontend/src/components/Header.jsx
+++ b/review-board/frontend/src/components/Header.jsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
-import { ROLE_LABEL } from '../constants';
 import { fetchUnreadCount } from '../api/notifications';
 import Avatar from './Avatar';
+import ShibaIcon from './ShibaIcon';
 
 // F-NOTIF-01：未読通知数のポーリング間隔（WebSocket は使わない）。
 const POLL_MS = 30000;
@@ -11,7 +11,9 @@ const POLL_MS = 30000;
 export default function Header() {
   const { user, logout } = useAuth();
   const location = useLocation();
+  const navigate = useNavigate();
   const [unread, setUnread] = useState(0);
+  const [q, setQ] = useState('');
 
   // ログイン中だけポーリング。画面遷移のたびにも即時更新（通知センターで既読化した直後の反映用）。
   useEffect(() => {
@@ -23,43 +25,56 @@ export default function Header() {
     return () => { alive = false; clearInterval(id); };
   }, [user, location.pathname]);
 
+  // ページが切り替わったら検索欄をクリア（前ページの語が残って ?q= 由来の自動スクロールが起きるのを防ぐ）。
+  // 同一パス内の検索（トップ "/" → "/?q=..."）では pathname が変わらないので入力は保持される。
+  useEffect(() => { setQ(''); }, [location.pathname]);
+
+  // ヘッダー検索：トップへ ?q= を渡して遷移（PostsPage が URL から初期値を拾う）。
+  const submitSearch = (e) => {
+    e.preventDefault();
+    navigate(q.trim() ? `/?q=${encodeURIComponent(q.trim())}` : '/');
+  };
+
   return (
-    <header className="flex items-center justify-between border-b border-gray-200 bg-white px-6 py-3">
-      <div className="flex items-center gap-6">
-        <Link to="/" className="text-lg font-bold text-gray-800">review-board</Link>
+    <header className="sticky top-0 z-20 border-b border-black/5 bg-white/85 backdrop-blur-xl">
+      <div className="mx-auto flex max-w-6xl items-center gap-3 px-6 py-3">
+        <Link to="/" className="flex shrink-0 items-center gap-2 whitespace-nowrap text-[17px] font-extrabold tracking-tight text-navy-700">
+          <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-[#fff3e8] ring-1 ring-black/5">
+            <ShibaIcon className="h-6 w-6" />
+          </span>
+          review-board
+        </Link>
         {user && (
-          <nav className="flex gap-4 text-sm text-gray-600">
-            <Link to="/" className="hover:text-gray-900">投稿一覧</Link>
-            <Link to="/posts/new" className="hover:text-gray-900">新規投稿</Link>
-            <Link to={`/users/${user.id}/profile`} className="hover:text-gray-900">自分の成長記録</Link>
-          </nav>
+          <div className="ml-auto flex items-center gap-3 sm:gap-5">
+            <form onSubmit={submitSearch} className="relative hidden w-48 lg:block xl:w-56">
+              <input
+                type="search"
+                value={q}
+                onChange={(e) => setQ(e.target.value)}
+                placeholder="作品を探す"
+                className="w-full rounded-full border border-black/10 bg-black/[0.03] py-1.5 pl-9 pr-3 text-sm outline-none transition focus:border-accent-400 focus:bg-white"
+              />
+              <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">🔍</span>
+            </form>
+            <Link to="/posts/new" className="hidden shrink-0 whitespace-nowrap rounded-lg bg-brand-500 px-3.5 py-2 text-sm font-bold text-white shadow-sm transition hover:bg-brand-600 sm:inline-flex">＋ 投稿する</Link>
+            <Link to="/notifications" className="relative text-gray-500 transition hover:text-navy-700" aria-label={`通知${unread > 0 ? `（未読 ${unread} 件）` : ''}`}>
+              <span className="inline-block text-xl leading-none">🔔</span>
+              {unread > 0 && (
+                <span className="absolute -right-2 -top-1 rounded-full bg-brand-500 px-1.5 text-xs font-bold text-white shadow-sm">
+                  {unread > 99 ? '99+' : unread}
+                </span>
+              )}
+            </Link>
+            <Link to={`/users/${user.id}/profile`} className="flex shrink-0 items-center gap-2 text-sm text-gray-700 hover:text-navy-700">
+              <Avatar url={user.avatarUrl} name={user.displayName} size="md" />
+              <span className="hidden font-medium xl:inline">{user.displayName}</span>
+            </Link>
+            <button onClick={logout} className="shrink-0 whitespace-nowrap rounded-lg border border-black/10 bg-white/70 px-3 py-1.5 text-sm font-medium text-gray-600 transition hover:bg-white">
+              ログアウト
+            </button>
+          </div>
         )}
       </div>
-      {user && (
-        <div className="flex items-center gap-4 text-sm">
-          <Link to="/notifications" className="relative text-gray-600 hover:text-gray-900" aria-label={`通知${unread > 0 ? `（未読 ${unread} 件）` : ''}`}>
-            <span className="relative top-1 inline-block text-xl leading-none">🔔</span>
-            {unread > 0 && (
-              <span className="absolute -right-2 -top-1 rounded-full bg-red-500 px-1.5 text-xs font-bold text-white">
-                {unread > 99 ? '99+' : unread}
-              </span>
-            )}
-          </Link>
-          <span className="flex items-center gap-2 text-gray-600">
-            <Avatar url={user.avatarUrl} name={user.displayName} size="sm" />
-            {user.displayName}
-            <span className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-500">
-              {ROLE_LABEL[user.role] ?? user.role}
-            </span>
-          </span>
-          <button
-            onClick={logout}
-            className="rounded border border-gray-300 px-3 py-1 text-gray-600 hover:bg-gray-50"
-          >
-            ログアウト
-          </button>
-        </div>
-      )}
     </header>
   );
 }

--- a/review-board/frontend/src/components/ReviewForm.jsx
+++ b/review-board/frontend/src/components/ReviewForm.jsx
@@ -55,24 +55,24 @@ export default function ReviewForm({ postId, onCreated }) {
   };
 
   return (
-    <form onSubmit={submit} className="rounded-lg border border-gray-200 bg-white p-4">
-      <h3 className="mb-3 font-medium text-gray-800">レビューを書く <span className="text-xs font-normal text-gray-400">（マークダウン記法が使えます）</span></h3>
+    <form onSubmit={submit} className="mac-card p-5">
+      <h3 className="mac-h mb-3 text-base">レビューを書く <span className="text-xs font-normal text-gray-400">（マークダウン記法が使えます）</span></h3>
       {restored && <DraftNotice onDiscard={discardDraft} />}
-      {error && <p className="mb-3 rounded bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
-      <label className="mb-1 block text-sm text-gray-600">✅ 良かった点（必須）</label>
+      {error && <p className="mb-3 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+      <label className="mac-label">✅ 良かった点（必須）</label>
       <textarea
         required
         value={good}
         onChange={(e) => setGood(e.target.value)}
-        className="mb-3 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+        className="mac-input mb-3"
         rows={2}
       />
-      <label className="mb-1 block text-sm text-gray-600">💡 もっと良くなる点（必須）</label>
+      <label className="mac-label">💡 もっと良くなる点（必須）</label>
       <textarea
         required
         value={improvement}
         onChange={(e) => setImprovement(e.target.value)}
-        className="mb-3 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+        className="mac-input mb-3"
         rows={2}
       />
       <p className="mb-2 text-xs text-gray-400">観点別コメント（任意・埋めたい軸だけでOK）</p>
@@ -82,15 +82,11 @@ export default function ReviewForm({ postId, onCreated }) {
           <input
             value={axis[a.key] ?? ''}
             onChange={(e) => setAxis((prev) => ({ ...prev, [a.key]: e.target.value }))}
-            className="w-full rounded border border-gray-200 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none"
+            className="mac-input py-1.5"
           />
         </div>
       ))}
-      <button
-        type="submit"
-        disabled={submitting}
-        className="mt-2 rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
-      >
+      <button type="submit" disabled={submitting} className="mac-btn-brand mt-2">
         {submitting ? '送信中…' : 'レビューを投稿'}
       </button>
     </form>

--- a/review-board/frontend/src/components/ReviewItem.jsx
+++ b/review-board/frontend/src/components/ReviewItem.jsx
@@ -119,118 +119,135 @@ export default function ReviewItem({ review, canThank, canManageGrowth, isOwner,
     }
   };
 
+  // 案B4（プレミアム）：ヘッダー帯＋グラデ色ブロック＋セグメント型フッター。
   return (
-    <li className={`rounded-lg border p-4 ${isBest ? 'border-yellow-400 bg-yellow-50' : review.teacherReview ? 'border-amber-300 bg-amber-50' : 'border-gray-200 bg-white'}`}>
-      <div className="mb-2 flex items-center gap-2 text-sm">
-        <Avatar url={review.reviewerAvatarUrl} name={review.reviewerDisplayName} size="sm" />
-        <Link to={`/users/${review.reviewerUserId}/profile`} className="font-medium text-gray-800 hover:underline">
-          {review.reviewerDisplayName}
-        </Link>
-        {review.teacherReview && (
-          <span className="rounded bg-amber-200 px-2 py-0.5 text-xs text-amber-800">講師レビュー</span>
+    <li className={`overflow-hidden rounded-2xl border shadow-mac ${isBest ? 'border-yellow-300 bg-yellow-50/40' : review.teacherReview ? 'border-amber-200 bg-amber-50/40' : 'border-black/5 bg-white'}`}>
+      {/* ヘッダー帯 */}
+      <div className="flex items-center gap-3 border-b border-black/5 px-5 py-3.5">
+        <Avatar url={review.reviewerAvatarUrl} name={review.reviewerDisplayName} size="md" />
+        <div className="min-w-0 leading-tight">
+          <div className="flex items-center gap-2">
+            <Link to={`/users/${review.reviewerUserId}/profile`} className="font-bold text-navy-700 hover:underline">
+              {review.reviewerDisplayName}
+            </Link>
+            {isBest && (
+              <span className="rounded-full bg-yellow-200 px-2 py-0.5 text-[11px] font-semibold text-yellow-900 ring-1 ring-yellow-300">⭐ ベスト</span>
+            )}
+          </div>
+          {review.teacherReview && <div className="text-xs font-medium text-amber-600">講師レビュー</div>}
+        </div>
+        <span className="ml-auto inline-flex items-center gap-1 rounded-full bg-navy-700/[0.06] px-2.5 py-1 text-xs font-semibold text-navy-700">
+          🙏 <span className="tabular-nums">{thanks}</span>
+        </span>
+      </div>
+
+      {/* 本文 */}
+      <div className="space-y-3 p-5">
+        {editing ? (
+          <div className="space-y-2">
+            <textarea value={good} onChange={(e) => setGood(e.target.value)} rows={2} className="mac-input" />
+            <textarea value={improvement} onChange={(e) => setImprovement(e.target.value)} rows={2} className="mac-input" />
+            <div className="flex gap-2">
+              <button onClick={saveEdit} disabled={busy} className="rounded-lg bg-navy-700 px-3 py-1 text-xs font-semibold text-white hover:bg-navy-800 disabled:opacity-50">保存</button>
+              <button onClick={() => { setEditing(false); setGood(review.good); setImprovement(review.improvement); }} className="rounded-lg border border-black/10 bg-white px-3 py-1 text-xs font-medium text-gray-600 transition hover:bg-black/[0.03]">キャンセル</button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <div className="rounded-xl bg-gradient-to-br from-green-50 to-emerald-50 p-4 text-sm leading-relaxed text-gray-700 ring-1 ring-green-100">
+              <div className="mb-1 font-bold text-green-700">✅ 良かった点</div>
+              <MarkdownText>{review.good}</MarkdownText>
+            </div>
+            <div className="rounded-xl bg-gradient-to-br from-sky-50 to-indigo-50 p-4 text-sm leading-relaxed text-gray-700 ring-1 ring-sky-100">
+              <div className="mb-1 font-bold text-sky-700">💡 改善点</div>
+              <MarkdownText>{review.improvement}</MarkdownText>
+            </div>
+            {review.axisComments?.length > 0 && (
+              <ul className="space-y-1 rounded-xl bg-black/[0.02] p-3">
+                {review.axisComments.map((c) => (
+                  <li key={c.axis} className="text-xs text-gray-600">
+                    <span className="font-semibold text-gray-500">{AXIS_LABEL[c.axis] ?? c.axis}：</span>
+                    <MarkdownText className="mt-0.5 text-xs">{c.comment}</MarkdownText>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </>
         )}
-        {isBest && (
-          <span className="rounded bg-yellow-300 px-2 py-0.5 text-xs font-medium text-yellow-900">⭐ ベストレビュー</span>
+
+        {/* F-GROW-01 対応状態バッジ＋Before-After（OPEN かつ投稿者でない場合は出さない） */}
+        {(growthStatus !== 'OPEN' || canManageGrowth) && (
+          <div className="rounded-xl bg-white/70 p-3 ring-1 ring-black/5">
+            <div className="flex items-center gap-2">
+              <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 ${GROWTH_MAP[growthStatus]?.badge ?? ''}`}>
+                {GROWTH_MAP[growthStatus]?.label ?? growthStatus}
+              </span>
+              {canManageGrowth && !editingGrowth && (
+                <button onClick={openGrowthEditor} className="rounded-lg px-2.5 py-1 text-xs font-medium text-brand-600 ring-1 ring-brand-400/40 transition hover:bg-brand-400/10">対応を記録</button>
+              )}
+            </div>
+            {beforeAfter && !editingGrowth && (
+              <div className="mt-1.5 text-xs text-gray-600"><span className="text-gray-400">Before→After：</span><MarkdownText className="mt-0.5 text-xs">{beforeAfter}</MarkdownText></div>
+            )}
+            {editingGrowth && (
+              <div className="mt-2 space-y-2">
+                <select value={draftStatus} onChange={(e) => setDraftStatus(e.target.value)} className="rounded-lg border border-black/10 bg-white px-2 py-1 text-xs text-gray-700 outline-none">
+                  {GROWTH_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+                </select>
+                <textarea
+                  value={draftBA}
+                  onChange={(e) => setDraftBA(e.target.value)}
+                  rows={2}
+                  placeholder="Before→After メモ（任意）：どう直したか、なぜ対応不要かなど"
+                  className="mac-input text-xs"
+                />
+                <div className="flex gap-2">
+                  <button onClick={saveGrowth} disabled={busy} className="rounded-lg bg-navy-700 px-3 py-1 text-xs font-semibold text-white hover:bg-navy-800 disabled:opacity-50">保存</button>
+                  <button onClick={() => setEditingGrowth(false)} className="rounded-lg border border-black/10 bg-white px-3 py-1 text-xs font-medium text-gray-600 transition hover:bg-black/[0.03]">キャンセル</button>
+                </div>
+              </div>
+            )}
+          </div>
         )}
       </div>
 
-      {editing ? (
-        <div className="space-y-2">
-          <textarea value={good} onChange={(e) => setGood(e.target.value)} rows={2} className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none" />
-          <textarea value={improvement} onChange={(e) => setImprovement(e.target.value)} rows={2} className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none" />
-          <div className="flex gap-2">
-            <button onClick={saveEdit} disabled={busy} className="rounded bg-blue-600 px-3 py-1 text-xs text-white hover:bg-blue-700 disabled:opacity-50">保存</button>
-            <button onClick={() => { setEditing(false); setGood(review.good); setImprovement(review.improvement); }} className="rounded border border-gray-300 px-3 py-1 text-xs text-gray-600 hover:bg-gray-50">キャンセル</button>
-          </div>
-        </div>
-      ) : (
-        <>
-          <div className="text-sm text-gray-700"><span className="text-green-600">✅ 良かった点：</span><MarkdownText className="mt-1">{review.good}</MarkdownText></div>
-          <div className="mt-1 text-sm text-gray-700"><span className="text-blue-600">💡 改善点：</span><MarkdownText className="mt-1">{review.improvement}</MarkdownText></div>
-          {review.axisComments?.length > 0 && (
-            <ul className="mt-2 space-y-1 border-t border-gray-100 pt-2">
-              {review.axisComments.map((c) => (
-                <li key={c.axis} className="text-xs text-gray-600">
-                  <span className="text-gray-400">{AXIS_LABEL[c.axis] ?? c.axis}：</span>
-                  <MarkdownText className="mt-0.5 text-xs">{c.comment}</MarkdownText>
-                </li>
-              ))}
-            </ul>
-          )}
-        </>
-      )}
-
-      {/* F-GROW-01 対応状態バッジ＋Before-After（OPEN かつ投稿者でない場合は出さない） */}
-      {(growthStatus !== 'OPEN' || canManageGrowth) && (
-        <div className="mt-2 border-t border-gray-100 pt-2">
-          <div className="flex items-center gap-2">
-            <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 ${GROWTH_MAP[growthStatus]?.badge ?? ''}`}>
-              {GROWTH_MAP[growthStatus]?.label ?? growthStatus}
-            </span>
-            {canManageGrowth && !editingGrowth && (
-              <button onClick={openGrowthEditor} className="text-xs text-blue-600 hover:underline">対応を記録</button>
-            )}
-          </div>
-          {beforeAfter && !editingGrowth && (
-            <div className="mt-1 text-xs text-gray-600"><span className="text-gray-400">Before→After：</span><MarkdownText className="mt-0.5 text-xs">{beforeAfter}</MarkdownText></div>
-          )}
-          {editingGrowth && (
-            <div className="mt-2 space-y-2">
-              <select value={draftStatus} onChange={(e) => setDraftStatus(e.target.value)} className="rounded border border-gray-300 px-2 py-1 text-xs focus:border-blue-500 focus:outline-none">
-                {GROWTH_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
-              </select>
-              <textarea
-                value={draftBA}
-                onChange={(e) => setDraftBA(e.target.value)}
-                rows={2}
-                placeholder="Before→After メモ（任意）：どう直したか、なぜ対応不要かなど"
-                className="w-full rounded border border-gray-300 px-3 py-2 text-xs focus:border-blue-500 focus:outline-none"
-              />
-              <div className="flex gap-2">
-                <button onClick={saveGrowth} disabled={busy} className="rounded bg-blue-600 px-3 py-1 text-xs text-white hover:bg-blue-700 disabled:opacity-50">保存</button>
-                <button onClick={() => setEditingGrowth(false)} className="rounded border border-gray-300 px-3 py-1 text-xs text-gray-600 hover:bg-gray-50">キャンセル</button>
-              </div>
-            </div>
-          )}
-        </div>
-      )}
-
-      <div className="mt-2 flex items-center gap-3 text-xs text-gray-500">
-        <span>🙏 ありがとう {thanks}</span>
+      {/* セグメント型フッター */}
+      <div className="flex flex-wrap items-center gap-1 border-t border-black/5 bg-black/[0.012] px-3 py-2 text-xs">
         {canThank && (
-          <button onClick={thank} disabled={busy || thanked} className="rounded border border-gray-300 px-2 py-0.5 text-gray-600 hover:bg-gray-50 disabled:opacity-50">
-            {thanked ? '送信済み' : 'ありがとうを送る'}
+          <button onClick={thank} disabled={busy || thanked}
+            className="rounded-lg px-3 py-1.5 font-medium text-gray-600 transition hover:bg-black/[0.05] disabled:opacity-50">
+            {thanked ? '送信済み' : 'ありがとう'}
           </button>
         )}
         {isOwner && !editing && (
           <>
-            <button onClick={() => setEditing(true)} className="text-blue-600 hover:underline">編集</button>
-            <button onClick={remove} disabled={busy} className="text-red-500 hover:underline disabled:opacity-50">削除</button>
+            <button onClick={() => setEditing(true)} className="rounded-lg px-3 py-1.5 font-medium text-gray-600 transition hover:bg-black/[0.05]">編集</button>
+            <button onClick={remove} disabled={busy} className="rounded-lg px-3 py-1.5 font-medium text-red-500 transition hover:bg-red-50 disabled:opacity-50">削除</button>
           </>
         )}
         {/* F-REV-05：投稿者だけが、まだベストでないレビューを選べる */}
         {canSelectBest && !isBest && (
-          <button onClick={() => onSelectBest?.(review.id)} className="text-yellow-700 hover:underline">
-            ⭐ ベストに選ぶ
+          <button onClick={() => onSelectBest?.(review.id)} className="rounded-lg px-3 py-1.5 font-medium text-yellow-700 transition hover:bg-yellow-50">
+            ベストに選ぶ
           </button>
         )}
         {/* F-REV-04：返信スレッドの開閉 */}
-        <button onClick={toggleReplies} className="text-gray-600 hover:underline">
-          💬 返信 {replyCount}
+        <button onClick={toggleReplies} className="rounded-lg px-3 py-1.5 font-medium text-gray-600 transition hover:bg-black/[0.05]">
+          返信 {replyCount}
         </button>
       </div>
 
       {showReplies && (
-        <div className="mt-3 space-y-2 border-t border-gray-100 pt-3">
+        <div className="space-y-2 border-t border-black/5 px-5 py-3">
           {replies === null ? (
             <p className="text-xs text-gray-400">読み込み中…</p>
           ) : replies.length === 0 ? (
             <p className="text-xs text-gray-400">まだ返信がありません。</p>
           ) : (
             replies.map((rp) => (
-              <div key={rp.id} className="rounded bg-gray-50 px-3 py-2 text-sm">
+              <div key={rp.id} className="rounded-xl bg-black/[0.03] px-3 py-2 text-sm">
                 <div className="flex items-center justify-between">
-                  <Link to={`/users/${rp.replierUserId}/profile`} className="text-xs font-medium text-gray-700 hover:underline">
+                  <Link to={`/users/${rp.replierUserId}/profile`} className="text-xs font-semibold text-navy-700 hover:underline">
                     {rp.replierDisplayName}
                   </Link>
                   {user?.id === rp.replierUserId && (
@@ -246,9 +263,9 @@ export default function ReviewItem({ review, canThank, canManageGrowth, isOwner,
               value={replyBody}
               onChange={(e) => setReplyBody(e.target.value)}
               placeholder="返信を書く"
-              className="flex-1 rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none"
+              className="mac-input py-1.5"
             />
-            <button type="submit" disabled={busy || !replyBody.trim()} className="rounded bg-blue-600 px-3 py-1 text-xs text-white hover:bg-blue-700 disabled:opacity-50">
+            <button type="submit" disabled={busy || !replyBody.trim()} className="shrink-0 rounded-xl bg-navy-700 px-4 py-1.5 text-xs font-semibold text-white transition hover:bg-navy-800 disabled:opacity-50">
               返信
             </button>
           </form>

--- a/review-board/frontend/src/components/ReviewPrefBadges.jsx
+++ b/review-board/frontend/src/components/ReviewPrefBadges.jsx
@@ -1,16 +1,16 @@
 import { TONE_LABEL, ASPECT_LABEL, AI_USAGE_LABEL } from '../constants/reviewPrefs';
 
-// F-SAFE-01 / F-REQ-01 / AI使用状況(#172)：投稿のトーン希望・募集観点・AI使用状況をバッジ表示（読み取り専用）。
+// F-SAFE-01 / F-REQ-01 / AI使用状況(#172)：投稿のトーン希望（多値）・募集観点・AI使用状況をバッジ表示（読み取り専用）。
 // reviewers が「どんなレビューが歓迎か」「AI をどの程度使ったか」を一目で把握できるようにする。
-export default function ReviewPrefBadges({ tone, aspects = [], aiUsage = null, className = '' }) {
-  if (!tone && (!aspects || aspects.length === 0) && !aiUsage) return null;
+export default function ReviewPrefBadges({ tones = [], aspects = [], aiUsage = null, className = '' }) {
+  if ((!tones || tones.length === 0) && (!aspects || aspects.length === 0) && !aiUsage) return null;
   return (
     <div className={`flex flex-wrap items-center gap-2 ${className}`}>
-      {tone && (
-        <span className="rounded-full bg-amber-50 px-2.5 py-0.5 text-xs font-medium text-amber-700 ring-1 ring-amber-200">
-          🫶 {TONE_LABEL[tone] ?? tone}
+      {tones.map((t) => (
+        <span key={t} className="rounded-full bg-amber-50 px-2.5 py-0.5 text-xs font-medium text-amber-700 ring-1 ring-amber-200">
+          🫶 {TONE_LABEL[t] ?? t}
         </span>
-      )}
+      ))}
       {aspects.map((a) => (
         <span key={a} className="rounded-full bg-indigo-50 px-2.5 py-0.5 text-xs font-medium text-indigo-700 ring-1 ring-indigo-200">
           🔍 {ASPECT_LABEL[a] ?? a}

--- a/review-board/frontend/src/components/ReviewPrefFields.jsx
+++ b/review-board/frontend/src/components/ReviewPrefFields.jsx
@@ -1,53 +1,112 @@
 import { TONE_OPTIONS, ASPECT_OPTIONS, AI_USAGE_OPTIONS } from '../constants/reviewPrefs';
 
-// F-SAFE-01 / F-REQ-01 / AI使用状況(#172)：投稿フォームのトーン（単一）・募集観点（多値）・AI使用状況（単一）入力。
-// props: tone(string|null), aspects(string[]), aiUsage(string|null), onToneChange, onAspectsChange, onAiUsageChange。
+// F-SAFE-01 / F-REQ-01 / AI使用状況(#172)：投稿フォームのトーン（多値）・募集観点（多値）・AI使用状況（単一）入力。
+// UI 案D「タグ入力パネル」：トーンはトグルピル（複数可）、観点は選択タグ＋候補、AI は単一ピル。
+// props: tones(string[]), aspects(string[]), aiUsage(string|null), onTonesChange, onAspectsChange, onAiUsageChange。
+
+// 単一選択ピル（ラジオ相当）。選択は navy 塗り、未選択は白＋極薄リング。
+function RadioPill({ checked, onClick, children }) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={checked}
+      onClick={onClick}
+      className={`rounded-full px-3.5 py-1.5 text-sm transition ${
+        checked ? 'bg-navy-700 font-semibold text-white shadow-sm' : 'bg-white text-gray-600 ring-1 ring-black/10 hover:ring-black/20'
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+// 多値トグルピル。選択は navy 塗り、未選択は白＋極薄リング。
+function TogglePill({ pressed, onClick, children }) {
+  return (
+    <button
+      type="button"
+      aria-pressed={pressed}
+      onClick={onClick}
+      className={`rounded-full px-3.5 py-1.5 text-sm transition ${
+        pressed ? 'bg-navy-700 font-semibold text-white shadow-sm' : 'bg-white text-gray-600 ring-1 ring-black/10 hover:ring-black/20'
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
 export default function ReviewPrefFields({
-  tone, aspects = [], aiUsage = null, onToneChange, onAspectsChange, onAiUsageChange,
+  tones = [], aspects = [], aiUsage = null, onTonesChange, onAspectsChange, onAiUsageChange,
 }) {
-  const toggleAspect = (value) => {
-    onAspectsChange(aspects.includes(value) ? aspects.filter((a) => a !== value) : [...aspects, value]);
-  };
+  const toggleTone = (value) =>
+    onTonesChange(tones.includes(value) ? tones.filter((t) => t !== value) : [...tones, value]);
+
+  const addAspect = (value) => onAspectsChange([...aspects, value]);
+  const removeAspect = (value) => onAspectsChange(aspects.filter((a) => a !== value));
+
+  // 観点：選択済み／候補（未選択）に分ける。元の定義順を保つ。
+  const selected = ASPECT_OPTIONS.filter((o) => aspects.includes(o.value));
+  const candidates = ASPECT_OPTIONS.filter((o) => !aspects.includes(o.value));
 
   return (
-    <fieldset className="mb-4 rounded border border-gray-200 p-4">
-      <legend className="px-1 text-sm font-medium text-gray-700">レビューの希望（任意）</legend>
+    <fieldset className="mb-4 rounded-2xl border border-black/10 bg-black/[0.02] p-5">
+      <legend className="px-1 text-sm font-semibold text-navy-700">レビューの希望（任意）</legend>
 
-      <p className="mb-1 text-sm text-gray-600">どんなトーンが歓迎ですか？</p>
-      <div className="mb-4 flex flex-wrap gap-3" role="radiogroup" aria-label="希望トーン">
-        <label className="flex cursor-pointer items-center gap-1.5 text-sm text-gray-700">
-          <input type="radio" name="reviewTone" checked={!tone} onChange={() => onToneChange(null)} />
-          指定しない
-        </label>
+      {/* トーン（多値・トグル） */}
+      <div className="mb-1.5 flex items-center justify-between">
+        <p className="text-sm font-semibold text-navy-700">どんなトーンが歓迎ですか？</p>
+        <span className="text-xs text-gray-400">複数選べます</span>
+      </div>
+      <div className="mb-5 flex flex-wrap gap-2" role="group" aria-label="希望トーン">
         {TONE_OPTIONS.map((o) => (
-          <label key={o.value} className="flex cursor-pointer items-center gap-1.5 text-sm text-gray-700" title={o.hint}>
-            <input type="radio" name="reviewTone" checked={tone === o.value} onChange={() => onToneChange(o.value)} />
-            {o.label}
-          </label>
+          <span key={o.value} title={o.hint}>
+            <TogglePill pressed={tones.includes(o.value)} onClick={() => toggleTone(o.value)}>{o.label}</TogglePill>
+          </span>
         ))}
       </div>
 
-      <p className="mb-1 text-sm text-gray-600">特に見てほしい観点（複数選択可）</p>
-      <div className="mb-4 flex flex-wrap gap-3">
-        {ASPECT_OPTIONS.map((o) => (
-          <label key={o.value} className="flex cursor-pointer items-center gap-1.5 text-sm text-gray-700">
-            <input type="checkbox" checked={aspects.includes(o.value)} onChange={() => toggleAspect(o.value)} />
+      {/* 募集観点（多値）：選択はタグ、未選択は候補から足す */}
+      <div className="mb-1.5 flex items-center justify-between">
+        <p className="text-sm font-semibold text-navy-700">特に見てほしい観点</p>
+        <span className="text-xs text-gray-400">候補から選ぶ（複数可）</span>
+      </div>
+      <div className="flex flex-wrap gap-2" role="group" aria-label="募集観点">
+        {selected.map((o) => (
+          <button
+            key={o.value}
+            type="button"
+            aria-pressed="true"
+            onClick={() => removeAspect(o.value)}
+            className="inline-flex items-center gap-1 rounded-full bg-brand-400/15 px-3 py-1 text-sm font-medium text-brand-600 transition hover:bg-brand-400/25"
+          >
+            {o.label} <span aria-hidden="true" className="text-brand-500">✕</span>
+            <span className="sr-only">を外す</span>
+          </button>
+        ))}
+        {selected.length > 0 && candidates.length > 0 && <span className="self-center text-gray-300">｜</span>}
+        {candidates.map((o) => (
+          <button
+            key={o.value}
+            type="button"
+            aria-pressed="false"
+            onClick={() => addAspect(o.value)}
+            className="rounded-full px-3 py-1 text-sm text-gray-500 ring-1 ring-black/10 transition hover:bg-white hover:text-navy-700 hover:ring-black/20"
+          >
             {o.label}
-          </label>
+          </button>
         ))}
       </div>
 
-      <p className="mb-1 text-sm text-gray-600">この成果物の AI 使用状況（任意）</p>
-      <div className="flex flex-wrap gap-3" role="radiogroup" aria-label="AI使用状況">
-        <label className="flex cursor-pointer items-center gap-1.5 text-sm text-gray-700">
-          <input type="radio" name="aiUsage" checked={!aiUsage} onChange={() => onAiUsageChange(null)} />
-          指定しない
-        </label>
+      {/* AI使用状況（単一） */}
+      <p className="mb-2 mt-5 text-sm font-semibold text-navy-700">この成果物の AI 使用状況</p>
+      <div className="inline-flex flex-wrap gap-2" role="radiogroup" aria-label="AI使用状況">
+        <RadioPill checked={!aiUsage} onClick={() => onAiUsageChange(null)}>指定しない</RadioPill>
         {AI_USAGE_OPTIONS.map((o) => (
-          <label key={o.value} className="flex cursor-pointer items-center gap-1.5 text-sm text-gray-700" title={o.hint}>
-            <input type="radio" name="aiUsage" checked={aiUsage === o.value} onChange={() => onAiUsageChange(o.value)} />
-            {o.label}
-          </label>
+          <span key={o.value} title={o.hint}>
+            <RadioPill checked={aiUsage === o.value} onClick={() => onAiUsageChange(o.value)}>{o.label}</RadioPill>
+          </span>
         ))}
       </div>
     </fieldset>

--- a/review-board/frontend/src/components/ShibaIcon.jsx
+++ b/review-board/frontend/src/components/ShibaIcon.jsx
@@ -1,0 +1,32 @@
+// 正面向きの豆柴（赤柴）アイコン。色は柴犬の代表色「赤」（赤柴）の暖色タン。
+// ブランドの 🌱 を置き換えるロゴ用の自作 SVG（依存なし）。
+const RED = '#C2682E'; // 赤柴の赤（暖かいタン）
+const CREAM = '#FBEAD7'; // 口元・差し毛の白
+const DARK = '#2B2620'; // 目・鼻
+
+export default function ShibaIcon({ className = '' }) {
+  return (
+    <svg viewBox="0 0 32 32" className={className} aria-hidden="true" focusable="false">
+      {/* 耳（立ち耳） */}
+      <path d="M6 3 L3.5 14.5 L13 9 Z" fill={RED} />
+      <path d="M26 3 L28.5 14.5 L19 9 Z" fill={RED} />
+      <path d="M6.8 6 L5.6 12.5 L11 9.2 Z" fill={CREAM} />
+      <path d="M25.2 6 L26.4 12.5 L21 9.2 Z" fill={CREAM} />
+      {/* 顔（赤） */}
+      <path d="M16 6.5 C22 6.5 25.6 10.8 25.6 16.8 C25.6 23 21.6 27.8 16 27.8 C10.4 27.8 6.4 23 6.4 16.8 C6.4 10.8 10 6.5 16 6.5 Z" fill={RED} />
+      {/* 口元・頬（白） */}
+      <path d="M16 15 C20.4 15 22.8 18 22.8 21.3 C22.8 25 19.8 27.6 16 27.6 C12.2 27.6 9.2 25 9.2 21.3 C9.2 18 11.6 15 16 15 Z" fill={CREAM} />
+      {/* 眉の差し毛（赤柴の特徴） */}
+      <circle cx="11.6" cy="11.4" r="0.9" fill={CREAM} />
+      <circle cx="20.4" cy="11.4" r="0.9" fill={CREAM} />
+      {/* 目 */}
+      <circle cx="11.8" cy="15" r="1.6" fill={DARK} />
+      <circle cx="20.2" cy="15" r="1.6" fill={DARK} />
+      {/* 鼻 */}
+      <path d="M16 17.6 C17.1 17.6 18 18.4 18 19.3 C18 20.3 17.1 21 16 21 C14.9 21 14 20.3 14 19.3 C14 18.4 14.9 17.6 16 17.6 Z" fill={DARK} />
+      {/* 口 */}
+      <path d="M16 21 L16 23 M16 23 C16 24 14.8 24.6 13.7 24.3 M16 23 C16 24 17.2 24.6 18.3 24.3"
+        stroke={DARK} strokeWidth="0.9" strokeLinecap="round" fill="none" />
+    </svg>
+  );
+}

--- a/review-board/frontend/src/constants/reviewPrefs.js
+++ b/review-board/frontend/src/constants/reviewPrefs.js
@@ -6,6 +6,8 @@ export const TONE_OPTIONS = [
   { value: 'WELCOME_BEGINNER', label: '初学者歓迎', hint: '基礎的な指摘も歓迎' },
   { value: 'HARSH_OK', label: '辛口OK', hint: '厳しめの指摘を歓迎' },
   { value: 'GENTLE', label: '優しめ希望', hint: '言葉選びに配慮してほしい' },
+  { value: 'DETAILED', label: 'じっくり詳しく', hint: '時間をかけて深く見てほしい' },
+  { value: 'QUICK_OK', label: 'ざっくりでOK', hint: '要点だけ手早く見てほしい' },
 ];
 
 export const TONE_LABEL = Object.fromEntries(TONE_OPTIONS.map((o) => [o.value, o.label]));
@@ -14,9 +16,13 @@ export const TONE_LABEL = Object.fromEntries(TONE_OPTIONS.map((o) => [o.value, o
 export const ASPECT_OPTIONS = [
   { value: 'DB', label: 'DB' },
   { value: 'UI', label: 'UI' },
+  { value: 'UX', label: 'UX' },
   { value: 'CODE', label: 'コード' },
+  { value: 'ARCHITECTURE', label: '設計' },
+  { value: 'TESTING', label: 'テスト' },
   { value: 'SECURITY', label: 'セキュリティ' },
   { value: 'PERFORMANCE', label: 'パフォーマンス' },
+  { value: 'ACCESSIBILITY', label: 'アクセシビリティ' },
 ];
 
 export const ASPECT_LABEL = Object.fromEntries(ASPECT_OPTIONS.map((o) => [o.value, o.label]));
@@ -29,3 +35,22 @@ export const AI_USAGE_OPTIONS = [
 ];
 
 export const AI_USAGE_LABEL = Object.fromEntries(AI_USAGE_OPTIONS.map((o) => [o.value, o.label]));
+
+// 検索キーワードの正規化：小文字化＋ひらがな→カタカナ（「せ」で「セキュリティ」に当てるため）。
+const normalize = (s) =>
+  (s ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/[ぁ-ゖ]/g, (c) => String.fromCharCode(c.charCodeAt(0) + 0x60));
+
+// キーワードを観点/トーンに解決：ラベルまたは enum 値に部分一致したものを返す（F-SEARCH-01）。
+// 例：「セキュリティ」「せ」→ ['SECURITY']、「UI」→ ['UI']、「辛口」→ tones ['HARSH_OK']。
+const matchByLabel = (options, keyword) => {
+  const k = normalize(keyword);
+  if (!k) return [];
+  return options
+    .filter((o) => normalize(o.label).includes(k) || o.value.toLowerCase().includes(k))
+    .map((o) => o.value);
+};
+export const matchAspects = (keyword) => matchByLabel(ASPECT_OPTIONS, keyword);
+export const matchTones = (keyword) => matchByLabel(TONE_OPTIONS, keyword);

--- a/review-board/frontend/src/context/AuthContext.jsx
+++ b/review-board/frontend/src/context/AuthContext.jsx
@@ -30,8 +30,15 @@ export function AuthProvider({ children }) {
     }
   }, []);
 
+  // プロフィール更新（アバター等）後にヘッダー表示を最新化するため /me を引き直す。
+  const refreshUser = useCallback(async () => {
+    const u = await authApi.fetchMe();
+    setUser(u);
+    return u;
+  }, []);
+
   return (
-    <AuthContext.Provider value={{ user, loading, login, logout }}>
+    <AuthContext.Provider value={{ user, loading, login, logout, refreshUser }}>
       {children}
     </AuthContext.Provider>
   );

--- a/review-board/frontend/src/index.css
+++ b/review-board/frontend/src/index.css
@@ -1,1 +1,104 @@
 @import "tailwindcss";
+
+/* ============================================================
+ * デザイントークン（macOS 風）。Tailwind v4 の @theme で一元管理。
+ * ============================================================ */
+@theme {
+  --font-sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display",
+    "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Yu Gothic", Meiryo, system-ui, sans-serif;
+
+  /* アクセント（macOS ブルー） */
+  --color-accent-50: #eaf3ff;
+  --color-accent-100: #d6e8ff;
+  --color-accent-400: #2e90ff;
+  --color-accent-500: #007aff;
+  --color-accent-600: #0a6dde;
+  --color-accent-700: #0857b3;
+
+  /* ブランド（採用デザイン L：ネイビー＋オレンジ） */
+  --color-navy-700: #13315a;
+  --color-navy-800: #0f2747;
+  --color-brand-400: #ff944d;
+  --color-brand-500: #ff7a18;
+  --color-brand-600: #ec6a08;
+
+  /* キャンバス（Apple グレー） */
+  --color-canvas: #f5f5f7;
+
+  /* 柔らかい多層シャドウ */
+  --shadow-mac-sm: 0 1px 2px rgba(0, 0, 0, 0.04), 0 4px 12px -4px rgba(0, 0, 0, 0.1);
+  --shadow-mac: 0 2px 6px rgba(0, 0, 0, 0.05), 0 18px 50px -16px rgba(0, 0, 0, 0.28);
+}
+
+/* ============================================================
+ * ベース：淡いグラデ背景・フォントスムージング・文字色
+ * ============================================================ */
+body {
+  margin: 0;
+  background: linear-gradient(160deg, #eef2f8 0%, #f5f5f7 42%, #ece9f4 100%);
+  background-attachment: fixed;
+  color: #1d1d1f;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* キーボード操作時のみアクセントのフォーカスリング（a11y を後退させない） */
+:focus-visible {
+  outline: 2px solid var(--color-accent-500);
+  outline-offset: 2px;
+}
+
+/* ============================================================
+ * 再利用コンポーネントクラス（全ページ共通の macOS 部品）
+ * ============================================================ */
+@layer components {
+  /* frosted glass のカード面 */
+  .mac-card {
+    @apply rounded-2xl border border-black/5 bg-white/80 shadow-mac backdrop-blur-xl;
+  }
+  /* 一段軽いカード（一覧の行など） */
+  .mac-panel {
+    @apply rounded-2xl border border-black/5 bg-white/75 shadow-mac-sm backdrop-blur-md;
+  }
+  /* 塗りつぶし入力（フォーカスで白＋アクセントのグロー） */
+  .mac-input {
+    @apply w-full rounded-xl border border-black/10 bg-black/[0.03] px-3.5 py-2.5 text-sm text-gray-900
+      transition outline-none placeholder:text-gray-400
+      focus:border-accent-400 focus:bg-white focus:ring-4 focus:ring-accent-500/15;
+  }
+  .mac-label {
+    @apply mb-1.5 block text-[13px] font-medium text-gray-500;
+  }
+  /* 主ボタン（アクセント・押下で微縮小） */
+  .mac-btn-primary {
+    @apply inline-flex items-center justify-center gap-1.5 rounded-xl bg-accent-500 px-4 py-2.5
+      text-sm font-semibold text-white shadow-mac-sm transition
+      hover:bg-accent-600 active:scale-[0.98] disabled:opacity-50 disabled:active:scale-100;
+  }
+  /* 副ボタン（白いガラス） */
+  .mac-btn-ghost {
+    @apply inline-flex items-center justify-center gap-1.5 rounded-xl border border-black/10 bg-white/70 px-3.5 py-2
+      text-sm font-medium text-gray-700 transition hover:bg-white active:scale-[0.98];
+  }
+  /* 丸いピル（バッジ・タグ） */
+  .mac-pill {
+    @apply inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium;
+  }
+  /* ブランドボタン（採用デザイン L） */
+  .mac-btn-navy {
+    @apply inline-flex items-center justify-center gap-1.5 rounded-xl bg-navy-700 px-4 py-2.5
+      text-sm font-bold text-white shadow-mac-sm transition hover:bg-navy-800 active:scale-[0.98] disabled:opacity-50;
+  }
+  .mac-btn-brand {
+    @apply inline-flex items-center justify-center gap-1.5 rounded-xl bg-brand-500 px-4 py-2.5
+      text-sm font-bold text-white shadow-mac-sm transition hover:bg-brand-600 active:scale-[0.98] disabled:opacity-50;
+  }
+  /* セクションの小見出し（REASON / WORKS 等） */
+  .mac-eyebrow {
+    @apply text-center text-sm font-bold tracking-wide text-brand-500;
+  }
+  /* 見出し（ネイビー太字） */
+  .mac-h {
+    @apply font-extrabold tracking-tight text-navy-700;
+  }
+}

--- a/review-board/frontend/src/pages/LoginPage.jsx
+++ b/review-board/frontend/src/pages/LoginPage.jsx
@@ -1,12 +1,14 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
+import ShibaIcon from '../components/ShibaIcon';
 
 export default function LoginPage() {
   const { login } = useAuth();
   const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState('');
   const [submitting, setSubmitting] = useState(false);
 
@@ -26,34 +28,69 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50">
-      <form onSubmit={onSubmit} className="w-full max-w-sm rounded-lg border border-gray-200 bg-white p-8 shadow-sm">
-        <h1 className="mb-6 text-center text-xl font-bold text-gray-800">review-board ログイン</h1>
-        {error && <p className="mb-4 rounded bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
-        <label className="mb-1 block text-sm text-gray-600">メールアドレス</label>
-        <input
-          type="email"
-          required
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          className="mb-4 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-        />
-        <label className="mb-1 block text-sm text-gray-600">パスワード</label>
-        <input
-          type="password"
-          required
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          className="mb-6 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-        />
-        <button
-          type="submit"
-          disabled={submitting}
-          className="w-full rounded bg-blue-600 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
-        >
-          {submitting ? 'ログイン中…' : 'ログイン'}
-        </button>
-      </form>
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        {/* ブランド */}
+        <div className="mb-7 flex flex-col items-center text-center">
+          <div className="mb-3 flex h-16 w-16 items-center justify-center rounded-[20px] bg-[#fff3e8] shadow-mac ring-1 ring-black/5">
+            <ShibaIcon className="h-12 w-12" />
+          </div>
+          <h1 className="text-2xl font-extrabold tracking-tight text-navy-700">review-board</h1>
+          <p className="mt-1 text-sm text-gray-500">成長を支え合うレビューコミュニティ</p>
+        </div>
+
+        {/* ログインカード */}
+        <form onSubmit={onSubmit} className="mac-card p-7">
+          {error && (
+            <p className="mb-4 rounded-xl border border-red-100 bg-red-50/80 px-3.5 py-2.5 text-sm text-red-600">
+              {error}
+            </p>
+          )}
+
+          <label className="mac-label" htmlFor="email">メールアドレス</label>
+          <input
+            id="email"
+            type="email"
+            required
+            autoComplete="email"
+            placeholder="you@example.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="mac-input mb-4"
+          />
+
+          <label className="mac-label" htmlFor="password">パスワード</label>
+          <div className="relative mb-6">
+            <input
+              id="password"
+              type={showPassword ? 'text' : 'password'}
+              required
+              autoComplete="current-password"
+              placeholder="••••••••"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="mac-input pr-12"
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword((v) => !v)}
+              aria-label={showPassword ? 'パスワードを隠す' : 'パスワードを表示'}
+              aria-pressed={showPassword}
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded-lg px-2.5 py-1 text-xs font-semibold text-gray-500 transition hover:bg-black/[0.05] hover:text-navy-700"
+            >
+              {showPassword ? '非表示' : '表示'}
+            </button>
+          </div>
+
+          <button type="submit" disabled={submitting} className="mac-btn-navy w-full py-2.5">
+            {submitting ? 'ログイン中…' : 'ログイン'}
+          </button>
+        </form>
+
+        <p className="mt-6 text-center text-xs text-gray-400">
+          アカウントは管理者・講師が発行します
+        </p>
+      </div>
     </div>
   );
 }

--- a/review-board/frontend/src/pages/NewPostPage.jsx
+++ b/review-board/frontend/src/pages/NewPostPage.jsx
@@ -6,7 +6,7 @@ import ReviewPrefFields from '../components/ReviewPrefFields';
 import DraftNotice from '../components/DraftNotice';
 import { useDraft } from '../hooks/useDraft';
 
-const EMPTY = { title: '', description: '', repoUrl: '', demoUrl: '', screenshotKey: null, reviewTone: null, reviewAspects: [], aiUsage: null };
+const EMPTY = { title: '', description: '', repoUrl: '', demoUrl: '', screenshotKey: null, reviewTones: [], reviewAspects: [], aiUsage: null };
 
 // F-POST-01：成果物の投稿（タイトル/説明は必須、URL・スクショは任意）。
 // F-DRAFT-01：入力を localStorage に自動保存し、再訪時に復元する。
@@ -20,7 +20,7 @@ export default function NewPostPage() {
   const { restored, save, clear } = useDraft('post-new', (draft) => setForm((p) => ({ ...p, ...draft })));
   // 空フォームは保存しない（「空の下書き復元」誤検知を防ぐ）。
   const dirty = !!(form.title || form.description || form.repoUrl || form.demoUrl
-    || form.screenshotKey || form.reviewTone || form.reviewAspects.length || form.aiUsage);
+    || form.screenshotKey || form.reviewTones.length || form.reviewAspects.length || form.aiUsage);
   useEffect(() => { if (dirty) save(form); }, [form, dirty, save]);
 
   const set = (k) => (e) => setForm((p) => ({ ...p, [k]: e.target.value }));
@@ -41,7 +41,7 @@ export default function NewPostPage() {
         repoUrl: form.repoUrl || null,
         demoUrl: form.demoUrl || null,
         screenshotKey: form.screenshotKey || null,
-        reviewTone: form.reviewTone,
+        reviewTones: form.reviewTones,
         reviewAspects: form.reviewAspects,
         aiUsage: form.aiUsage,
       });
@@ -55,29 +55,30 @@ export default function NewPostPage() {
   };
 
   return (
-    <main className="mx-auto max-w-2xl p-6">
-      <h2 className="mb-4 text-lg font-bold text-gray-800">成果物を投稿</h2>
-      <form onSubmit={submit} className="rounded-lg border border-gray-200 bg-white p-6">
+    <main className="mx-auto max-w-2xl px-6 py-8">
+      <p className="mac-eyebrow text-left">CREATE</p>
+      <h2 className="mac-h mb-5 text-2xl">成果物を投稿</h2>
+      <form onSubmit={submit} className="mac-card p-6 sm:p-7">
         {restored && <DraftNotice onDiscard={discardDraft} />}
-        {error && <p className="mb-3 rounded bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
-        <label className="mb-1 block text-sm text-gray-600">タイトル（必須）</label>
-        <input required value={form.title} onChange={set('title')} className="mb-4 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none" />
-        <label className="mb-1 block text-sm text-gray-600">説明（必須）<span className="text-xs text-gray-400">・マークダウン可</span></label>
-        <textarea required value={form.description} onChange={set('description')} rows={4} className="mb-4 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none" />
-        <label className="mb-1 block text-sm text-gray-600">リポジトリ URL（任意）</label>
-        <input type="url" value={form.repoUrl} onChange={set('repoUrl')} className="mb-4 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none" />
-        <label className="mb-1 block text-sm text-gray-600">デモ URL（任意）</label>
-        <input type="url" value={form.demoUrl} onChange={set('demoUrl')} className="mb-4 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none" />
+        {error && <p className="mb-3 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+        <label className="mac-label">タイトル（必須）</label>
+        <input required value={form.title} onChange={set('title')} className="mac-input mb-4" />
+        <label className="mac-label">説明（必須）<span className="ml-1 text-xs text-gray-400">・マークダウン可</span></label>
+        <textarea required value={form.description} onChange={set('description')} rows={4} className="mac-input mb-4" />
+        <label className="mac-label">リポジトリ URL（任意）</label>
+        <input type="url" value={form.repoUrl} onChange={set('repoUrl')} className="mac-input mb-4" />
+        <label className="mac-label">デモ URL（任意）</label>
+        <input type="url" value={form.demoUrl} onChange={set('demoUrl')} className="mac-input mb-4" />
         <ScreenshotUploader onChange={(key) => setForm((p) => ({ ...p, screenshotKey: key }))} />
         <ReviewPrefFields
-          tone={form.reviewTone}
+          tones={form.reviewTones}
           aspects={form.reviewAspects}
           aiUsage={form.aiUsage}
-          onToneChange={(v) => setForm((p) => ({ ...p, reviewTone: v }))}
+          onTonesChange={(v) => setForm((p) => ({ ...p, reviewTones: v }))}
           onAspectsChange={(v) => setForm((p) => ({ ...p, reviewAspects: v }))}
           onAiUsageChange={(v) => setForm((p) => ({ ...p, aiUsage: v }))}
         />
-        <button type="submit" disabled={busy} className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50">
+        <button type="submit" disabled={busy} className="mac-btn-brand">
           {busy ? '投稿中…' : '投稿する'}
         </button>
       </form>

--- a/review-board/frontend/src/pages/NotificationsPage.jsx
+++ b/review-board/frontend/src/pages/NotificationsPage.jsx
@@ -55,11 +55,11 @@ export default function NotificationsPage() {
   if (error) return <p className="p-6 text-red-600">{error}</p>;
 
   return (
-    <main className="mx-auto max-w-2xl p-6">
+    <main className="mx-auto max-w-2xl px-6 py-8">
       <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-lg font-bold text-gray-800">通知</h2>
+        <h2 className="mac-h text-2xl">通知</h2>
         {items.some((n) => !n.read) && (
-          <button onClick={readAll} className="text-sm text-blue-600 hover:underline">すべて既読にする</button>
+          <button onClick={readAll} className="text-sm font-semibold text-brand-500 hover:underline">すべて既読にする</button>
         )}
       </div>
 
@@ -71,9 +71,9 @@ export default function NotificationsPage() {
             <li key={n.id}>
               <button
                 onClick={() => open(n)}
-                className={`flex w-full items-start gap-3 rounded-lg border p-4 text-left hover:border-blue-300 ${n.read ? 'border-gray-200 bg-white' : 'border-blue-200 bg-blue-50'}`}
+                className={`flex w-full items-start gap-3 rounded-2xl border p-4 text-left shadow-mac-sm transition hover:-translate-y-0.5 hover:shadow-mac ${n.read ? 'border-black/5 bg-white/80' : 'border-brand-500/30 bg-brand-400/10'}`}
               >
-                {!n.read && <span className="mt-1 h-2 w-2 flex-shrink-0 rounded-full bg-blue-500" aria-label="未読" />}
+                {!n.read && <span className="mt-1 h-2 w-2 flex-shrink-0 rounded-full bg-brand-500" aria-label="未読" />}
                 <Avatar url={n.actorAvatarUrl} name={n.actorDisplayName} size="sm" />
                 <span className="flex-1 text-sm text-gray-700">
                   {ICON[n.type] ?? '🔔 '}

--- a/review-board/frontend/src/pages/PostDetailPage.jsx
+++ b/review-board/frontend/src/pages/PostDetailPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
-import { fetchPost, deletePost, selectBestReview } from '../api/posts';
+import { fetchPost, deletePost, selectBestReview, likePost, unlikePost } from '../api/posts';
 import { fetchReviews } from '../api/reviews';
 import { fetchEvaluation } from '../api/evaluations';
 import { useAuth } from '../context/AuthContext';
@@ -61,35 +61,54 @@ export default function PostDetailPage() {
     }
   };
 
-  return (
-    <main className="mx-auto max-w-3xl space-y-6 p-6">
-      <Link to="/" className="text-sm text-blue-600 hover:underline">← 一覧へ</Link>
+  // いいね（👍）のトグル。更新後の件数と押下状態を反映。
+  const toggleLike = async () => {
+    try {
+      const res = post.liked ? await unlikePost(post.id) : await likePost(post.id);
+      setPost((p) => ({ ...p, likeCount: res.likeCount, liked: res.liked }));
+    } catch {
+      setError('いいねに失敗しました');
+    }
+  };
 
-      <article className="rounded-lg border border-gray-200 bg-white p-6">
-        <div className="flex items-start justify-between">
-          <h2 className="text-xl font-bold text-gray-800">{post.title}</h2>
+  return (
+    <main className="mx-auto max-w-3xl space-y-6 px-6 py-8">
+      <Link to="/" className="text-sm font-medium text-brand-500 hover:underline">← 一覧へ</Link>
+
+      <article className="mac-card p-6 sm:p-7">
+        <div className="flex items-start justify-between gap-4">
+          <h2 className="mac-h text-2xl">{post.title}</h2>
           {isAuthor && (
-            <div className="flex gap-3 text-sm">
-              <Link to={`/posts/${post.id}/edit`} className="text-blue-600 hover:underline">編集</Link>
-              <button onClick={removePost} className="text-red-500 hover:underline">削除</button>
+            <div className="flex flex-shrink-0 gap-3 text-sm">
+              <Link to={`/posts/${post.id}/edit`} className="font-medium text-brand-500 hover:underline">編集</Link>
+              <button onClick={removePost} className="font-medium text-red-500 hover:underline">削除</button>
             </div>
           )}
         </div>
-        <ReviewPrefBadges tone={post.reviewTone} aspects={post.reviewAspects} aiUsage={post.aiUsage} className="mt-3" />
+        <ReviewPrefBadges tones={post.reviewTones} aspects={post.reviewAspects} aiUsage={post.aiUsage} className="mt-3" />
         <MarkdownText className="mt-3">{post.description}</MarkdownText>
         {post.screenshotUrl && (
-          <img src={post.screenshotUrl} alt={`${post.title} のスクリーンショット`} className="mt-4 max-h-96 rounded border border-gray-200" />
+          <img src={post.screenshotUrl} alt={`${post.title} のスクリーンショット`} className="mt-4 max-h-96 rounded-xl border border-black/5 shadow-mac-sm" />
         )}
-        <div className="mt-3 flex gap-4 text-sm">
-          {post.repoUrl && <a href={post.repoUrl} target="_blank" rel="noreferrer" className="text-blue-600 hover:underline">リポジトリ</a>}
-          {post.demoUrl && <a href={post.demoUrl} target="_blank" rel="noreferrer" className="text-blue-600 hover:underline">デモ</a>}
+        <div className="mt-4 flex flex-wrap items-center gap-3 text-sm">
+          <button
+            onClick={toggleLike}
+            aria-pressed={post.liked}
+            className={`inline-flex items-center gap-1.5 rounded-xl px-3.5 py-2 text-sm font-bold transition active:scale-[0.98] ${
+              post.liked ? 'bg-navy-700 text-white shadow-mac-sm' : 'bg-white text-navy-700 ring-1 ring-black/10 hover:bg-black/[0.03]'
+            }`}
+          >
+            👍 いいね <span className="tabular-nums">{post.likeCount}</span>
+          </button>
+          {post.repoUrl && <a href={post.repoUrl} target="_blank" rel="noreferrer" className="mac-btn-ghost">リポジトリ</a>}
+          {post.demoUrl && <a href={post.demoUrl} target="_blank" rel="noreferrer" className="mac-btn-ghost">デモ</a>}
         </div>
       </article>
 
       <EvaluationPanel postId={post.id} evaluation={evaluation} isTeacher={isTeacher} onEvaluated={setEvaluation} />
 
       <section>
-        <h3 className="mb-3 font-medium text-gray-800">レビュー（{reviews.length}）</h3>
+        <h3 className="mac-h mb-3 text-lg">レビュー（{reviews.length}）</h3>
         {reviews.length === 0 ? (
           <p className="mb-4 text-sm text-gray-500">まだレビューがありません。</p>
         ) : (

--- a/review-board/frontend/src/pages/PostEditPage.jsx
+++ b/review-board/frontend/src/pages/PostEditPage.jsx
@@ -23,7 +23,7 @@ export default function PostEditPage() {
           demoUrl: p.demoUrl ?? '',
           // 未変更なら既存 key を維持。差し替え時に Uploader が新 key を入れる。
           screenshotKey: p.screenshotKey ?? null,
-          reviewTone: p.reviewTone ?? null,
+          reviewTones: p.reviewTones ?? [],
           reviewAspects: p.reviewAspects ?? [],
           aiUsage: p.aiUsage ?? null,
         });
@@ -45,7 +45,7 @@ export default function PostEditPage() {
         repoUrl: form.repoUrl || null,
         demoUrl: form.demoUrl || null,
         screenshotKey: form.screenshotKey || null,
-        reviewTone: form.reviewTone,
+        reviewTones: form.reviewTones,
         reviewAspects: form.reviewAspects,
         aiUsage: form.aiUsage,
       });
@@ -61,32 +61,33 @@ export default function PostEditPage() {
   if (!form) return <p className="p-6 text-gray-500">読み込み中…</p>;
 
   return (
-    <main className="mx-auto max-w-2xl p-6">
-      <h2 className="mb-4 text-lg font-bold text-gray-800">投稿を編集</h2>
-      <form onSubmit={submit} className="rounded-lg border border-gray-200 bg-white p-6">
-        {error && <p className="mb-3 rounded bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
-        <label className="mb-1 block text-sm text-gray-600">タイトル（必須）</label>
-        <input required value={form.title} onChange={set('title')} className="mb-4 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none" />
-        <label className="mb-1 block text-sm text-gray-600">説明（必須）</label>
-        <textarea required value={form.description} onChange={set('description')} rows={4} className="mb-4 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none" />
-        <label className="mb-1 block text-sm text-gray-600">リポジトリ URL（任意）</label>
-        <input type="url" value={form.repoUrl} onChange={set('repoUrl')} className="mb-4 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none" />
-        <label className="mb-1 block text-sm text-gray-600">デモ URL（任意）</label>
-        <input type="url" value={form.demoUrl} onChange={set('demoUrl')} className="mb-4 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none" />
+    <main className="mx-auto max-w-2xl px-6 py-8">
+      <p className="mac-eyebrow text-left">EDIT</p>
+      <h2 className="mac-h mb-5 text-2xl">投稿を編集</h2>
+      <form onSubmit={submit} className="mac-card p-6 sm:p-7">
+        {error && <p className="mb-3 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+        <label className="mac-label">タイトル（必須）</label>
+        <input required value={form.title} onChange={set('title')} className="mac-input mb-4" />
+        <label className="mac-label">説明（必須）</label>
+        <textarea required value={form.description} onChange={set('description')} rows={4} className="mac-input mb-4" />
+        <label className="mac-label">リポジトリ URL（任意）</label>
+        <input type="url" value={form.repoUrl} onChange={set('repoUrl')} className="mac-input mb-4" />
+        <label className="mac-label">デモ URL（任意）</label>
+        <input type="url" value={form.demoUrl} onChange={set('demoUrl')} className="mac-input mb-4" />
         <ScreenshotUploader initialUrl={screenshotUrl} onChange={(key) => setForm((p) => ({ ...p, screenshotKey: key }))} />
         <ReviewPrefFields
-          tone={form.reviewTone}
+          tones={form.reviewTones}
           aspects={form.reviewAspects}
           aiUsage={form.aiUsage}
-          onToneChange={(v) => setForm((p) => ({ ...p, reviewTone: v }))}
+          onTonesChange={(v) => setForm((p) => ({ ...p, reviewTones: v }))}
           onAspectsChange={(v) => setForm((p) => ({ ...p, reviewAspects: v }))}
           onAiUsageChange={(v) => setForm((p) => ({ ...p, aiUsage: v }))}
         />
         <div className="flex gap-3">
-          <button type="submit" disabled={busy} className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50">
+          <button type="submit" disabled={busy} className="mac-btn-brand">
             {busy ? '更新中…' : '更新する'}
           </button>
-          <button type="button" onClick={() => navigate(`/posts/${id}`)} className="rounded border border-gray-300 px-4 py-2 text-sm text-gray-600 hover:bg-gray-50">
+          <button type="button" onClick={() => navigate(`/posts/${id}`)} className="mac-btn-ghost">
             キャンセル
           </button>
         </div>

--- a/review-board/frontend/src/pages/PostsPage.jsx
+++ b/review-board/frontend/src/pages/PostsPage.jsx
@@ -1,110 +1,309 @@
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { fetchPosts } from '../api/posts';
-import { RECRUIT_LABEL } from '../constants';
+import { fetchLandingStats } from '../api/stats';
+import { matchAspects, matchTones } from '../constants/reviewPrefs';
+import { ROLE_LABEL } from '../constants';
 import ReviewPrefBadges from '../components/ReviewPrefBadges';
+import Avatar from '../components/Avatar';
+import AppShot from '../components/AppShot';
 
-// F-POST-03 一覧 ＋ F-SEARCH-01 検索 ＋ F-FILTER-01 絞り込み/並び替え。
+// スクショ未登録カードのサムネ：id から決め打ちの「アプリ画面」種別（それっぽいトップpage風）。
+const KINDS = ['todo', 'portfolio', 'api', 'weather', 'chat', 'dashboard'];
+const kindOf = (id) => KINDS[id % KINDS.length];
+
+// 案L：スクール土台（ランディング）＋マーケット要素（観点カテゴリ／カード）。
+const REASONS = [
+  { icon: '🤝', title: '受講生どうしの相互レビュー', body: '読む・読まれる経験で独学では得にくい視点が身につく。' },
+  { icon: '🏅', title: '講師の評価と合格バッジ', body: '講師の最終評価。合格は最高の証跡として記録に残る。' },
+  { icon: '🌱', title: '積み重なる成長記録', body: '投稿・レビュー・連続活動を可視化。努力が「歩み」に。' },
+];
+// 観点カテゴリ（クリックで検索語を入れて WORKS を絞る）。
+const CATS = [
+  { icon: '🎨', label: 'UI / デザイン', q: 'UI' }, { icon: '⚙️', label: 'コード品質', q: 'コード' },
+  { icon: '🔒', label: 'セキュリティ', q: 'セキュリティ' }, { icon: '⚡', label: 'パフォーマンス', q: 'パフォーマンス' },
+  { icon: '🏗', label: '設計', q: '設計' }, { icon: '🧑‍🏫', label: '講師の課題', q: '講師' },
+];
+
+function Eyebrow({ children }) {
+  return <p className="mac-eyebrow">{children}</p>;
+}
+function SectionHeading({ children }) {
+  return <h2 className="mac-h mt-1 text-center text-[26px]">{children}</h2>;
+}
+
+const scrollToWorks = () => document.getElementById('works')?.scrollIntoView({ behavior: 'smooth' });
+
+// F-POST-03 一覧 ＋ F-SEARCH-01 検索 ＋ F-FILTER-01 絞り込み/並び替え（案L ランディングに内包）。
 export default function PostsPage() {
+  const [searchParams] = useSearchParams();
   const [posts, setPosts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [stats, setStats] = useState(null);
+  const [ranking, setRanking] = useState([]);
 
-  // 検索・絞り込み・並び替えの状態。q は入力中の値、applied で確定値を持つ（Enter/ボタンで反映）。
-  const [q, setQ] = useState('');
-  const [applied, setApplied] = useState({ q: '', status: '', unreviewed: false, sort: 'newest' });
+  // 検索・絞り込み・並び替え。初期 q はヘッダー検索からの URL パラメータを尊重。
+  const [q, setQ] = useState(searchParams.get('q') ?? '');
+  const [applied, setApplied] = useState({
+    q: searchParams.get('q') ?? '', status: '', unreviewed: false, sort: 'newest',
+  });
+
+  // ヘッダー検索で ?q= が変わったら反映（同一ページ内遷移）。検索語があれば結果（WORKS）まで誘導。
+  useEffect(() => {
+    const urlQ = searchParams.get('q') ?? '';
+    setQ(urlQ);
+    setApplied((p) => ({ ...p, q: urlQ }));
+    if (urlQ) {
+      // レイアウト確定後にスクロール（ランキング・統計の読み込みでズレないよう少し待つ）。
+      const t = setTimeout(scrollToWorks, 120);
+      return () => clearTimeout(t);
+    }
+    return undefined;
+  }, [searchParams]);
 
   useEffect(() => {
     setLoading(true);
-    fetchPosts(applied)
+    // キーワードを観点/トーンにも解決して渡す（本文に無くてもタグ一致でヒット）。
+    fetchPosts({ ...applied, aspects: matchAspects(applied.q), tones: matchTones(applied.q) })
       .then((slice) => setPosts(slice.content ?? []))
       .catch(() => setError('投稿の取得に失敗しました'))
       .finally(() => setLoading(false));
   }, [applied]);
 
+  useEffect(() => {
+    fetchLandingStats().then(setStats).catch(() => {});
+    // いいね人気ランキング：いいね数順の上位3件。
+    fetchPosts({ sort: 'likes' }, 0, 3).then((s) => setRanking(s.content ?? [])).catch(() => {});
+  }, []);
+
   const submitSearch = (e) => {
     e.preventDefault();
     setApplied((p) => ({ ...p, q }));
+    scrollToWorks();
   };
-
   const setFilter = (patch) => setApplied((p) => ({ ...p, ...patch }));
+  const pickCategory = (kw) => { setQ(kw); setApplied((p) => ({ ...p, q: kw })); scrollToWorks(); };
+
+  const tiles = [
+    [stats?.postsCount ?? '—', '成果物'],
+    [stats?.reviewsCount ?? '—', 'レビュー'],
+    [stats?.approvedBadgesCount ?? '—', '合格バッジ'],
+  ];
 
   return (
-    <main className="mx-auto max-w-3xl p-6">
-      <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-lg font-bold text-gray-800">成果物（同じ期のメンバー）</h2>
-        <Link to="/posts/new" className="rounded bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700">
-          新規投稿
-        </Link>
-      </div>
-
-      {/* F-SEARCH-01 キーワード検索 */}
-      <form onSubmit={submitSearch} className="mb-3 flex gap-2">
-        <input
-          type="search"
-          value={q}
-          onChange={(e) => setQ(e.target.value)}
-          placeholder="タイトル・説明で検索"
-          className="flex-1 rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none"
-        />
-        <button type="submit" className="rounded bg-gray-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-gray-800">
-          検索
-        </button>
-      </form>
-
-      {/* F-FILTER-01 絞り込み・並び替え */}
-      <div className="mb-4 flex flex-wrap items-center gap-3 text-sm text-gray-600">
-        <select
-          value={applied.status}
-          onChange={(e) => setFilter({ status: e.target.value })}
-          className="rounded border border-gray-300 px-2 py-1"
-        >
-          <option value="">すべての状態</option>
-          <option value="OPEN">レビュー募集中</option>
-          <option value="CLOSED">募集終了</option>
-        </select>
-        <label className="flex items-center gap-1">
-          <input
-            type="checkbox"
-            checked={applied.unreviewed}
-            onChange={(e) => setFilter({ unreviewed: e.target.checked })}
-          />
-          未レビューのみ
-        </label>
-        <select
-          value={applied.sort}
-          onChange={(e) => setFilter({ sort: e.target.value })}
-          className="ml-auto rounded border border-gray-300 px-2 py-1"
-        >
-          <option value="newest">新着順</option>
-          <option value="reviews">レビュー数順</option>
-        </select>
-      </div>
-
-      {loading ? (
-        <p className="text-gray-500">読み込み中…</p>
-      ) : error ? (
-        <p className="text-red-600">{error}</p>
-      ) : posts.length === 0 ? (
-        <p className="text-gray-500">該当する投稿がありません。</p>
-      ) : (
-        <ul className="space-y-3">
-          {posts.map((p) => (
-            <li key={p.id} className="rounded-lg border border-gray-200 bg-white p-4 hover:border-blue-300">
-              <Link to={`/posts/${p.id}`} className="block">
-                <div className="flex items-center justify-between">
-                  <h3 className="font-medium text-gray-800">{p.title}</h3>
-                  <span className="rounded bg-blue-50 px-2 py-0.5 text-xs text-blue-600">
-                    {RECRUIT_LABEL[p.recruitStatus] ?? p.recruitStatus}
-                  </span>
+    <main>
+      {/* ヒーロー（スクール・ランディング＝明るい土台。案L 準拠） */}
+      <section className="bg-gradient-to-b from-[#f4f8ff] to-[#eaf1fb]">
+        <div className="mx-auto grid max-w-6xl items-center gap-10 px-6 pb-16 pt-12 lg:grid-cols-2 lg:pt-14">
+          <div>
+            <span className="inline-block rounded-full bg-brand-500 px-3 py-1 text-xs font-bold text-white">
+              エンジニアスクールの成長支援コミュニティ
+            </span>
+            <h1 className="mac-h mt-4 text-[32px] leading-[1.25] sm:text-[40px]">
+              レビューこそが<span className="whitespace-nowrap">エンジニアを<span className="text-brand-500">育てる</span></span>
+            </h1>
+            <p className="mt-4 text-[15px] leading-relaxed text-gray-600">
+              受講生どうし・講師が成果物をレビュー。<br className="hidden sm:block" />その積み重ねが、あなたの「成長の証跡」になります。
+            </p>
+            <div className="mt-7 flex flex-wrap gap-3">
+              <Link to="/posts/new" className="rounded-xl bg-navy-700 px-6 py-3 text-sm font-bold text-white shadow-md transition hover:bg-navy-800">成果物を投稿する</Link>
+              <button onClick={scrollToWorks} className="rounded-xl border-2 border-navy-700 px-6 py-3 text-sm font-bold text-navy-700 transition hover:bg-navy-700/5">成果物を見る ›</button>
+            </div>
+          </div>
+          <div className="space-y-4">
+            {(stats?.featured ?? []).map((u) => (
+              <Link key={u.userId} to={`/users/${u.userId}/profile`}
+                className="flex items-center gap-4 rounded-2xl border border-black/5 bg-white p-4 shadow-mac-sm transition hover:-translate-y-0.5 hover:shadow-mac">
+                <Avatar name={u.displayName} size="md" />
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm font-bold text-navy-700">{u.displayName}</div>
+                  <div className="mt-1 flex flex-wrap items-center gap-1.5 text-xs">
+                    <span className="rounded bg-gray-100 px-1.5 py-0.5 text-gray-500">{ROLE_LABEL[u.role] ?? u.role}</span>
+                    <span className="text-brand-500">▶</span>
+                    <span className="font-semibold text-gray-700">投稿 {u.postsCount}・レビュー {u.reviewsCount}</span>
+                    {u.approved && <span className="rounded-full bg-amber-100 px-2 py-0.5 font-bold text-amber-700">🏅 合格</span>}
+                  </div>
                 </div>
-                <ReviewPrefBadges tone={p.reviewTone} aspects={p.reviewAspects} aiUsage={p.aiUsage} className="mt-2" />
-                <p className="mt-1 text-sm text-gray-500">レビュー {p.reviewCount} 件</p>
               </Link>
-            </li>
+            ))}
+            <div className="grid grid-cols-3 gap-3 pt-1 text-center">
+              {tiles.map(([n, l]) => (
+                <div key={l} className="rounded-2xl bg-white p-3 shadow-mac-sm">
+                  <div className="text-2xl font-extrabold text-navy-700">{n}</div>
+                  <div className="text-xs text-gray-500">{l}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* REASON：伸びる3つの理由 */}
+      <section id="reason" className="mx-auto max-w-6xl px-6 py-14">
+        <Eyebrow>REASON</Eyebrow>
+        <SectionHeading>review-board で伸びる3つの理由</SectionHeading>
+        <div className="mt-9 grid grid-cols-1 gap-6 md:grid-cols-3">
+          {REASONS.map((r, i) => (
+            <div key={r.title} className="relative rounded-2xl border border-black/5 bg-white p-6 shadow-mac-sm">
+              <span className="absolute -top-3 left-6 flex h-7 w-7 items-center justify-center rounded-full bg-brand-500 text-xs font-bold text-white">{i + 1}</span>
+              <div className="mb-3 text-4xl">{r.icon}</div>
+              <h3 className="mb-2 text-[16px] font-bold text-navy-700">{r.title}</h3>
+              <p className="text-sm leading-relaxed text-gray-600">{r.body}</p>
+            </div>
           ))}
-        </ul>
+        </div>
+      </section>
+
+      {/* BROWSE：検索＋観点カテゴリ */}
+      <section className="bg-[#f6f9fe] py-14">
+        <div className="mx-auto max-w-6xl px-6">
+          <Eyebrow>BROWSE</Eyebrow>
+          <SectionHeading>観点から探す</SectionHeading>
+          <form onSubmit={submitSearch} className="mx-auto mt-7 flex max-w-2xl items-center rounded-full bg-white p-1.5 shadow-mac">
+            <span className="pl-4 text-gray-400">🔍</span>
+            <input
+              type="search"
+              value={q}
+              onChange={(e) => setQ(e.target.value)}
+              placeholder="作品・技術・観点で探す（例：React, API 設計）"
+              style={{ outline: 'none' }}
+              className="min-w-0 flex-1 bg-transparent px-3 py-2.5 text-sm text-gray-800 outline-none"
+            />
+            <button type="submit" className="rounded-full bg-brand-500 px-6 py-2.5 text-sm font-bold text-white transition hover:bg-brand-600">探す</button>
+          </form>
+          <div className="mt-6 grid grid-cols-3 gap-3 sm:grid-cols-6">
+            {CATS.map((c) => (
+              <button key={c.label} onClick={() => pickCategory(c.q)}
+                className="flex flex-col items-center gap-2 rounded-2xl border border-black/5 bg-white p-4 text-center shadow-sm transition hover:-translate-y-0.5 hover:shadow-mac-sm">
+                <span className="text-2xl">{c.icon}</span>
+                <span className="text-xs font-medium leading-tight text-navy-700">{c.label}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* RANKING：いいね数順の人気成果物トップ3（👍 が基準） */}
+      {ranking.length > 0 && (
+        <section className="mx-auto max-w-6xl px-6 py-14">
+          <Eyebrow>RANKING</Eyebrow>
+          <SectionHeading>いいね人気ランキング</SectionHeading>
+          <div className="mt-9 grid grid-cols-1 gap-5 md:grid-cols-3">
+            {ranking.map((p, i) => {
+              const medal = ['🥇', '🥈', '🥉'][i] ?? `#${i + 1}`;
+              return (
+                <Link key={p.id} to={`/posts/${p.id}`}
+                  className="group relative flex items-center gap-4 rounded-2xl border border-black/5 bg-white p-5 shadow-mac-sm transition hover:-translate-y-1 hover:shadow-mac">
+                  <span className="text-3xl leading-none">{medal}</span>
+                  <div className="min-w-0 flex-1">
+                    <h3 className="line-clamp-2 text-[15px] font-bold leading-snug text-navy-700">{p.title}</h3>
+                    <div className="mt-1 flex items-center gap-2 text-xs text-gray-500">
+                      <Avatar name={p.authorDisplayName ?? ''} size="sm" />
+                      <span className="truncate">{p.authorDisplayName ?? '—'}</span>
+                    </div>
+                  </div>
+                  <span className="flex flex-shrink-0 items-center gap-1 rounded-full bg-navy-700/[0.06] px-3 py-1 text-sm font-bold text-navy-700">
+                    👍 <span className="tabular-nums">{p.likeCount}</span>
+                  </span>
+                </Link>
+              );
+            })}
+          </div>
+        </section>
       )}
+
+      {/* WORKS：成果物一覧（検索/絞り込み/並び替えの機能はここに集約） */}
+      <section id="works" className="mx-auto max-w-6xl px-6 py-14">
+        <Eyebrow>WORKS</Eyebrow>
+        <SectionHeading>みんなの成果物</SectionHeading>
+
+        <div className="mt-8 flex flex-wrap items-center gap-3">
+          <select value={applied.status} onChange={(e) => setFilter({ status: e.target.value })}
+            className="rounded-xl border border-black/10 bg-white px-3 py-1.5 text-sm text-gray-700 outline-none">
+            <option value="">すべての状態</option>
+            <option value="OPEN">レビュー募集中</option>
+            <option value="CLOSED">募集終了</option>
+          </select>
+          <label className="flex items-center gap-1.5 rounded-xl border border-black/10 bg-white px-3 py-1.5 text-sm text-gray-700">
+            <input type="checkbox" checked={applied.unreviewed} onChange={(e) => setFilter({ unreviewed: e.target.checked })} />
+            未レビューのみ
+          </label>
+          <select value={applied.sort} onChange={(e) => setFilter({ sort: e.target.value })}
+            className="rounded-xl border border-black/10 bg-white px-3 py-1.5 text-sm text-gray-700 outline-none">
+            <option value="newest">新着順</option>
+            <option value="reviews">レビュー数順</option>
+            <option value="likes">いいね順</option>
+          </select>
+          {applied.q && (
+            <span className="rounded-full bg-brand-400/15 px-3 py-1 text-xs font-medium text-brand-600">
+              「{applied.q}」で絞り込み中
+              <button onClick={() => pickCategory('')} className="ml-1.5 font-bold">×</button>
+            </span>
+          )}
+          <Link to="/posts/new" className="mac-btn-brand ml-auto">＋ 投稿する</Link>
+        </div>
+
+        <div className="mt-6">
+          {loading ? (
+            <p className="py-16 text-center text-gray-400">読み込み中…</p>
+          ) : error ? (
+            <p className="py-16 text-center text-red-500">{error}</p>
+          ) : posts.length === 0 ? (
+            <p className="py-16 text-center text-gray-400">該当する成果物がありません。</p>
+          ) : (
+            <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+              {posts.map((p) => (
+                <Link key={p.id} to={`/posts/${p.id}`}
+                  className="group overflow-hidden rounded-2xl border border-black/5 bg-white shadow-mac-sm transition hover:-translate-y-1 hover:shadow-mac">
+                  {/* ブラウザ枠付きサムネ（アプリのトップページ風）。スクショがあれば実画像、無ければ画面モック。 */}
+                  <div className="relative h-36 overflow-hidden bg-gray-50">
+                    {p.screenshotUrl ? (
+                      <>
+                        <div className="flex h-7 items-center gap-1.5 border-b border-black/5 bg-white px-3">
+                          <span className="h-2 w-2 rounded-full bg-red-400" />
+                          <span className="h-2 w-2 rounded-full bg-amber-400" />
+                          <span className="h-2 w-2 rounded-full bg-green-400" />
+                        </div>
+                        <img src={p.screenshotUrl} alt="" className="h-[calc(9rem-1.75rem)] w-full object-cover" />
+                      </>
+                    ) : (
+                      <AppShot kind={kindOf(p.id)} />
+                    )}
+                    {p.recruitStatus === 'OPEN'
+                      ? <span className="absolute right-3 top-9 rounded-full bg-brand-500 px-2 py-0.5 text-[11px] font-bold text-white shadow-sm">募集中</span>
+                      : <span className="absolute right-3 top-9 rounded-full bg-gray-700/80 px-2 py-0.5 text-[11px] font-bold text-white shadow-sm">締切</span>}
+                  </div>
+                  <div className="p-4">
+                    <h3 className="mb-2 line-clamp-2 min-h-[2.6em] text-[15px] font-bold leading-snug text-navy-700">{p.title}</h3>
+                    <div className="mb-3 flex items-center gap-2">
+                      <Avatar name={p.authorDisplayName ?? ''} size="sm" />
+                      <span className="truncate text-xs text-gray-500">{p.authorDisplayName ?? '—'}</span>
+                    </div>
+                    <div className="mb-3"><ReviewPrefBadges tones={p.reviewTones} aspects={p.reviewAspects} aiUsage={p.aiUsage} /></div>
+                    <div className="flex items-center justify-between border-t border-black/5 pt-3 text-xs text-gray-400">
+                      <span className="flex items-center gap-3">
+                        <span>👍 {p.likeCount}</span>
+                        <span>💬 {p.reviewCount}</span>
+                      </span>
+                      <span className="font-semibold text-brand-500 group-hover:underline">見る ›</span>
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* CTA 帯（スクール） */}
+      <section className="bg-navy-700 px-6 py-16">
+        <div className="mx-auto max-w-3xl text-center">
+          <h2 className="text-[26px] font-extrabold leading-tight text-white">まずは成果物を投稿して、<br />レビューを受けてみよう。</h2>
+          <p className="mt-3 text-sm text-white/70">レビューし合うほど、あなたの成長が積み上がる。</p>
+          <Link to="/posts/new" className="mt-7 inline-block rounded-xl bg-brand-500 px-8 py-3.5 text-sm font-bold text-white shadow-lg transition hover:bg-brand-600">成果物を投稿する</Link>
+        </div>
+      </section>
     </main>
   );
 }

--- a/review-board/frontend/src/pages/ProfilePage.jsx
+++ b/review-board/frontend/src/pages/ProfilePage.jsx
@@ -4,7 +4,7 @@ import { fetchProfile, updateMyProfile } from '../api/profile';
 import { ROLE_LABEL, EVAL_LABEL } from '../constants';
 import { useAuth } from '../context/AuthContext';
 import Avatar from '../components/Avatar';
-import ScreenshotUploader from '../components/ScreenshotUploader';
+import AvatarUploader from '../components/AvatarUploader';
 
 // F-PROF：成長記録ページ（本アプリの主役）。投稿履歴・もらったレビュー・実績・合格バッジ・継続。
 export default function ProfilePage() {
@@ -31,8 +31,10 @@ export default function ProfilePage() {
   const isOwn = user?.id === profile.userId;
 
   return (
-    <main className="mx-auto max-w-3xl space-y-6 p-6">
-      <header className="rounded-lg border border-gray-200 bg-white p-6">
+    <main className="mx-auto max-w-3xl space-y-6 px-6 py-8">
+      <header className={editing
+        ? 'mac-card p-6 sm:p-7'
+        : 'overflow-hidden rounded-3xl border border-black/5 bg-gradient-to-b from-[#f4f8ff] to-[#eaf1fb] p-6 shadow-mac-sm sm:p-7'}>
         {editing ? (
           <ProfileEditor profile={profile} onSaved={(p) => { setProfile(p); setEditing(false); }} onCancel={() => setEditing(false)} />
         ) : (
@@ -40,17 +42,17 @@ export default function ProfilePage() {
             <div className="flex items-start gap-4">
               <Avatar url={avatarUrl} name={displayName} size="lg" />
               <div className="flex-1">
-                <h2 className="text-xl font-bold text-gray-800">
+                <h2 className="mac-h text-2xl">
                   {displayName}
-                  <span className="ml-2 rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-500">{ROLE_LABEL[role] ?? role}</span>
+                  <span className="ml-2 rounded-full bg-navy-700/10 px-2.5 py-0.5 text-xs font-semibold text-navy-700">{ROLE_LABEL[role] ?? role}</span>
                 </h2>
                 {bio && <p className="mt-1 whitespace-pre-wrap text-sm text-gray-600">{bio}</p>}
               </div>
               {isOwn && (
-                <button onClick={() => setEditing(true)} className="text-sm text-blue-600 hover:underline">プロフィール編集</button>
+                <button onClick={() => setEditing(true)} className="text-sm font-semibold text-brand-500 hover:underline">プロフィール編集</button>
               )}
             </div>
-            <div className="mt-4 grid grid-cols-3 gap-4 text-center">
+            <div className="mt-5 grid grid-cols-3 gap-3 text-center">
               <Stat label="もらったレビュー" value={stats.receivedReviewsCount} />
               <Stat label="したレビュー" value={stats.givenReviewsCount} />
               <Stat label="もらった🙏" value={stats.thanksReceivedCount} />
@@ -62,18 +64,18 @@ export default function ProfilePage() {
       {streak && <StreakCard streak={streak} />}
 
       <section>
-        <h3 className="mb-3 font-medium text-gray-800">投稿した成果物（{posts.length}）</h3>
+        <h3 className="mac-h mb-3 text-lg">投稿した成果物（{posts.length}）</h3>
         {posts.length === 0 ? (
           <p className="text-sm text-gray-500">まだ投稿がありません。</p>
         ) : (
           <ul className="space-y-2">
             {posts.map((p) => (
-              <li key={p.postId} className="flex items-center justify-between rounded-lg border border-gray-200 bg-white p-3">
-                <Link to={`/posts/${p.postId}`} className="text-sm font-medium text-gray-800 hover:underline">{p.title}</Link>
+              <li key={p.postId} className="mac-panel flex items-center justify-between p-3">
+                <Link to={`/posts/${p.postId}`} className="text-sm font-semibold text-navy-700 hover:underline">{p.title}</Link>
                 <span className="flex items-center gap-2 text-xs text-gray-500">
                   レビュー {p.reviewCount}
-                  {p.approved && <span className="rounded bg-green-100 px-2 py-0.5 text-green-700">🏅 合格</span>}
-                  {p.evaluationResult === 'RETURNED' && <span className="rounded bg-orange-100 px-2 py-0.5 text-orange-700">{EVAL_LABEL.RETURNED}</span>}
+                  {p.approved && <span className="rounded-full bg-green-100 px-2 py-0.5 text-green-700">🏅 合格</span>}
+                  {p.evaluationResult === 'RETURNED' && <span className="rounded-full bg-orange-100 px-2 py-0.5 text-orange-700">{EVAL_LABEL.RETURNED}</span>}
                 </span>
               </li>
             ))}
@@ -82,15 +84,15 @@ export default function ProfilePage() {
       </section>
 
       <section>
-        <h3 className="mb-3 font-medium text-gray-800">もらったレビュー（{receivedReviews.length}）</h3>
+        <h3 className="mac-h mb-3 text-lg">もらったレビュー（{receivedReviews.length}）</h3>
         {receivedReviews.length === 0 ? (
           <p className="text-sm text-gray-500">まだありません。</p>
         ) : (
           <ul className="space-y-2">
             {receivedReviews.map((r) => (
-              <li key={r.reviewId} className={`rounded-lg border p-3 text-sm ${r.teacherReview ? 'border-amber-300 bg-amber-50' : 'border-gray-200 bg-white'}`}>
-                <span className="font-medium text-gray-700">{r.reviewerDisplayName}</span>
-                {r.teacherReview && <span className="ml-2 rounded bg-amber-200 px-2 py-0.5 text-xs text-amber-800">講師</span>}
+              <li key={r.reviewId} className={`rounded-2xl border p-3 text-sm shadow-mac-sm ${r.teacherReview ? 'border-amber-300 bg-amber-50' : 'border-black/5 bg-white/75'}`}>
+                <span className="font-semibold text-gray-700">{r.reviewerDisplayName}</span>
+                {r.teacherReview && <span className="ml-2 rounded-full bg-amber-200 px-2 py-0.5 text-xs text-amber-800">講師</span>}
                 <span className="ml-2 text-xs text-gray-400">🙏 {r.thanksCount}</span>
                 <p className="mt-1 text-gray-600">{r.good}</p>
               </li>
@@ -106,6 +108,7 @@ export default function ProfilePage() {
 // avatarKey は現在値を初期値に持ち、差し替え時のみ更新。bio＋avatarKey を常に送って全置換する
 // （送らないと backend が null 扱いで既存アバターを消すため）。
 function ProfileEditor({ profile, onSaved, onCancel }) {
+  const { refreshUser } = useAuth();
   const [bio, setBio] = useState(profile.bio ?? '');
   const [avatarKey, setAvatarKey] = useState(profile.avatarKey ?? null);
   const [busy, setBusy] = useState(false);
@@ -117,6 +120,8 @@ function ProfileEditor({ profile, onSaved, onCancel }) {
     try {
       const updated = await updateMyProfile({ bio: bio || null, avatarKey });
       onSaved(updated);
+      // ヘッダー（通知ベル横）のアバター等を最新化（AuthContext の user を引き直す）。
+      refreshUser().catch(() => {});
     } catch {
       setErr('保存に失敗しました');
     } finally {
@@ -126,28 +131,25 @@ function ProfileEditor({ profile, onSaved, onCancel }) {
 
   return (
     <div className="space-y-3">
-      <h2 className="font-bold text-gray-800">プロフィール編集</h2>
-      {err && <p className="rounded bg-red-50 px-3 py-2 text-sm text-red-600">{err}</p>}
-      <div className="flex items-start gap-4">
-        <Avatar url={profile.avatarUrl} name={profile.displayName} size="lg" />
-        <div className="flex-1">
-          <p className="mb-1 text-sm text-gray-600">アバター画像（PNG/JPEG/WebP・5MB まで）</p>
-          <ScreenshotUploader initialUrl={profile.avatarUrl ?? ''} onChange={(key) => setAvatarKey(key)} />
-        </div>
+      <h2 className="mac-h text-lg">プロフィール編集</h2>
+      {err && <p className="rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{err}</p>}
+      <div>
+        <p className="mac-label">アバター画像（PNG/JPEG/WebP・5MB まで・正方形に切り抜き）</p>
+        <AvatarUploader initialUrl={profile.avatarUrl ?? ''} onChange={(key) => setAvatarKey(key)} />
       </div>
-      <label className="block text-sm text-gray-600">自己紹介</label>
+      <label className="mac-label">自己紹介</label>
       <textarea
         value={bio}
         onChange={(e) => setBio(e.target.value)}
         rows={3}
         maxLength={500}
-        className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+        className="mac-input"
       />
       <div className="flex gap-2">
-        <button onClick={save} disabled={busy} className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50">
+        <button onClick={save} disabled={busy} className="mac-btn-brand">
           {busy ? '保存中…' : '保存'}
         </button>
-        <button onClick={onCancel} className="rounded border border-gray-300 px-4 py-2 text-sm text-gray-600 hover:bg-gray-50">キャンセル</button>
+        <button onClick={onCancel} className="mac-btn-ghost">キャンセル</button>
       </div>
     </div>
   );
@@ -155,8 +157,8 @@ function ProfileEditor({ profile, onSaved, onCancel }) {
 
 function Stat({ label, value }) {
   return (
-    <div className="rounded-lg bg-gray-50 p-3">
-      <div className="text-2xl font-bold text-gray-800">{value}</div>
+    <div className="rounded-xl bg-white/95 p-3 shadow-mac-sm">
+      <div className="text-2xl font-extrabold text-navy-700">{value}</div>
       <div className="text-xs text-gray-500">{label}</div>
     </div>
   );
@@ -166,7 +168,7 @@ function Stat({ label, value }) {
 function StreakCard({ streak }) {
   const { currentStreak, longestStreak, totalActiveDays, achievedBadges = [] } = streak;
   return (
-    <section className="rounded-lg border border-orange-200 bg-orange-50 p-6">
+    <section className="rounded-2xl border border-orange-200 bg-orange-50 p-6 shadow-mac-sm">
       <h3 className="mb-3 font-medium text-orange-800">継続の記録 <span className="text-xs font-normal text-orange-600">（投稿・レビューを続けた日数）</span></h3>
       <div className="grid grid-cols-3 gap-4 text-center">
         <Stat label="現在の連続" value={`🔥 ${currentStreak}日`} />


### PR DESCRIPTION
## 関連 Issue

Closes #176

---

## 変更の概要

トップページを明るい案Lデザインのランディングへ全面統一（Hero / REASON / BROWSE / RANKING / WORKS / CTA）。各ページ（Login / Header / PostDetail / New / Edit / Notifications / Profile / 評価 / レビュー）も案Lトーンへ刷新。

主な追加機能:
- いいね(👍)＋いいね人気ランキング（`post_likes` / V11、`sort=likes`）
- レビュートーンの多値化（V10、`reviewTones` 配列、DETAILED/QUICK_OK 追加）＋観点拡充（UX/ARCHITECTURE/TESTING/ACCESSIBILITY）
- 観点/トーン検索・一文字対応（ひらがな→カタカナ正規化＋部分一致で enum 解決）
- ランディング統計API（`GET /api/stats/landing`）と一覧APIの著者名/スクショ拡張（SEC-8 バッチ解決）
- アバター切り抜き（AvatarCropper / AvatarUploader）、レビュー表示の刷新（ReviewItem）、豆柴アイコン
- 遷移時のスクロール位置リセット（ScrollToTop）＋ヘッダー検索欄のクリア

デザイン採用に伴い、プレビュー一式（`preview/` と `/preview/*` ルート）を削除。

> 注: 作業ディレクトリパス更新を含む CLAUDE.md の変更は本PRには**含めていません**（別Issue/PRで対応）。

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（Chrome DevTools で全機能・主要導線を実機確認）
- [x] 既存の機能が壊れていないことを確認した（`./gradlew test` 成功、`eslint` 0 errors、`npm run build` 成功）
- [x] `.env` ファイルやパスワードをコミットしていない

---

## スクリーンショット（任意）

ローカル(localhost:5175)でトップページの案Lデザイン・いいねランキング・観点検索・プロフィール継続記録などを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)