### PR TITLE
fix: cd-build の startup_failure を修正（if 条件の secrets 参照を除去）

### DIFF
--- a/.github/workflows/review-board-cd-build.yml
+++ b/.github/workflows/review-board-cd-build.yml
@@ -115,9 +115,24 @@ jobs:
           if-no-files-found: error
 
       # AWS 認証とアーティファクトバケットが設定済みなら、S3 にも push（EC2 の deploy.sh が取得）。
-      # 未設定（S-2 前）なら GitHub Artifact のみで、この step はスキップする。
-      - name: アーティファクトを S3 に push（任意・認証時のみ）
-        if: ${{ secrets.AWS_ACCESS_KEY_ID != '' && vars.RB_ARTIFACTS_BUCKET != '' }}
+      # 未設定（S-2 前）なら GitHub Artifact のみで、以降の step はスキップする。
+      # 注意: `if:` 条件で secrets コンテキストは参照不可（startup_failure になる）。
+      #       secret は env へ写してから guard step の出力で判定する（cd-deploy と同方式）。
+      - name: 前提チェック（AWS 認証が無ければ S3 push をスキップ）
+        id: guard
+        env:
+          AWS_KEY: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          ARTIFACTS_BUCKET: ${{ vars.RB_ARTIFACTS_BUCKET }}
+        run: |
+          if [ -n "${AWS_KEY}" ] && [ -n "${ARTIFACTS_BUCKET}" ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "AWS 認証または RB_ARTIFACTS_BUCKET 未設定のため S3 push はスキップ（GitHub Artifact のみ）。" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: アーティファクトを S3 に push（認証時のみ）
+        if: steps.guard.outputs.ready == 'true'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## 概要
`review-board-cd-build.yml` が main push 時に **0秒で startup_failure** し、アーティファクトが S3 に発行されず初回デプロイ(S-2 §8-2)に進めなかった問題を修正。

## 真因
`if:` 条件で **secrets コンテキスト**を参照していた（GitHub Actions では不可・検証エラー＝startup_failure）：
```yaml
if: ${{ secrets.AWS_ACCESS_KEY_ID != '' && vars.RB_ARTIFACTS_BUCKET != '' }}
```

## 修正
cd-deploy.yml と同じ **guard step 方式**に統一。secret を env に写し、guard の出力 `ready` で S3 push step をゲート。`vars` は `if:` で参照可だが `secrets` は不可、という制約に合わせた。

## 検証
- 修正後 cd-build が startup_failure せず実行されること（マージで main にトリガ）
- AWS 認証・`RB_ARTIFACTS_BUCKET` 設定済みのため S3 へアーティファクト発行

Closes #196
