### PR TITLE
feat: S-2 アプリ層デプロイ資産＋アーティファクト基盤（apply前準備）

### DIFF
--- a/.github/workflows/review-board-cd-build.yml
+++ b/.github/workflows/review-board-cd-build.yml
@@ -114,6 +114,20 @@ jobs:
           retention-days: 30
           if-no-files-found: error
 
+      # AWS 認証とアーティファクトバケットが設定済みなら、S3 にも push（EC2 の deploy.sh が取得）。
+      # 未設定（S-2 前）なら GitHub Artifact のみで、この step はスキップする。
+      - name: アーティファクトを S3 に push（任意・認証時のみ）
+        if: ${{ secrets.AWS_ACCESS_KEY_ID != '' && vars.RB_ARTIFACTS_BUCKET != '' }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ap-northeast-1
+          ARTIFACTS_BUCKET: ${{ vars.RB_ARTIFACTS_BUCKET }}
+        run: |
+          TAG="${{ steps.meta.outputs.tag }}"
+          aws s3 sync "artifact/$TAG/" "s3://$ARTIFACTS_BUCKET/$TAG/" --only-show-errors
+          echo "::notice title=pushed to S3::s3://$ARTIFACTS_BUCKET/$TAG/"
+
       - name: 次の手動デプロイで使う SHA を表示
         run: |
           echo "::notice title=artifact ready::SHA=${{ steps.meta.outputs.tag }} を review-board-cd-deploy の sha 入力に渡して昇格する"

--- a/.github/workflows/review-board-cd-deploy.yml
+++ b/.github/workflows/review-board-cd-deploy.yml
@@ -111,17 +111,9 @@ jobs:
             --command-id "$CMD_ID" --instance-id "${{ steps.ec2.outputs.id }}" \
             --query 'StandardOutputContent' --output text
 
-      - name: ヘルスチェック（公開エンドポイント）
+      - name: 昇格結果
         if: steps.guard.outputs.ready == 'true'
-        run: |
-          IP=$(aws ec2 describe-instances --region "$AWS_REGION" \
-            --instance-ids "${{ steps.ec2.outputs.id }}" \
-            --query 'Reservations[0].Instances[0].PublicIpAddress' --output text)
-          for i in {1..20}; do
-            if curl -skf "https://${IP}/api/actuator/health" >/dev/null 2>&1 \
-               || curl -sf "http://${IP}/api/actuator/health" >/dev/null 2>&1; then
-              echo "::notice title=deployed::SHA=${{ github.event.inputs.sha }} を昇格しました（${IP}）"; exit 0
-            fi
-            sleep 6
-          done
-          echo "ヘルスチェックに失敗。ロールバック手順（docs）を参照。"; exit 1
+        # deploy.sh が localhost の actuator/health を権威的にチェックし、失敗時は非ゼロ終了する
+        # （前段の SSM step で command-executed を待機済み＝ここに到達＝成功）。
+        # actuator は外部公開しない方針のため、公開エンドポイントの health curl は行わない。
+        run: echo "::notice title=deployed::SHA=${{ github.event.inputs.sha }} を昇格しました"

--- a/review-board/infra/artifacts.tf
+++ b/review-board/infra/artifacts.tf
@@ -1,0 +1,88 @@
+# =====================================================================
+# artifacts.tf — CD の不変アーティファクト配布バケット（#161 / S-2）
+# =====================================================================
+# cd-build が <sha>/app.jar と <sha>/dist を push し、EC2 の deploy.sh が
+# IAM ロールで取得する。非公開・暗号化・versioning・非SSL拒否（screenshots と同方針）。
+# =====================================================================
+
+#tfsec:ignore:aws-s3-enable-bucket-logging アクセスログ用バケットは本格運用フェーズで追加
+resource "aws_s3_bucket" "artifacts" {
+  bucket = "${local.name_prefix}-artifacts-${data.aws_caller_identity.current.account_id}"
+
+  tags = { Name = "${local.name_prefix}-artifacts" }
+}
+
+resource "aws_s3_bucket_public_access_block" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+#tfsec:ignore:aws-s3-encryption-customer-key 学習スコープは SSE-S3（無料）。CMK は本格運用フェーズ
+resource "aws_s3_bucket_server_side_encryption_configuration" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# 古い版・サイズ管理（無料枠 5GB 内）。アーティファクトは SHA 単位で増えるため期限切れを設定。
+resource "aws_s3_bucket_lifecycle_configuration" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+
+  rule {
+    id     = "expire-old-artifacts"
+    status = "Enabled"
+
+    filter {}
+
+    # 現行版は 90 日、旧版は 30 日で失効（ロールバック余地を残しつつ肥大化を防ぐ）。
+    expiration {
+      days = 90
+    }
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+
+# 非 SSL アクセス拒否（転送時暗号化の強制）。
+data "aws_iam_policy_document" "artifacts" {
+  statement {
+    sid       = "DenyInsecureTransport"
+    effect    = "Deny"
+    actions   = ["s3:*"]
+    resources = [aws_s3_bucket.artifacts.arn, "${aws_s3_bucket.artifacts.arn}/*"]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "artifacts" {
+  bucket     = aws_s3_bucket.artifacts.id
+  policy     = data.aws_iam_policy_document.artifacts.json
+  depends_on = [aws_s3_bucket_public_access_block.artifacts]
+}

--- a/review-board/infra/deploy/README.md
+++ b/review-board/infra/deploy/README.md
@@ -1,0 +1,40 @@
+# review-board アプリ層デプロイ資産（S-2 / #161・#189）
+
+`infra/` の Terraform が用意した土台（EC2＋nginx＋Java＋SSM＋S3＋IAM）の上に、
+**アプリの器**（systemd・nginx vhost・env・デプロイ機構）を載せるための資産。
+user_data.sh は土台までで止め、ここから先を本ディレクトリで定義する。
+
+| ファイル | 役割 |
+|---|---|
+| `provision.sh` | 一度きりの初期化（EnvironmentFile を SSM から生成・systemd/nginx 設置・TLS・deploy.sh 設置） |
+| `review-board.service` | systemd ユニット（`current/app.jar` を prod 起動） |
+| `nginx-review-board.conf` | vhost（443→静的・`/api`→127.0.0.1:8082・actuator 非公開） |
+| `deploy.sh` | アプリのみ更新（S3 から `<sha>` 取得→current 切替→再起動→localhost health）。cd-deploy が SSM で呼ぶ |
+
+## 前提（env の出所）
+`provision.sh` は SSM `/review-board/prod/*` から以下を読む（Terraform が作成）：
+`JWT_SECRET`・`DATABASE_URL`・`DATABASE_PASSWORD`・`S3_BUCKET`・`ARTIFACTS_BUCKET`・
+（任意）`BOOTSTRAP_ADMIN_EMAIL`/`BOOTSTRAP_ADMIN_PASSWORD`。
+静的な本番値（`SPRING_PROFILES_ACTIVE=prod`・`JWT_COOKIE_SECURE=true`・`S3_REGION`）は provision.sh が固定。
+フロントは相対 `/api`＝同一オリジンのため、デザイン/挙動は localhost:5175 と同一。
+
+## 初回手順（apply 後・EC2 上で 1 回）
+```bash
+# 1) Session Manager で EC2 に入り、リポジトリを取得
+sudo dnf install -y git
+git clone <repo> /tmp/rb && cd /tmp/rb/review-board/infra/deploy
+
+# 2) 初期化（DOMAIN を渡すと certbot で TLS まで。PUBLIC_ORIGIN は CORS 用）
+sudo PUBLIC_ORIGIN=https://<domain> DOMAIN=<domain> ./provision.sh
+
+# 3) 初回のアプリ投入（cd-build が S3 に push 済みの SHA を指定）
+sudo /opt/review-board/deploy.sh <sha>
+```
+以降の更新は **cd-deploy（手動 dispatch）** で `sha` を渡すだけ。ロールバックは
+`docs/デプロイ・ロールバック手順.md`（前 SHA を再昇格）。
+
+## CD 連携に必要な設定（GitHub 側）
+- secrets：`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`（cd-build の S3 push・cd-deploy の SSM 用）
+- variables：`RB_ARTIFACTS_BUCKET`（Terraform 出力 `artifacts_bucket` の値）
+
+> いずれも S-2 実施時に設定する。未設定の間は cd-build は GitHub Artifact のみ、cd-deploy は安全にスキップ。

--- a/review-board/infra/deploy/deploy.sh
+++ b/review-board/infra/deploy/deploy.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# =====================================================================
+# deploy.sh — EC2 上で「アプリのみ」を不変アーティファクトに切り替える（#161 / S-2）。
+# cd-deploy.yml が SSM Run Command で `sudo /opt/review-board/deploy.sh <sha>` として呼ぶ。
+#
+# やること（インフラ破壊的変更ゼロ）：
+#   1) S3 アーティファクトバケットから <sha> を releases/<sha> に取得（app.jar + dist）
+#   2) current シンボリックリンクを切替（直前の向き先を previous に記録＝ロールバック余地）
+#   3) systemd review-board を再起動、nginx をリロード
+#   4) localhost の actuator/health が UP になるまで待機（失敗で非ゼロ終了）
+#   5) 古いリリースを刈り取り（直近 KEEP 世代のみ保持）
+# =====================================================================
+set -euo pipefail
+
+SHA="${1:?usage: deploy.sh <sha>}"
+APP=/opt/review-board
+ENV_FILE="$APP/env"
+KEEP=5
+
+[ -f "$ENV_FILE" ] || { echo "env がありません（provision.sh 未実行）: $ENV_FILE"; exit 1; }
+ARTIFACTS_BUCKET="$(grep '^ARTIFACTS_BUCKET=' "$ENV_FILE" | cut -d= -f2-)"
+[ -n "$ARTIFACTS_BUCKET" ] || { echo "ARTIFACTS_BUCKET が env に設定されていません"; exit 1; }
+
+REL="$APP/releases/$SHA"
+mkdir -p "$REL"
+# IAM ロールで S3 から取得（静的キーなし）。app.jar と dist/ を同期。
+aws s3 sync "s3://$ARTIFACTS_BUCKET/$SHA/" "$REL/" --only-show-errors
+[ -f "$REL/app.jar" ] || { echo "app.jar が見つかりません: $REL"; exit 1; }
+[ -d "$REL/dist" ]   || { echo "dist が見つかりません: $REL"; exit 1; }
+
+# ロールバック用に直前の向き先を記録してから切替。
+if [ -L "$APP/current" ]; then readlink -f "$APP/current" > "$APP/previous" || true; fi
+ln -sfn "$REL" "$APP/current"
+ln -sfn "$APP/current/dist" /var/www/review-board
+
+systemctl restart review-board
+nginx -t && nginx -s reload || systemctl reload nginx || true
+
+# localhost ヘルスチェック（公開エンドポイント経由ではなく内部で確認）。
+for _ in $(seq 1 30); do
+  if curl -sf http://127.0.0.1:8082/actuator/health | grep -q '"status":"UP"'; then
+    echo "deploy ok: sha=$SHA"
+    # 古いリリースを刈り取り（current/previous は残す）。
+    ls -1dt "$APP"/releases/*/ 2>/dev/null | tail -n +$((KEEP + 1)) | xargs -r rm -rf
+    exit 0
+  fi
+  sleep 3
+done
+
+echo "health check failed for sha=$SHA（ロールバックは docs/デプロイ・ロールバック手順.md 参照）"
+exit 1

--- a/review-board/infra/deploy/nginx-review-board.conf
+++ b/review-board/infra/deploy/nginx-review-board.conf
@@ -1,0 +1,34 @@
+# review-board nginx vhost（443→React 静的・/api→backend 8082）。
+# 初期は HTTP(80)。`certbot --nginx -d <domain>` 実行で 443/TLS＋80→443 リダイレクトが追加される。
+# フロントは相対パス /api を呼ぶ（同一オリジン）。デザイン/挙動は localhost:5175 と同一。
+server {
+    listen 80;
+    listen [::]:80;
+    server_name _;
+
+    # アップロード上限（バックエンドの max-upload-bytes=5MB と整合・余裕を持たせる）。
+    client_max_body_size 8m;
+
+    # React 静的（SPA）。current/dist を指すシンボリックリンク。
+    root /var/www/review-board;
+    index index.html;
+
+    # API は backend にそのままプロキシ（/api プレフィックスを保持）。
+    location /api/ {
+        proxy_pass http://127.0.0.1:8082;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+    }
+
+    # actuator は外部公開しない（ヘルスは localhost / SSM で確認）。
+    location /actuator/ { return 404; }
+
+    # SPA フォールバック（クライアントルーティング）。
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/review-board/infra/deploy/provision.sh
+++ b/review-board/infra/deploy/provision.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# =====================================================================
+# provision.sh — EC2 の「アプリ層」初期化（apply 後に一度だけ実行）。
+# user_data.sh は土台（nginx/Java/SSM）まで。本スクリプトでアプリの器を整える：
+#   - /opt/review-board ディレクトリと EnvironmentFile（SSM から機密を取得）
+#   - systemd review-board.service の設置・有効化
+#   - nginx vhost の設置（443→静的・/api→127.0.0.1:8082）
+#   - certbot による TLS（ドメイン指定時のみ・任意）
+# 実行例（Session Manager もしくは SSM Run Command で root として）：
+#   sudo PUBLIC_ORIGIN=https://example.com DOMAIN=example.com \
+#        /opt/review-board/infra-deploy/provision.sh
+# アプリ本体（jar/dist）の配置は本スクリプトでは行わない。続けて deploy.sh <sha> を実行する。
+# =====================================================================
+set -euo pipefail
+
+REGION="${AWS_REGION:-ap-northeast-1}"
+SSM_PREFIX="${SSM_PREFIX:-/review-board/prod}"
+PUBLIC_ORIGIN="${PUBLIC_ORIGIN:-}"   # 例: https://example.com（CORS 用。同一オリジンなら未指定でも可）
+DOMAIN="${DOMAIN:-}"                 # certbot 用（未指定なら TLS はスキップ＝後で手動）
+APP=/opt/review-board
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+ssm() { aws ssm get-parameter --with-decryption --region "$REGION" \
+          --name "$SSM_PREFIX/$1" --query 'Parameter.Value' --output text 2>/dev/null || true; }
+
+id -u reviewboard >/dev/null 2>&1 || useradd --system --home "$APP" --shell /usr/sbin/nologin reviewboard || true
+mkdir -p "$APP/releases" /var/www
+chown -R reviewboard:reviewboard "$APP" || true
+
+# --- EnvironmentFile（機密は SSM、静的値はここで固定） ---
+umask 077
+cat > "$APP/env" <<EOF
+SPRING_PROFILES_ACTIVE=prod
+JWT_COOKIE_SECURE=true
+JWT_SECRET=$(ssm JWT_SECRET)
+DATABASE_URL=$(ssm DATABASE_URL)
+DATABASE_USERNAME=reviewboard
+DATABASE_PASSWORD=$(ssm DATABASE_PASSWORD)
+S3_BUCKET=$(ssm S3_BUCKET)
+S3_REGION=$REGION
+ARTIFACTS_BUCKET=$(ssm ARTIFACTS_BUCKET)
+CORS_ALLOWED_ORIGINS=$PUBLIC_ORIGIN
+BOOTSTRAP_ADMIN_EMAIL=$(ssm BOOTSTRAP_ADMIN_EMAIL)
+BOOTSTRAP_ADMIN_PASSWORD=$(ssm BOOTSTRAP_ADMIN_PASSWORD)
+EOF
+chmod 600 "$APP/env"
+# SEED_PASSWORD は本番では設定しない（prod プロファイルは seeder 非活性だが二重に明示）。
+
+# --- deploy.sh を所定パスへ設置（cd-deploy が /opt/review-board/deploy.sh を SSM 実行する） ---
+install -m 755 "$HERE/deploy.sh" "$APP/deploy.sh"
+
+# --- systemd ユニット ---
+install -m 644 "$HERE/review-board.service" /etc/systemd/system/review-board.service
+systemctl daemon-reload
+systemctl enable review-board
+
+# --- nginx vhost ---
+install -m 644 "$HERE/nginx-review-board.conf" /etc/nginx/conf.d/review-board.conf
+nginx -t && systemctl reload nginx
+
+# --- TLS（任意・ドメイン指定時のみ） ---
+if [ -n "$DOMAIN" ]; then
+  dnf install -y certbot python3-certbot-nginx || true
+  certbot --nginx -d "$DOMAIN" --non-interactive --agree-tos \
+    -m "${CERTBOT_EMAIL:-admin@$DOMAIN}" --redirect || \
+    echo "certbot に失敗。DNS が EIP を指しているか確認し、手動で再実行してください。"
+fi
+
+echo "provision 完了。次に deploy.sh <sha> でアプリを投入してください。"

--- a/review-board/infra/deploy/review-board.service
+++ b/review-board/infra/deploy/review-board.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=review-board backend (Spring Boot, prod)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=reviewboard
+Group=reviewboard
+# 機密・本番設定は provision.sh が SSM から生成（JWT_COOKIE_SECURE=true / SPRING_PROFILES_ACTIVE=prod 等）。
+EnvironmentFile=/opt/review-board/env
+WorkingDirectory=/opt/review-board/current
+# current は deploy.sh が不変リリース（releases/<sha>）へ張り替える。
+ExecStart=/usr/bin/java -jar /opt/review-board/current/app.jar
+SuccessExitStatus=143
+Restart=on-failure
+RestartSec=5
+# t3.micro(1GB) 向けに JVM ヒープを控えめに（swap 併用）。
+Environment=JAVA_TOOL_OPTIONS=-XX:MaxRAMPercentage=60
+
+[Install]
+WantedBy=multi-user.target

--- a/review-board/infra/iam.tf
+++ b/review-board/infra/iam.tf
@@ -45,6 +45,20 @@ data "aws_iam_policy_document" "ec2_permissions" {
     resources = [aws_s3_bucket.screenshots.arn]
   }
 
+  # CD アーティファクトの取得（読み取り専用）。deploy.sh が <sha>/ を sync する。
+  statement {
+    sid    = "ArtifactsBucketRead"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket",
+    ]
+    resources = [
+      aws_s3_bucket.artifacts.arn,
+      "${aws_s3_bucket.artifacts.arn}/*",
+    ]
+  }
+
   statement {
     sid    = "ReadOwnSsmParameters"
     effect = "Allow"

--- a/review-board/infra/outputs.tf
+++ b/review-board/infra/outputs.tf
@@ -32,6 +32,11 @@ output "s3_screenshot_bucket" {
   value       = aws_s3_bucket.screenshots.bucket
 }
 
+output "artifacts_bucket" {
+  description = "CD アーティファクト配布バケット名（cd-build の S3 push 先）"
+  value       = aws_s3_bucket.artifacts.bucket
+}
+
 output "ssm_parameter_prefix" {
   description = "アプリが読む SSM パラメータのプレフィックス"
   value       = local.ssm_prefix

--- a/review-board/infra/ssm.tf
+++ b/review-board/infra/ssm.tf
@@ -38,3 +38,44 @@ resource "aws_ssm_parameter" "db_url" {
 
   tags = { Name = "${local.name_prefix}-db-url" }
 }
+
+# 画像保存先（本番＝実 S3）。provision.sh が EnvironmentFile に S3_BUCKET として展開する。
+resource "aws_ssm_parameter" "s3_bucket" {
+  name        = "${local.ssm_prefix}/S3_BUCKET"
+  description = "review-board screenshots bucket name"
+  type        = "String"
+  value       = aws_s3_bucket.screenshots.bucket
+
+  tags = { Name = "${local.name_prefix}-s3-bucket" }
+}
+
+# CD アーティファクト配布バケット。deploy.sh が s3://<artifacts>/<sha>/ から取得する。
+resource "aws_ssm_parameter" "artifacts_bucket" {
+  name        = "${local.ssm_prefix}/ARTIFACTS_BUCKET"
+  description = "review-board CD artifacts bucket name"
+  type        = "String"
+  value       = aws_s3_bucket.artifacts.bucket
+
+  tags = { Name = "${local.name_prefix}-artifacts-bucket" }
+}
+
+# 初代管理者の bootstrap（任意）。password が空なら作成しない（AdminBootstrap も未設定で skip）。
+resource "aws_ssm_parameter" "bootstrap_admin_email" {
+  count       = var.bootstrap_admin_password != "" ? 1 : 0
+  name        = "${local.ssm_prefix}/BOOTSTRAP_ADMIN_EMAIL"
+  description = "review-board initial admin email"
+  type        = "String"
+  value       = var.bootstrap_admin_email
+
+  tags = { Name = "${local.name_prefix}-bootstrap-admin-email" }
+}
+
+resource "aws_ssm_parameter" "bootstrap_admin_password" {
+  count       = var.bootstrap_admin_password != "" ? 1 : 0
+  name        = "${local.ssm_prefix}/BOOTSTRAP_ADMIN_PASSWORD"
+  description = "review-board initial admin password"
+  type        = "SecureString"
+  value       = var.bootstrap_admin_password
+
+  tags = { Name = "${local.name_prefix}-bootstrap-admin-password" }
+}

--- a/review-board/infra/variables.tf
+++ b/review-board/infra/variables.tf
@@ -160,3 +160,18 @@ variable "budget_notify_email" {
     error_message = "budget_notify_email は有効なメールアドレスを指定してください。"
   }
 }
+
+# 初代管理者の bootstrap（任意）。password を空にすると管理者を作成しない
+# （後から管理 API/手動で発行）。設定する場合は tfvars で機密扱い。
+variable "bootstrap_admin_email" {
+  description = "初代管理者のメールアドレス（bootstrap_admin_password 設定時のみ有効）"
+  type        = string
+  default     = "admin@example.com"
+}
+
+variable "bootstrap_admin_password" {
+  description = "初代管理者の初期パスワード（空なら管理者を作成しない）"
+  type        = string
+  default     = ""
+  sensitive   = true
+}


### PR DESCRIPTION
## 関連 Issue

Refs #189（実 apply・初回投入は別途。本PRは準備のみで #189 はクローズしない）

---

## 変更の概要

デプロイ（S-2）の最大の漏れ＝**アプリ層が未コード化**だった点を整備。`infra/` の土台の上に、アプリの器とデプロイ機構を載せる。

### infra
- `artifacts.tf`：CD アーティファクト用 S3 バケット（非公開・暗号化・versioning・非SSL拒否・lifecycle）
- `iam.tf`：EC2 ロールに artifacts バケットの read 追加
- `ssm.tf`：`S3_BUCKET` / `ARTIFACTS_BUCKET`（String）＋任意の `BOOTSTRAP_ADMIN_EMAIL`/`PASSWORD`（SecureString・password 空なら作成しない）
- `variables.tf` / `outputs.tf`：bootstrap admin 変数、`artifacts_bucket` 出力

### アプリ層（`infra/deploy/`）
- `review-board.service`：systemd（`current/app.jar` を prod 起動・JVM ヒープ抑制）
- `nginx-review-board.conf`：vhost（443→静的・`/api`→127.0.0.1:8082・actuator 非公開）
- `deploy.sh`：アプリのみ更新（S3 から `<sha>` 取得→`current` 切替→再起動→localhost health→旧版刈取）。cd-deploy が SSM で呼ぶ
- `provision.sh`：一度きり初期化（SSM から EnvironmentFile 生成・**`JWT_COOKIE_SECURE=true`**・`SPRING_PROFILES_ACTIVE=prod`・systemd/nginx 設置・certbot 任意・deploy.sh 設置）
- `README.md`：初回手順・CD 連携に要る GitHub secrets/vars

### CD 連携
- cd-build：認証＋`RB_ARTIFACTS_BUCKET` 設定時に S3 へ push（未設定なら GitHub Artifact のみ）
- cd-deploy：`deploy.sh` の localhost health を権威に（IP/TLS で不安定な公開 curl を廃止）

## 重要
- **デザイン/挙動は不変**：フロントは相対 `/api`＝同一オリジン。同じソースを build するだけ。
- **`apply` は人間承認必須**（CLAUDE.md §6/§12）。本PRはコード準備のみ。

## 変更の種別
- [x] feat（新機能の追加）

---

## 動作確認チェックリスト
- [x] `terraform fmt` / `init -backend=false` / `validate` 成功
- [x] `shellcheck` 確認（警告解消・info の SC2012 のみ許容）
- [x] `.env`・パスワードをコミットしていない（機密は SSM/IAM ロール、tfvars は .gitignore）

🤖 Generated with [Claude Code](https://claude.com/claude-code)