### PR TITLE
feat: 本番の画像アップロードを AWS S3（IAMロール）で行う

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/storage/S3Config.java
+++ b/review-board/backend/src/main/java/com/reviewboard/storage/S3Config.java
@@ -3,6 +3,8 @@ package com.reviewboard.storage;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -12,8 +14,15 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import java.net.URI;
 
 /**
- * S3 / MinIO クライアント。MinIO は path-style（バケットをパスに置く）が必須で、
- * 静的クレデンシャル（env 由来）で認証する。重い Netty を避け url-connection-client を使う（build.gradle）。
+ * S3 / MinIO クライアント。ローカル（MinIO）と本番（AWS S3）を同じインタフェースで使い分ける。
+ *
+ * <ul>
+ *   <li>endpoint 指定あり（MinIO）：endpointOverride＋path-style＋静的クレデンシャル（env 由来）。</li>
+ *   <li>endpoint 空（本番 AWS S3）：override せず AWS 既定エンドポイント＋仮想ホスト形式。
+ *       access/secret も空なら IAM ロール（EC2 インスタンスプロファイル）で認証する
+ *       （静的キーをサーバに置かない＝SEC-9／最小権限。infra/iam.tf で S3 権限付与済み）。</li>
+ * </ul>
+ * 重い Netty を避け url-connection-client を使う（build.gradle）。
  */
 @Configuration
 public class S3Config {
@@ -24,29 +33,52 @@ public class S3Config {
         this.props = props;
     }
 
+    /** endpoint が指定されていれば MinIO 等のカスタムエンドポイント、空なら AWS 既定。 */
+    private boolean hasCustomEndpoint() {
+        return props.endpoint() != null && !props.endpoint().isBlank();
+    }
+
     @Bean
     public S3Client s3Client() {
-        return S3Client.builder()
-                .endpointOverride(URI.create(props.endpoint()))
+        var b = S3Client.builder()
                 .region(Region.of(props.region()))
                 .credentialsProvider(credentials())
-                // MinIO 互換：仮想ホスト形式ではなくパス形式を強制する。
-                .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
-                .build();
+                .serviceConfiguration(serviceConfiguration());
+        if (hasCustomEndpoint()) {
+            b.endpointOverride(URI.create(props.endpoint()));
+        }
+        return b.build();
     }
 
     @Bean
     public S3Presigner s3Presigner() {
-        return S3Presigner.builder()
-                .endpointOverride(URI.create(props.endpoint()))
+        var b = S3Presigner.builder()
                 .region(Region.of(props.region()))
                 .credentialsProvider(credentials())
-                .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
+                .serviceConfiguration(serviceConfiguration());
+        if (hasCustomEndpoint()) {
+            b.endpointOverride(URI.create(props.endpoint()));
+        }
+        return b.build();
+    }
+
+    /** MinIO はパス形式が必須。AWS S3 は仮想ホスト形式（既定）を使う。 */
+    private S3Configuration serviceConfiguration() {
+        return S3Configuration.builder()
+                .pathStyleAccessEnabled(hasCustomEndpoint())
                 .build();
     }
 
-    private StaticCredentialsProvider credentials() {
-        return StaticCredentialsProvider.create(
-                AwsBasicCredentials.create(props.accessKey(), props.secretKey()));
+    /**
+     * access/secret が両方そろっていれば静的クレデンシャル（MinIO・ローカル）。
+     * 空なら DefaultCredentialsProvider＝本番 EC2 の IAM ロールで認証する。
+     */
+    private AwsCredentialsProvider credentials() {
+        String ak = props.accessKey();
+        String sk = props.secretKey();
+        if (ak != null && !ak.isBlank() && sk != null && !sk.isBlank()) {
+            return StaticCredentialsProvider.create(AwsBasicCredentials.create(ak, sk));
+        }
+        return DefaultCredentialsProvider.create();
     }
 }

--- a/review-board/backend/src/main/resources/application.yml
+++ b/review-board/backend/src/main/resources/application.yml
@@ -98,3 +98,13 @@ logging:
   structured:
     format:
       console: ecs
+# 本番のオブジェクトストレージは AWS S3。endpoint/キーは既定で空にして、
+# AWS 既定エンドポイント＋EC2 の IAM ロール（インスタンスプロファイル）で認証する
+# （静的キーをサーバに置かない＝SEC-9。infra/iam.tf で S3 権限付与済み）。
+# bucket は deploy 時に S3_BUCKET（infra の screenshots バケット名）で指定する。
+app:
+  storage:
+    s3:
+      endpoint: ${S3_ENDPOINT:}
+      access-key: ${S3_ACCESS_KEY:}
+      secret-key: ${S3_SECRET_KEY:}


### PR DESCRIPTION
## 関連 Issue

Closes #187

---

## 変更の概要

ユーザー同士の相互利用を見据え、**デプロイ以降の画像アップロードを実 AWS S3**（EC2 の IAM ロール認証）に保存できるようにする。ローカルは MinIO のまま。

- `S3Config` を環境で分岐
  - endpoint 指定あり（MinIO/ローカル）→ `endpointOverride`＋path-style＋静的キー（従来どおり）
  - endpoint 空（本番 AWS S3）→ AWS 既定エンドポイント＋仮想ホスト形式。access/secret も空なら **`DefaultCredentialsProvider`＝EC2 の IAM ロール**で認証（静的キーをサーバに置かない＝SEC-9）
- prod プロファイルで `app.storage.s3.endpoint / access-key / secret-key` を既定空に。`bucket` は deploy 時に `S3_BUCKET`（infra の screenshots バケット名）で指定

## 前提（確認済み・既存）
- `infra/iam.tf`：EC2 ロールに screenshots バケットの Get/Put/Delete/ListBucket 付与済み
- `infra/s3.tf`：screenshots バケット（private・暗号化・versioning・public access block）作成済み

## 変更の種別
- [x] feat（新機能の追加）

---

## 動作確認チェックリスト
- [x] ローカルで動作確認した（`./gradlew test` 成功。UploadIntegrationTest は MinIO で静的キー経路＝挙動不変）
- [x] 既存の機能が壊れていないことを確認した
- [x] `.env` ファイルやパスワードをコミットしていない（本番は IAM ロール＝キーレス）

🤖 Generated with [Claude Code](https://claude.com/claude-code)