### PR TITLE
feat: review-board E2E（Playwright）CI＋smoke/a11yシナリオ

### DIFF
--- a/.github/workflows/review-board-e2e.yml
+++ b/.github/workflows/review-board-e2e.yml
@@ -1,0 +1,165 @@
+name: review-board E2E (Playwright)
+
+# ============================================================
+# #162：PR ごとに smoke を自動実行（Chromium デスクトップ）。
+# full / a11y / mobile は workflow_dispatch で手動トリガ（a11y=P-9 の WCAG 監査）。
+#
+# スタックは Postgres + MinIO + backend(8082) を起動し、Playwright が
+# フロント（Vite 5175・/api を 8082 へプロキシ）を立ち上げて E2E を回す。
+# 認証は HttpOnly Cookie。seed ユーザー（SEED_PASSWORD）でログインする。
+# ============================================================
+
+on:
+  pull_request:
+    paths:
+      - 'review-board/frontend/**'
+      - 'review-board/backend/**'
+      - 'review-board/e2e/**'
+      - '.github/workflows/review-board-e2e.yml'
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: 実行スコープ
+        required: true
+        type: choice
+        default: smoke
+        options:
+          - smoke
+          - full
+          - a11y
+          - mobile
+
+concurrency:
+  group: rb-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: ${{ github.event_name == 'pull_request' && 'smoke' || inputs.scope }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: reviewboard
+          POSTGRES_PASSWORD: ci-reviewboard-pass
+          POSTGRES_DB: reviewboard
+        ports:
+          - 5434:5432
+        options: >-
+          --health-cmd "pg_isready -U reviewboard -d reviewboard"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      # backend / E2E 共通の接続情報（CI 専用・本番資格情報ではない）。
+      DATABASE_URL: jdbc:postgresql://localhost:5434/reviewboard
+      DATABASE_USERNAME: reviewboard
+      DATABASE_PASSWORD: ci-reviewboard-pass
+      JWT_SECRET: ci-only-secret-must-be-at-least-32-bytes-long-xx
+      S3_ENDPOINT: http://localhost:9002
+      S3_BUCKET: review-board
+      S3_REGION: ap-northeast-1
+      S3_ACCESS_KEY: minioadmin
+      S3_SECRET_KEY: minioadmin
+      SEED_PASSWORD: devpass12345
+      E2E_PASSWORD: devpass12345
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Start MinIO + create bucket
+        run: |
+          docker run -d --name minio \
+            -p 9002:9000 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            minio/minio:latest server /data
+          for i in {1..30}; do
+            curl -sf http://localhost:9002/minio/health/live >/dev/null && break
+            sleep 2
+          done
+          docker run --rm --network host --entrypoint /bin/sh minio/mc:latest -c "
+            mc alias set local http://localhost:9002 minioadmin minioadmin &&
+            mc mb --ignore-existing local/review-board &&
+            mc anonymous set download local/review-board
+          "
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Start backend (8082) and wait for health
+        working-directory: review-board/backend
+        run: |
+          nohup ./gradlew bootRun --no-daemon --quiet > /tmp/backend.log 2>&1 &
+          for i in {1..60}; do
+            curl -sf http://localhost:8082/actuator/health >/dev/null && exit 0
+            sleep 3
+          done
+          echo "Backend failed to start"; tail -120 /tmp/backend.log; exit 1
+
+      - name: Install frontend deps (Vite は Playwright が起動)
+        working-directory: review-board/frontend
+        run: npm install
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('review-board/e2e/package.json') }}
+
+      - name: Install E2E deps + browsers
+        working-directory: review-board/e2e
+        run: |
+          npm install
+          npx playwright install --with-deps chromium webkit
+
+      - name: Run E2E
+        working-directory: review-board/e2e
+        env:
+          CI: 'true'
+        run: |
+          case "${{ github.event_name == 'pull_request' && 'smoke' || inputs.scope }}" in
+            smoke)  npm run e2e:smoke ;;
+            full)   npm run e2e:full ;;
+            a11y)   npm run e2e:a11y ;;
+            mobile) npm run e2e:mobile ;;
+          esac
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rb-playwright-report-${{ github.run_id }}
+          path: review-board/e2e/playwright-report/
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Upload traces (failures only)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rb-playwright-traces-${{ github.run_id }}
+          path: review-board/e2e/test-results/
+          retention-days: 14
+          if-no-files-found: ignore
+
+      - name: Dump backend log on failure
+        if: failure()
+        run: tail -200 /tmp/backend.log || true

--- a/.github/workflows/review-board-e2e.yml
+++ b/.github/workflows/review-board-e2e.yml
@@ -69,6 +69,8 @@ jobs:
       S3_SECRET_KEY: minioadmin
       SEED_PASSWORD: devpass12345
       E2E_PASSWORD: devpass12345
+      # dev プロファイルで seed（講師/受講生）を有効化する（DevDataSeeder は @Profile("dev")）。
+      SPRING_PROFILES_ACTIVE: dev
 
     steps:
       - uses: actions/checkout@v4

--- a/review-board/e2e/.gitignore
+++ b/review-board/e2e/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+playwright-report/
+test-results/
+/blob-report/
+.playwright/

--- a/review-board/e2e/README.md
+++ b/review-board/e2e/README.md
@@ -1,0 +1,34 @@
+# review-board E2E（Playwright）
+
+主要導線の E2E と WCAG 監査（P-9）。PR で smoke を自動実行し、full / a11y / mobile は手動スコープ。
+
+## 構成
+- `playwright.config.js` … baseURL=フロント(5175)。`webServer` で Vite を起動（稼働中なら再利用）。
+- `pages/` … ページオブジェクト（`LoginPage`・seed ユーザー）。
+- `tests/smoke.spec.js` … `@smoke`：login → 投稿 → 詳細 → 成長記録。
+- `tests/a11y.spec.js` … `@a11y`：axe による WCAG 監査（critical を失敗条件、serious はログ）。
+
+## ローカル実行
+事前に backend(8082)・MinIO(9002)・Postgres(5434) を起動し、`SEED_PASSWORD` でユーザーをシードしておく。
+
+```bash
+cd review-board/e2e
+npm install
+npx playwright install chromium webkit
+npm run e2e:smoke     # PR 相当（Chromium）
+npm run e2e:a11y      # WCAG 監査
+npm run e2e:full      # 全プロジェクト
+npm run e2e:report    # レポート閲覧
+```
+
+`E2E_BASE_URL`（既定 http://localhost:5175）・`E2E_PASSWORD`（既定 devpass12345）で上書き可。
+
+## スコープ
+| スコープ | 内容 | トリガ |
+|---|---|---|
+| smoke | 主要導線（Chromium） | PR 自動 |
+| a11y | WCAG 監査（axe） | 手動 |
+| full | 全テスト×全ブラウザ | 手動 |
+| mobile | iPhone エミュ | 手動 |
+
+CI は `.github/workflows/review-board-e2e.yml`。

--- a/review-board/e2e/package-lock.json
+++ b/review-board/e2e/package-lock.json
@@ -1,0 +1,102 @@
+{
+  "name": "review-board-e2e",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "review-board-e2e",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@axe-core/playwright": "^4.10.0",
+        "@playwright/test": "^1.48.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/review-board/e2e/package.json
+++ b/review-board/e2e/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "review-board-e2e",
+  "version": "0.1.0",
+  "private": true,
+  "description": "review-board の E2E（Playwright）。PR で smoke 自動、a11y/full/mobile は手動スコープ。",
+  "scripts": {
+    "install:browsers": "playwright install --with-deps chromium webkit",
+    "e2e:smoke": "playwright test --project=chromium-desktop --grep @smoke",
+    "e2e:full": "playwright test",
+    "e2e:a11y": "playwright test --grep @a11y",
+    "e2e:chromium": "playwright test --project=chromium-desktop",
+    "e2e:webkit": "playwright test --project=webkit-desktop",
+    "e2e:mobile": "playwright test --project=mobile-safari",
+    "e2e:report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@axe-core/playwright": "^4.10.0",
+    "@playwright/test": "^1.48.0"
+  }
+}

--- a/review-board/e2e/pages/LoginPage.js
+++ b/review-board/e2e/pages/LoginPage.js
@@ -1,0 +1,29 @@
+// ログイン画面のページオブジェクト。認証は HttpOnly Cookie（POST /api/auth/login）。
+export class LoginPage {
+  constructor(page) {
+    this.page = page;
+    this.email = page.locator('#email');
+    this.password = page.locator('#password');
+    this.submit = page.getByRole('button', { name: 'ログイン' });
+    this.error = page.locator('text=メールアドレスまたはパスワードが違います');
+  }
+
+  async goto() {
+    await this.page.goto('/login');
+  }
+
+  async login(email, password) {
+    await this.email.fill(email);
+    await this.password.fill(password);
+    await Promise.all([
+      this.page.waitForURL('**/'), // 成功時はトップへ replace 遷移
+      this.submit.click(),
+    ]);
+  }
+}
+
+// seed ユーザー（SEED_PASSWORD）。本番資格情報ではなくローカル/CI 専用。
+export const USERS = {
+  student: { email: 'student@example.com', password: process.env.E2E_PASSWORD || 'devpass12345' },
+  teacher: { email: 'teacher@example.com', password: process.env.E2E_PASSWORD || 'devpass12345' },
+};

--- a/review-board/e2e/playwright.config.js
+++ b/review-board/e2e/playwright.config.js
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// review-board E2E 設定。
+// - baseURL はフロント（Vite 5175）。/api は Vite プロキシ経由で backend(8082) に届く。
+// - smoke は chromium-desktop のみ（PR 自動）。full/a11y/mobile は手動スコープ（workflow_dispatch）。
+// - webServer は「起動済みなら再利用、無ければ起動」。ローカルは稼働中のフロントを再利用し、
+//   CI ではワークフローが backend を起動した後に Playwright がフロントを立ち上げる。
+const BASE_URL = process.env.E2E_BASE_URL || 'http://localhost:5175';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: [['html', { open: 'never' }], ['list']],
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    { name: 'chromium-desktop', use: { ...devices['Desktop Chrome'] } },
+    { name: 'webkit-desktop', use: { ...devices['Desktop Safari'] } },
+    { name: 'mobile-safari', use: { ...devices['iPhone 13'] } },
+  ],
+
+  webServer: {
+    command: 'npm run dev',
+    cwd: '../frontend',
+    url: BASE_URL,
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+});

--- a/review-board/e2e/tests/a11y.spec.js
+++ b/review-board/e2e/tests/a11y.spec.js
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import { LoginPage, USERS } from '../pages/LoginPage.js';
+
+// @a11y：WCAG 監査（P-9）。手動スコープ（workflow_dispatch）で実行。
+// smoke ゲートを不安定にしないため、致命的（critical）違反のみを失敗条件とし、
+// serious 以下はレポートに記録する（装飾モックは aria-hidden 済みで axe の対象外）。
+const WCAG = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
+
+async function scan(page) {
+  const results = await new AxeBuilder({ page }).withTags(WCAG).analyze();
+  const critical = results.violations.filter((v) => v.impact === 'critical');
+  const serious = results.violations.filter((v) => v.impact === 'serious');
+  // serious は可視化のためログに残す（落とさない）。
+  if (serious.length) {
+    console.log('a11y serious violations:', serious.map((v) => `${v.id} (${v.nodes.length})`).join(', '));
+  }
+  return { critical, serious, all: results.violations };
+}
+
+test.describe('accessibility @a11y', () => {
+  test('ログイン画面に critical な a11y 違反が無い', async ({ page }) => {
+    await page.goto('/login');
+    const { critical } = await scan(page);
+    expect(critical, critical.map((v) => v.id).join(', ')).toEqual([]);
+  });
+
+  test('トップ（認証後）に critical な a11y 違反が無い', async ({ page }) => {
+    const login = new LoginPage(page);
+    await login.goto();
+    await login.login(USERS.student.email, USERS.student.password);
+    await expect(page.getByRole('heading', { name: /エンジニアを育てる/ })).toBeVisible();
+
+    const { critical } = await scan(page);
+    expect(critical, critical.map((v) => v.id).join(', ')).toEqual([]);
+  });
+});

--- a/review-board/e2e/tests/smoke.spec.js
+++ b/review-board/e2e/tests/smoke.spec.js
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+import { LoginPage, USERS } from '../pages/LoginPage.js';
+
+// @smoke：PR で自動実行する主要導線（login → トップ → 成果物詳細 → 成長記録）。
+// 受講生どうしの相互レビューが主役のため、まず受講生でログインして閲覧導線を担保する。
+test.describe('smoke @smoke', () => {
+  test('受講生でログインしてトップが表示される', async ({ page }) => {
+    const login = new LoginPage(page);
+    await login.goto();
+    await login.login(USERS.student.email, USERS.student.password);
+
+    // ランディングのヒーロー見出しが見える＝認証後トップに到達。
+    await expect(page.getByRole('heading', { name: /エンジニアを育てる/ })).toBeVisible();
+  });
+
+  test('成果物を投稿して詳細が表示される', async ({ page }) => {
+    const login = new LoginPage(page);
+    await login.goto();
+    await login.login(USERS.student.email, USERS.student.password);
+
+    const title = `E2E投稿 ${Date.now()}`;
+    await page.goto('/posts/new');
+    // タイトル（必須 input）・説明（必須 textarea）を入力して投稿。
+    // ヘッダーの検索フォームを避けるため main 内の投稿フォームにスコープする。
+    await page.locator('main form input').first().fill(title);
+    await page.locator('main form textarea').first().fill('E2E smoke の自動投稿です。');
+    await page.getByRole('button', { name: '投稿する' }).click();
+
+    // 投稿成功で詳細へ遷移し、タイトルが見える。
+    await expect(page).toHaveURL(/\/posts\/\d+/);
+    await expect(page.getByRole('heading', { name: title })).toBeVisible();
+    await expect(page.getByRole('link', { name: /一覧へ/ })).toBeVisible();
+  });
+
+  test('成長記録（プロフィール）が表示される', async ({ page }) => {
+    const login = new LoginPage(page);
+    await login.goto();
+    await login.login(USERS.student.email, USERS.student.password);
+
+    // ヘッダーのアバターから自分の成長記録へ。
+    await page.locator('header a[href^="/users/"]').first().click();
+    await expect(page).toHaveURL(/\/users\/\d+\/profile/);
+    await expect(page.getByText('継続の記録')).toBeVisible();
+    await expect(page.getByText('投稿した成果物')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## 関連 Issue

Closes #162

---

## 変更の概要

sns-board の `e2e.yml` を review-board へ移植し、E2E（Playwright）を整備。

- **PR で smoke を自動実行**（Chromium デスクトップ）。full / a11y / mobile は `workflow_dispatch` で手動スコープ
- **主要導線**を smoke で網羅：login → 投稿 → 成果物詳細 → 成長記録（受講生）
- **a11y（axe）で WCAG 監査**＝P-9 前進。critical を失敗条件、serious はログ（装飾モックは aria-hidden 済み）
- CI は Postgres + MinIO + backend(8082) を起動し、Playwright が Vite(5175・/api→8082 プロキシ) を立ち上げて実行。認証は HttpOnly Cookie、seed ユーザーでログイン

ローカルの稼働スタックで **smoke 3件・a11y 2件の green を確認済み**。

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（smoke/a11y を実機実行）
- [x] 既存の機能が壊れていないことを確認した（追加のみ）
- [x] `.env` ファイルやパスワードをコミットしていない（CI 専用ダミー値のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)