### PR TITLE
feat: CD完全自動化（専用CDユーザー新設＋EC2のSSM管理）

### DIFF
--- a/.github/workflows/review-board-cd-build.yml
+++ b/.github/workflows/review-board-cd-build.yml
@@ -118,24 +118,24 @@ jobs:
       # 未設定（S-2 前）なら GitHub Artifact のみで、以降の step はスキップする。
       # 注意: `if:` 条件で secrets コンテキストは参照不可（startup_failure になる）。
       #       secret は env へ写してから guard step の出力で判定する（cd-deploy と同方式）。
-      - name: 前提チェック（AWS 認証が無ければ S3 push をスキップ）
+      - name: 前提チェック（CD 認証が無ければ S3 push をスキップ）
         id: guard
         env:
-          AWS_KEY: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_KEY: ${{ secrets.RB_CD_AWS_ACCESS_KEY_ID }}
           ARTIFACTS_BUCKET: ${{ vars.RB_ARTIFACTS_BUCKET }}
         run: |
           if [ -n "${AWS_KEY}" ] && [ -n "${ARTIFACTS_BUCKET}" ]; then
             echo "ready=true" >> "$GITHUB_OUTPUT"
           else
             echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "AWS 認証または RB_ARTIFACTS_BUCKET 未設定のため S3 push はスキップ（GitHub Artifact のみ）。" >> "$GITHUB_STEP_SUMMARY"
+            echo "RB_CD_AWS_ACCESS_KEY_ID または RB_ARTIFACTS_BUCKET 未設定のため S3 push はスキップ（GitHub Artifact のみ）。" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: アーティファクトを S3 に push（認証時のみ）
         if: steps.guard.outputs.ready == 'true'
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.RB_CD_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.RB_CD_AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ap-northeast-1
           ARTIFACTS_BUCKET: ${{ vars.RB_ARTIFACTS_BUCKET }}
         run: |

--- a/.github/workflows/review-board-cd-deploy.yml
+++ b/.github/workflows/review-board-cd-deploy.yml
@@ -35,7 +35,7 @@ env:
   AWS_REGION: ap-northeast-1
   # EC2 を特定するタグ（infra の common_tags と整合：Project=review-board）。
   INSTANCE_TAG_PROJECT: review-board
-  AWS_KEY: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_KEY: ${{ secrets.RB_CD_AWS_ACCESS_KEY_ID }}
 
 jobs:
   deploy:
@@ -57,8 +57,8 @@ jobs:
             {
               echo '## review-board CD deploy（スキップ）'
               echo ''
-              echo 'AWS 認証 secret が未設定のため、デプロイはスキップしました（S-2 前の足場状態）。'
-              echo 'S-2 完了後、AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY と S3 アーティファクト配布を'
+              echo 'CD 認証 secret が未設定のため、デプロイはスキップしました（S-2 前の足場状態）。'
+              echo 'RB_CD_AWS_ACCESS_KEY_ID / RB_CD_AWS_SECRET_ACCESS_KEY（専用CDユーザー）と S3 アーティファクト配布を'
               echo '整備すると、本ワークフローが「アプリのみ更新」を実行します。'
               echo '配置規約・ロールバックは docs/デプロイ・ロールバック手順.md を参照。'
             } >> "$GITHUB_STEP_SUMMARY"
@@ -70,8 +70,8 @@ jobs:
         if: steps.guard.outputs.ready == 'true'
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.RB_CD_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.RB_CD_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: EC2 インスタンス ID を解決（タグ）

--- a/review-board/infra/iam.tf
+++ b/review-board/infra/iam.tf
@@ -96,3 +96,78 @@ resource "aws_iam_instance_profile" "ec2" {
 
   tags = { Name = "${local.name_prefix}-ec2-profile" }
 }
+
+# SSM Session Manager / Run Command 用。cd-deploy が SSM Run Command で deploy.sh を実行するため、
+# EC2 が SSM Systems Manager に登録される必要がある（ssmmessages/ec2messages/UpdateInstanceInformation）。
+# AWS 管理ポリシーを追加付与（最小スコープの管理ポリシー）。
+resource "aws_iam_role_policy_attachment" "ec2_ssm_core" {
+  role       = aws_iam_role.ec2.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+# =====================================================================
+# CD 用 CI ユーザー（GitHub Actions 専用・最小権限・#198）
+# =====================================================================
+# cd-build: artifacts バケットへアーティファクト push。
+# cd-deploy: ec2:DescribeInstances でインスタンス解決 → ssm:SendCommand で deploy.sh 実行。
+# 既存の github-actions-rds-stop（rds-auto-stop / terraform-plan が共有）とは分離し、
+# 関心と権限を CD に限定する。鍵は別シークレット RB_CD_AWS_* に設定する。
+resource "aws_iam_user" "github_actions_cd" {
+  name = "${local.name_prefix}-github-actions-cd"
+  tags = { Name = "${local.name_prefix}-github-actions-cd" }
+}
+
+data "aws_iam_policy_document" "cd_permissions" {
+  # cd-build: artifacts への push（sync = Put/Get/List）。
+  statement {
+    sid       = "ArtifactsBucketWrite"
+    effect    = "Allow"
+    actions   = ["s3:PutObject", "s3:GetObject", "s3:ListBucket"]
+    resources = [aws_s3_bucket.artifacts.arn, "${aws_s3_bucket.artifacts.arn}/*"]
+  }
+
+  # cd-deploy: タグでインスタンスを解決（describe は resource-level 非対応＝*）。
+  statement {
+    sid       = "DescribeInstances"
+    effect    = "Allow"
+    actions   = ["ec2:DescribeInstances"]
+    resources = ["*"] #tfsec:ignore:aws-iam-no-policy-wildcards DescribeInstances は resource-level 非対応
+  }
+
+  # cd-deploy: RunShellScript を Project タグ付きインスタンスにのみ送信。
+  statement {
+    sid     = "SendCommandToTaggedInstance"
+    effect  = "Allow"
+    actions = ["ssm:SendCommand"]
+    resources = [
+      "arn:aws:ssm:${var.aws_region}::document/AWS-RunShellScript",
+      "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*",
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "ssm:resourceTag/Project"
+      values   = ["review-board"]
+    }
+  }
+
+  # cd-deploy: コマンド実行結果のポーリング（read-only・command id は動的）。
+  statement {
+    sid       = "ReadCommandInvocation"
+    effect    = "Allow"
+    actions   = ["ssm:GetCommandInvocation", "ssm:ListCommandInvocations"]
+    resources = ["*"] #tfsec:ignore:aws-iam-no-policy-wildcards command invocation の ARN は動的・read-only
+  }
+}
+
+resource "aws_iam_user_policy" "github_actions_cd" {
+  name   = "${local.name_prefix}-cd-policy"
+  user   = aws_iam_user.github_actions_cd.name
+  policy = data.aws_iam_policy_document.cd_permissions.json
+}
+
+# アクセスキー（GitHub Secret に設定するため output で取得）。
+# tfstate に平文保存される点に留意（terraform.tfstate は gitignore・ローカル限定）。
+#tfsec:ignore:aws-iam-no-user-attached-policies
+resource "aws_iam_access_key" "github_actions_cd" {
+  user = aws_iam_user.github_actions_cd.name
+}

--- a/review-board/infra/outputs.tf
+++ b/review-board/infra/outputs.tf
@@ -41,3 +41,16 @@ output "ssm_parameter_prefix" {
   description = "アプリが読む SSM パラメータのプレフィックス"
   value       = local.ssm_prefix
 }
+
+# --- CD 用 CI ユーザーの鍵（GitHub Secret RB_CD_AWS_* に設定する・#198）---
+# 取得: terraform output -raw cd_aws_access_key_id / cd_aws_secret_access_key
+output "cd_aws_access_key_id" {
+  description = "github-actions-cd のアクセスキー ID（GitHub Secret RB_CD_AWS_ACCESS_KEY_ID へ）"
+  value       = aws_iam_access_key.github_actions_cd.id
+}
+
+output "cd_aws_secret_access_key" {
+  description = "github-actions-cd のシークレット（GitHub Secret RB_CD_AWS_SECRET_ACCESS_KEY へ）"
+  value       = aws_iam_access_key.github_actions_cd.secret
+  sensitive   = true
+}


### PR DESCRIPTION
## 概要
S-2 本番デプロイ稼働後、CD を完全自動化（main push→ビルド→S3→手動昇格デプロイ）するための残2 follow-up を整備。初回デプロイは手動(SSH+ローカルpush)で回避していた。

## 変更
1. **EC2のSSM管理**: EC2ロールに `AmazonSSMManagedInstanceCore` を付与。EC2 が SSM Systems Manager に登録され、cd-deploy の SSM Run Command が動く。
2. **専用CDユーザー `github-actions-cd` 新設（最小権限）**:
   - artifacts バケットへ `s3:PutObject/GetObject/ListBucket`（cd-build）
   - `ec2:DescribeInstances`（cd-deploy のインスタンス解決）
   - `ssm:SendCommand`（AWS-RunShellScript＋`Project=review-board` タグ条件付き）・`ssm:GetCommandInvocation`（cd-deploy）
   - アクセスキー発行 → output（sensitive）で取得
3. **ワークフロー**: cd-build / cd-deploy を新シークレット `RB_CD_AWS_ACCESS_KEY_ID` / `RB_CD_AWS_SECRET_ACCESS_KEY` 参照に変更。`rds-auto-stop` / `terraform-plan` が共有する既存 `AWS_ACCESS_KEY_ID` は据置で**無影響**。

## 検証
- `validate` 成功 / plan = **4 to add・変更0・破棄0**（IAMユーザー・ポリシー・アクセスキー・SSM管理アタッチのみ）

## apply 後の手順（人間）
1. apply（修練城ルールで人間実行）
2. `output -raw cd_aws_access_key_id` / `cd_aws_secret_access_key` を取得
3. `gh secret set RB_CD_AWS_ACCESS_KEY_ID` / `RB_CD_AWS_SECRET_ACCESS_KEY`
4. main push で cd-build が S3 push・cd-deploy 手動 dispatch で SSM 更新を確認

Closes #198
