### PR TITLE
feat: アクセシビリティ前進（P-9）— コントラストAA・select-name対応

### DIFF
--- a/review-board/frontend/src/components/AppShot.jsx
+++ b/review-board/frontend/src/components/AppShot.jsx
@@ -133,7 +133,8 @@ const SCREENS = { todo: Todo, portfolio: Portfolio, api: Api, weather: Weather, 
 export default function AppShot({ kind, className = '' }) {
   const Screen = SCREENS[kind] || (() => <div className="h-full bg-gray-100" />);
   return (
-    <div className={`flex h-full flex-col overflow-hidden bg-white ${className}`}>
+    // 装飾的な「アプリ画面風」モック。内容は意味を持たないので支援技術からは隠す。
+    <div aria-hidden="true" className={`flex h-full flex-col overflow-hidden bg-white ${className}`}>
       {/* ブラウザ枠（撮影したスクショ風） */}
       <div className="flex items-center gap-1 bg-gray-200/80 px-1.5 py-1">
         <span className="h-1.5 w-1.5 rounded-full bg-red-400" />

--- a/review-board/frontend/src/index.css
+++ b/review-board/frontend/src/index.css
@@ -15,12 +15,15 @@
   --color-accent-600: #0a6dde;
   --color-accent-700: #0857b3;
 
-  /* ブランド（採用デザイン L：ネイビー＋オレンジ） */
+  /* ブランド（採用デザイン L：ネイビー＋オレンジ）
+     白文字ボタン・白地のオレンジ文字が WCAG AA（4.5:1）を満たすよう、
+     主要色 500 を濃いめのオレンジに調整（hover 用 600 はさらに濃く）。
+     400 は淡い装飾フィル用にやや明るめを維持。 */
   --color-navy-700: #13315a;
   --color-navy-800: #0f2747;
-  --color-brand-400: #ff944d;
-  --color-brand-500: #ff7a18;
-  --color-brand-600: #ec6a08;
+  --color-brand-400: #f97316;
+  --color-brand-500: #c2410c;
+  --color-brand-600: #9a3412;
 
   /* キャンバス（Apple グレー） */
   --color-canvas: #f5f5f7;

--- a/review-board/frontend/src/pages/PostsPage.jsx
+++ b/review-board/frontend/src/pages/PostsPage.jsx
@@ -119,7 +119,7 @@ export default function PostsPage() {
                 <div className="min-w-0 flex-1">
                   <div className="text-sm font-bold text-navy-700">{u.displayName}</div>
                   <div className="mt-1 flex flex-wrap items-center gap-1.5 text-xs">
-                    <span className="rounded bg-gray-100 px-1.5 py-0.5 text-gray-500">{ROLE_LABEL[u.role] ?? u.role}</span>
+                    <span className="rounded bg-gray-100 px-1.5 py-0.5 text-gray-600">{ROLE_LABEL[u.role] ?? u.role}</span>
                     <span className="text-brand-500">▶</span>
                     <span className="font-semibold text-gray-700">投稿 {u.postsCount}・レビュー {u.reviewsCount}</span>
                     {u.approved && <span className="rounded-full bg-amber-100 px-2 py-0.5 font-bold text-amber-700">🏅 合格</span>}
@@ -220,6 +220,7 @@ export default function PostsPage() {
 
         <div className="mt-8 flex flex-wrap items-center gap-3">
           <select value={applied.status} onChange={(e) => setFilter({ status: e.target.value })}
+            aria-label="募集状態で絞り込み"
             className="rounded-xl border border-black/10 bg-white px-3 py-1.5 text-sm text-gray-700 outline-none">
             <option value="">すべての状態</option>
             <option value="OPEN">レビュー募集中</option>
@@ -230,6 +231,7 @@ export default function PostsPage() {
             未レビューのみ
           </label>
           <select value={applied.sort} onChange={(e) => setFilter({ sort: e.target.value })}
+            aria-label="並び替え"
             className="rounded-xl border border-black/10 bg-white px-3 py-1.5 text-sm text-gray-700 outline-none">
             <option value="newest">新着順</option>
             <option value="reviews">レビュー数順</option>
@@ -281,7 +283,7 @@ export default function PostsPage() {
                       <span className="truncate text-xs text-gray-500">{p.authorDisplayName ?? '—'}</span>
                     </div>
                     <div className="mb-3"><ReviewPrefBadges tones={p.reviewTones} aspects={p.reviewAspects} aiUsage={p.aiUsage} /></div>
-                    <div className="flex items-center justify-between border-t border-black/5 pt-3 text-xs text-gray-400">
+                    <div className="flex items-center justify-between border-t border-black/5 pt-3 text-xs text-gray-500">
                       <span className="flex items-center gap-3">
                         <span>👍 {p.likeCount}</span>
                         <span>💬 {p.reviewCount}</span>


### PR DESCRIPTION
## 関連 Issue

Closes #182

---

## 変更の概要

Lighthouse のアクセシビリティ監査に基づき、実UIの WCAG AA 違反を解消（Accessibility **89 → 96**）。

- ブランドのオレンジを白文字・白地文字で AA（4.5:1）を満たす濃さへ調整（`--color-brand-500: #c2410c`、hover 用 `600` も連動）
- WORKS の絞り込み/並び替え `<select>` に `aria-label` を付与（select-name）
- カードの 👍/💬 カウント・役割チップの灰色を濃く（コントラスト確保）
- 装飾の「アプリ画面風」モック（AppShot）を `aria-hidden` 化（支援技術から隠す）

残る color-contrast は aria-hidden 済みの装飾モック内テキストのみ。

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（Lighthouse 再監査で 96、ブランド色の見た目を確認）
- [x] 既存の機能が壊れていないことを確認した（`eslint` 0 errors）
- [x] `.env` ファイルやパスワードをコミットしていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)