### PR TITLE
fix: nginx の actuator を設計（ログ・監視書/SecurityConfig）準拠に整合

### DIFF
--- a/review-board/docs/デプロイ・ロールバック手順.md
+++ b/review-board/docs/デプロイ・ロールバック手順.md
@@ -50,7 +50,13 @@ user_data.sh は土台（nginx・Java 25・SSM Agent）までを用意する。�
 1. main に変更がマージされると **cd-build** が自動実行され、`review-board-<sha>` アーティファクトが発行される。
 2. Actions の cd-build 実行ログ（`::notice artifact ready`）で **SHA** を確認。
 3. **cd-deploy** を `workflow_dispatch` で起動し、`sha=<確認したSHA>`・`confirm=deploy` を入力。
-4. SSM がアプリのみ更新し、ヘルスチェック成功で昇格完了。
+4. SSM がアプリのみ更新し、`deploy.sh` の localhost `/actuator/health` UP で昇格完了。
+5. **デプロイ後の疎通確認**：[テスト計画書 §8-2](./テスト計画書.md) の手動ブラックボックスチェック
+   （未ログイン→401／投稿→自cohort一覧／受講生で評価API→403／講師承認→合格バッジ／別cohort URL→404）と、
+   HTTPS・Cookie の Secure 属性、画像アップロードが実 S3 に保存されることを確認する。
+
+> 監視：`/actuator/health` は未認証開放（プローブ用）、`metrics`/`prometheus` は ROLE_TEACHER 限定
+> （[ログ・監視・障害対応設計書 §4](./ログ・監視・障害対応設計書.md)）。nginx も同方針で `/actuator/` を素通しする。
 
 ---
 

--- a/review-board/infra/deploy/nginx-review-board.conf
+++ b/review-board/infra/deploy/nginx-review-board.conf
@@ -24,8 +24,17 @@ server {
         proxy_read_timeout 60s;
     }
 
-    # actuator は外部公開しない（ヘルスは localhost / SSM で確認）。
-    location /actuator/ { return 404; }
+    # actuator は backend にプロキシ（ログ・監視設計書 §4 に整合）。
+    # health は監視プローブ用に未認証開放、metrics/prometheus は app 層で ROLE_TEACHER 限定
+    # （SecurityConfig）。ネットワーク層では塞がず app 層認可で保護する設計。
+    location /actuator/ {
+        proxy_pass http://127.0.0.1:8082;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
 
     # SPA フォールバック（クライアントルーティング）。
     location / {


### PR DESCRIPTION
## 関連 Issue
Refs #189

## 概要
設計書との整合確認で見つかった不整合の修正。

- **不整合**：デプロイ資産の nginx vhost が `/actuator/` を `return 404` で全遮断していた。
- **設計（正）**：[ログ・監視・障害対応設計書 §4](review-board/docs/ログ・監視・障害対応設計書.md) と `SecurityConfig`（`/actuator/health`=permitAll・`/actuator/**`=ROLE_TEACHER）は、**health を監視プローブ用に開放し、metrics/prometheus は app 層認可で保護**する方針。nginx の全遮断は health プローブも塞いでおり誤り。
- **修正**：nginx は `/actuator/` を backend に素通しし、保護は app 層に委ねる。
- デプロイ手順書に **テスト計画書 §8-2** の疎通チェック（401/投稿/評価403/承認バッジ/別cohort404）と監視方針を参照追記。

## 設計整合チェックの結論
- インフラ構成書：nginx 443/80＋静的＋/api→8082、`JWT_COOKIE_SECURE=true`/HTTPS、SSM 機密注入、IAM 最小権限 → **整合**
- テスト計画書 §8-2：デプロイ後疎通チェックを手順書に明記 → **整合**
- ログ・監視書 §4：actuator の公開方針 → **本PRで整合**

## 変更の種別
- [x] fix（バグ修正）

🤖 Generated with [Claude Code](https://claude.com/claude-code)