### PR TITLE
feat: review-board Terraform plan CI（PRで差分ゲート・危険差分検知）

### DIFF
--- a/.github/workflows/review-board-terraform-plan.yml
+++ b/.github/workflows/review-board-terraform-plan.yml
@@ -1,0 +1,132 @@
+name: review-board Terraform Plan
+
+# ============================================================
+# #164：infra/ の変更を PR でゲートする。fmt / validate / init で
+# 「.tf が plan 可能か（構文＋プロバイダスキーマ）」を常時検証し、
+# AWS 認証が設定されている場合のみ実 plan を実行して差分を可視化する。
+#
+# 危険な差分（リソースの destroy / 再作成 / prevent_destroy 解除）を
+# 強調表示する（修練城 §12-4 デプロイ前監査チェックリストと整合）。
+#
+# apply は CI では行わない（CLAUDE.md §6/§12：apply は人間承認必須）。
+# review-board は未デプロイ（S-2 前）のため、AWS 認証 secret が未設定でも
+# CI が壊れないよう plan は条件付き実行とする。
+# ============================================================
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'review-board/infra/**'
+      - '.github/workflows/review-board-terraform-plan.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'review-board/infra/**'
+      - '.github/workflows/review-board-terraform-plan.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: rb-tfplan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  terraform-plan:
+    name: Terraform plan (review-board/infra)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: review-board/infra
+    env:
+      # secret が未設定なら空文字。空かどうかで plan の実行可否を分岐する。
+      AWS_KEY: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          # ローカル検証環境と version を揃える（fmt 差異の回避）。versions.tf の >= 1.5.0 を満たす。
+          terraform_version: "1.15.2"
+
+      - name: Terraform fmt check
+        run: terraform fmt -check -recursive
+
+      - name: Terraform init (no backend)
+        # versions.tf は local backend（S3 backend 未設定）。CI は state を持たないため
+        # -backend=false でプロバイダ DL のみ行い、構文・スキーマ整合を検証する。
+        run: terraform init -backend=false -input=false
+
+      - name: Terraform validate
+        run: terraform validate -no-color
+
+      # ---- ここから先は AWS 認証がある時だけ（実 plan は AWS API を叩くため） ----
+      - name: Configure AWS credentials
+        if: env.AWS_KEY != ''
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-1
+
+      - name: Terraform plan
+        if: env.AWS_KEY != ''
+        # default の無い必須変数にはダミー値を渡す（plan は値の中身を検証しない）。
+        # 実 apply 用の本物の値はローカルの terraform.tfvars で人間が指定する（CLAUDE.md §6）。
+        # 必須変数を追加したらここにも -var を足すこと（-input=false で hang を防止）。
+        run: |
+          terraform plan -no-color -input=false \
+            -var="db_password=ci-plan-check-dummy-pass" \
+            -var="jwt_secret=ci-plan-check-dummy-secret-at-least-32-chars" \
+            -var="budget_notify_email=ci-plan-check@example.com" \
+            | tee plan-output.txt
+
+      - name: Detect dangerous changes
+        if: env.AWS_KEY != ''
+        # destroy / 再作成 / prevent_destroy 解除を検出して強調（修練城 §12-4）。
+        run: |
+          DANGER=0
+          {
+            echo '## ⚠️ 危険な差分の検査'
+            echo ''
+            if grep -Eq 'will be destroyed|must be replaced|forces replacement' plan-output.txt; then
+              echo '- 🔴 **リソースの削除 / 再作成 / 置換** が plan に含まれています。人間レビュー必須。'
+              grep -nE 'will be destroyed|must be replaced|forces replacement' plan-output.txt | head -40
+              DANGER=1
+            fi
+            if git diff -U0 origin/main -- . 2>/dev/null | grep -Eq '^\-.*prevent_destroy\s*=\s*true|^\+.*prevent_destroy\s*=\s*false'; then
+              echo '- 🔴 **prevent_destroy の解除** が検出されました。意図をコミットメッセージ/PR に明記すること（CLAUDE.md §12-3）。'
+              DANGER=1
+            fi
+            if [ "$DANGER" = "0" ]; then
+              echo '- ✅ 削除・再作成・prevent_destroy 解除は検出されませんでした。'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+          # 危険差分があっても CI は赤にせず（人間レビュー前提）、Summary で強調するに留める。
+
+      - name: Write plan to job summary
+        if: always() && env.AWS_KEY != ''
+        # PR コメントは pull-requests:write 権限を要し 403 になりやすいため、
+        # 権限不要の Step Summary に出力する（PR の Checks タブから閲覧可能）。
+        run: |
+          {
+            echo '## Terraform Plan (review-board/infra)'
+            echo ''
+            echo '```'
+            tail -80 plan-output.txt 2>/dev/null || echo '(plan output が生成されませんでした)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Note when plan skipped
+        if: env.AWS_KEY == ''
+        run: |
+          {
+            echo '## Terraform Plan (review-board/infra)'
+            echo ''
+            echo 'AWS 認証 secret (AWS_ACCESS_KEY_ID) が未設定のため、実 plan はスキップしました。'
+            echo 'fmt / validate / init による「plan 可能性（構文＋プロバイダスキーマ）」の検証は完了しています。'
+            echo 'S-2（本番デプロイ）開始時に secret を設定すると、PR で差分ゲートが有効になります。'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## 関連 Issue

Closes #164

---

## 変更の概要

`review-board/infra/` 変更時に走る Terraform plan CI を追加（sns-board の terraform-plan.yml を移植）。

- `fmt -check` / `init -backend=false` / `validate` で **plan 可能性（構文＋プロバイダスキーマ）を常時検証**
- AWS 認証 secret がある場合のみ実 `plan` を実行し、差分を Step Summary に出力
- **危険な差分（削除 / 再作成 / 置換 / prevent_destroy 解除）を検出して強調**（修練城 §12-4）
- `apply` は CI では実行しない（CLAUDE.md §6/§12：人間承認必須）
- 未デプロイ（S-2 前）でも壊れないよう、認証未設定時は plan をスキップして fmt/validate のみ

ローカル（Terraform v1.15.2）で `fmt -check` / `init -backend=false` / `validate` の成功を確認済み。

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（infra/ で fmt/init/validate 成功）
- [x] 既存の機能が壊れていないことを確認した（ワークフロー追加のみ）
- [x] `.env` ファイルやパスワードをコミットしていない（ダミー値のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)