### PR TITLE
fix: SG ingress 説明文の不正文字を除去（apply ブロッカー）

### DIFF
--- a/review-board/infra/network.tf
+++ b/review-board/infra/network.tf
@@ -90,7 +90,7 @@ resource "aws_security_group" "ec2" {
   }
 
   ingress {
-    description = "HTTPS (nginx, Let's Encrypt)"
+    description = "HTTPS (nginx, Lets Encrypt TLS)"
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"


### PR DESCRIPTION
## 関連 Issue
Refs #189

## 概要
`terraform plan` 実行中に判明した apply ブロッカーの修正。

- AWS セキュリティグループの description は許可文字集合にアポストロフィ `'` を含まない。
- `"HTTPS (nginx, Let's Encrypt)"` の `'` が `ingress.1.description` 違反エラーを起こし plan/apply を阻んでいた。
- `"HTTPS (nginx, Lets Encrypt TLS)"` に修正。プラン結果は **37 追加 / 0 変更 / 0 破棄・エラーなし** を確認。

## 変更の種別
- [x] fix（バグ修正）

🤖 Generated with [Claude Code](https://claude.com/claude-code)