### PR TITLE
feat: provision.sh に自己署名HTTPSモードを追加（S-2 疎通）

### DIFF
--- a/review-board/infra/deploy/README.md
+++ b/review-board/infra/deploy/README.md
@@ -8,7 +8,8 @@ user_data.sh は土台までで止め、ここから先を本ディレクトリ�
 |---|---|
 | `provision.sh` | 一度きりの初期化（EnvironmentFile を SSM から生成・systemd/nginx 設置・TLS・deploy.sh 設置） |
 | `review-board.service` | systemd ユニット（`current/app.jar` を prod 起動） |
-| `nginx-review-board.conf` | vhost（443→静的・`/api`→127.0.0.1:8082・actuator 非公開） |
+| `nginx-review-board.conf` | vhost（HTTP・`/api`→127.0.0.1:8082・actuator 非公開）。certbot が 443/リダイレクトを追記 |
+| `nginx-review-board-tls.conf` | 自己署名モード用 vhost（443/TLS＋80→443 リダイレクト・同 location） |
 | `deploy.sh` | アプリのみ更新（S3 から `<sha>` 取得→current 切替→再起動→localhost health）。cd-deploy が SSM で呼ぶ |
 
 ## 前提（env の出所）
@@ -24,8 +25,12 @@ user_data.sh は土台までで止め、ここから先を本ディレクトリ�
 sudo dnf install -y git
 git clone <repo> /tmp/rb && cd /tmp/rb/review-board/infra/deploy
 
-# 2) 初期化（DOMAIN を渡すと certbot で TLS まで。PUBLIC_ORIGIN は CORS 用）
+# 2) 初期化（TLS は3モード。PUBLIC_ORIGIN は CORS 用＝同一オリジンなら省略可）
+#   a) ドメインあり（Let's Encrypt）：
 sudo PUBLIC_ORIGIN=https://<domain> DOMAIN=<domain> ./provision.sh
+#   b) ドメイン無し（自己署名・IP 直 HTTPS。ブラウザ警告は想定どおり）：
+sudo TLS_SELFSIGNED=1 PUBLIC_ORIGIN=https://<EIP> ./provision.sh
+#   ※ JWT_COOKIE_SECURE=true 固定のため、いずれかの HTTPS が必須（HTTP のみだとログイン不可）
 
 # 3) 初回のアプリ投入（cd-build が S3 に push 済みの SHA を指定）
 sudo /opt/review-board/deploy.sh <sha>

--- a/review-board/infra/deploy/nginx-review-board-tls.conf
+++ b/review-board/infra/deploy/nginx-review-board-tls.conf
@@ -1,0 +1,60 @@
+# review-board nginx vhost（TLS 版・443→React 静的・/api→backend 8082）。
+# 自己署名証明書モード（DOMAIN 無し・TLS_SELFSIGNED=1）で provision.sh が設置する。
+# 証明書は /etc/nginx/ssl/review-board.{crt,key}（provision.sh が openssl で生成）。
+# 本番ドメイン取得後は `certbot --nginx -d <domain>` で Let's Encrypt 証明書へ差し替え可。
+# フロントは相対パス /api を呼ぶ（同一オリジン）。デザイン/挙動は localhost:5175 と同一。
+
+# HTTP(80) は HTTPS(443) へ恒久リダイレクト。
+server {
+    listen 80;
+    listen [::]:80;
+    server_name _;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name _;
+
+    ssl_certificate     /etc/nginx/ssl/review-board.crt;
+    ssl_certificate_key /etc/nginx/ssl/review-board.key;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
+
+    # アップロード上限（バックエンドの max-upload-bytes=5MB と整合・余裕を持たせる）。
+    client_max_body_size 8m;
+
+    # React 静的（SPA）。current/dist を指すシンボリックリンク。
+    root /var/www/review-board;
+    index index.html;
+
+    # API は backend にそのままプロキシ（/api プレフィックスを保持）。
+    location /api/ {
+        proxy_pass http://127.0.0.1:8082;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+    }
+
+    # actuator は backend にプロキシ（ログ・監視設計書 §4 に整合）。
+    # health は監視プローブ用に未認証開放、metrics/prometheus は app 層で ROLE_TEACHER 限定
+    # （SecurityConfig）。ネットワーク層では塞がず app 層認可で保護する設計。
+    location /actuator/ {
+        proxy_pass http://127.0.0.1:8082;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # SPA フォールバック（クライアントルーティング）。
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/review-board/infra/deploy/provision.sh
+++ b/review-board/infra/deploy/provision.sh
@@ -5,9 +5,13 @@
 #   - /opt/review-board ディレクトリと EnvironmentFile（SSM から機密を取得）
 #   - systemd review-board.service の設置・有効化
 #   - nginx vhost の設置（443→静的・/api→127.0.0.1:8082）
-#   - certbot による TLS（ドメイン指定時のみ・任意）
-# 実行例（Session Manager もしくは SSM Run Command で root として）：
+#   - TLS：DOMAIN 指定時は certbot(Let's Encrypt)、TLS_SELFSIGNED=1 時は自己署名証明書、
+#          どちらも未指定なら HTTP のみ（後で手動 TLS）
+# 実行例（ドメインあり / Let's Encrypt）：
 #   sudo PUBLIC_ORIGIN=https://example.com DOMAIN=example.com \
+#        /opt/review-board/infra-deploy/provision.sh
+# 実行例（ドメイン無し / 自己署名・IP 直 HTTPS）：
+#   sudo TLS_SELFSIGNED=1 PUBLIC_ORIGIN=https://18.176.19.160 \
 #        /opt/review-board/infra-deploy/provision.sh
 # アプリ本体（jar/dist）の配置は本スクリプトでは行わない。続けて deploy.sh <sha> を実行する。
 # =====================================================================
@@ -16,7 +20,8 @@ set -euo pipefail
 REGION="${AWS_REGION:-ap-northeast-1}"
 SSM_PREFIX="${SSM_PREFIX:-/review-board/prod}"
 PUBLIC_ORIGIN="${PUBLIC_ORIGIN:-}"   # 例: https://example.com（CORS 用。同一オリジンなら未指定でも可）
-DOMAIN="${DOMAIN:-}"                 # certbot 用（未指定なら TLS はスキップ＝後で手動）
+DOMAIN="${DOMAIN:-}"                 # certbot 用（指定で Let's Encrypt）
+TLS_SELFSIGNED="${TLS_SELFSIGNED:-0}" # 1 で自己署名証明書（ドメイン無し・IP 直 HTTPS）
 APP=/opt/review-board
 HERE="$(cd "$(dirname "$0")" && pwd)"
 
@@ -54,16 +59,40 @@ install -m 644 "$HERE/review-board.service" /etc/systemd/system/review-board.ser
 systemctl daemon-reload
 systemctl enable review-board
 
-# --- nginx vhost ---
-install -m 644 "$HERE/nginx-review-board.conf" /etc/nginx/conf.d/review-board.conf
-nginx -t && systemctl reload nginx
+# --- nginx vhost ＋ TLS ---
+# 既存の review-board conf を一旦撤去（HTTP/TLS どちらか一方のみ有効化するため）。
+rm -f /etc/nginx/conf.d/review-board.conf /etc/nginx/conf.d/review-board-tls.conf
 
-# --- TLS（任意・ドメイン指定時のみ） ---
-if [ -n "$DOMAIN" ]; then
+if [ "$TLS_SELFSIGNED" = "1" ]; then
+  # 自己署名証明書モード（ドメイン無し・IP 直 HTTPS）。
+  # EIP を SAN(IP) に含めることで「https://<EIP>」でのアクセスを証明書対象にする。
+  EIP="$(curl -s --max-time 3 http://169.254.169.254/latest/meta-data/public-ipv4 || echo '')"
+  CN="${EIP:-review-board}"
+  mkdir -p /etc/nginx/ssl
+  if [ ! -f /etc/nginx/ssl/review-board.crt ]; then
+    openssl req -x509 -newkey rsa:2048 -nodes -days 825 \
+      -keyout /etc/nginx/ssl/review-board.key \
+      -out /etc/nginx/ssl/review-board.crt \
+      -subj "/CN=$CN" \
+      ${EIP:+-addext "subjectAltName=IP:$EIP"}
+    chmod 600 /etc/nginx/ssl/review-board.key
+  fi
+  install -m 644 "$HERE/nginx-review-board-tls.conf" /etc/nginx/conf.d/review-board-tls.conf
+  nginx -t && systemctl reload nginx
+  echo "自己署名 TLS を設定（CN=$CN）。ブラウザ警告は想定どおり。"
+elif [ -n "$DOMAIN" ]; then
+  # Let's Encrypt モード。まず HTTP で起動し、certbot が 443/リダイレクトを追加する。
+  install -m 644 "$HERE/nginx-review-board.conf" /etc/nginx/conf.d/review-board.conf
+  nginx -t && systemctl reload nginx
   dnf install -y certbot python3-certbot-nginx || true
   certbot --nginx -d "$DOMAIN" --non-interactive --agree-tos \
     -m "${CERTBOT_EMAIL:-admin@$DOMAIN}" --redirect || \
     echo "certbot に失敗。DNS が EIP を指しているか確認し、手動で再実行してください。"
+else
+  # TLS なし（HTTP のみ）。JWT_COOKIE_SECURE=true 環境ではログイン不可になる点に注意。
+  install -m 644 "$HERE/nginx-review-board.conf" /etc/nginx/conf.d/review-board.conf
+  nginx -t && systemctl reload nginx
+  echo "警告: TLS 未設定（HTTP のみ）。JWT_COOKIE_SECURE=true ではログインできません。"
 fi
 
 echo "provision 完了。次に deploy.sh <sha> でアプリを投入してください。"


### PR DESCRIPTION
## 概要
S-2 本番デプロイのインフラ(36/36)完成後、EC2 アプリ層プロビジョニングで **ドメイン無しでも HTTPS を張れる**ようにする。

`provision.sh` は `JWT_COOKIE_SECURE=true` を固定書き込みするため、Secure Cookie は HTTPS でしか送信されない＝HTTPS 必須。だが現状 TLS は certbot(ドメイン必須)のみで、無料枠アカウント(Route53 取得不可)・ドメイン未所有では HTTPS を張れずログイン不可だった。

## 変更内容
- `provision.sh` の TLS を **3モード**に整理：
  - `TLS_SELFSIGNED=1`：openssl で EIP を SAN(IP) に含む自己署名証明書を生成し、443/TLS + 80→443 リダイレクトを適用（IP 直 HTTPS）
  - `DOMAIN=<domain>`：従来どおり certbot(Let's Encrypt)
  - どちらも未指定：HTTP のみ(警告表示)
- `nginx-review-board-tls.conf` 新規：443/TLS + 80→443 リダイレクトの vhost（location は HTTP 版と同一）
- `README.md`：3モードの手順を追記

## 検証
- shellcheck クリーン（既存の SC2012 info を除き新規指摘なし）
- 本番ドメイン取得後は `certbot --nginx -d <domain>` 1回で正規証明書へ差し替え可（やり直し不要）

## 非対象
- 正規ドメイン取得（外部レジストラ・有料・別途判断）

Closes #194
