### PR TITLE
fix: RDS backup_retention_period を無料枠準拠（1日）に

### DIFF
--- a/review-board/infra/rds.tf
+++ b/review-board/infra/rds.tf
@@ -42,8 +42,10 @@ resource "aws_db_instance" "main" {
   publicly_accessible    = false # インターネット非到達（EC2 SG からのみ）
   multi_az               = false # Single-AZ（無料枠条件・冗長化は本格運用フェーズ＝S-2）
 
-  # バックアップ：7日保持＋破棄時に最終スナップショット（誤破棄からの復旧余地）
-  backup_retention_period   = 7
+  # バックアップ：自動バックアップを保持（破棄時は最終スナップショット）。
+  # 新 AWS Free プランは保持期間に上限があり 7 日だと FreeTierRestrictionError。
+  # 無料枠準拠で 1 日に短縮（本格運用フェーズで延長）。
+  backup_retention_period   = 1
   skip_final_snapshot       = false
   final_snapshot_identifier = "${local.name_prefix}-db-final"
   copy_tags_to_snapshot     = true


### PR DESCRIPTION
## 関連 Issue
Refs #189

## 概要
本番 apply 中に RDS 作成が失敗したため修正。

- エラー：`FreeTierRestrictionError: The specified backup retention period exceeds the maximum available to free tier customers`
- 原因：新 AWS Free プランは自動バックアップ保持期間に上限があり、`backup_retention_period = 7` が超過。
- 修正：`= 1`（自動バックアップは維持・最小化）。本格運用フェーズで延長。
- プラン結果：**2 追加 / 0 変更 / 0 破棄・エラーなし**（残りは RDS と db_url SSM）。

## 変更の種別
- [x] fix（バグ修正）

🤖 Generated with [Claude Code](https://claude.com/claude-code)