### PR TITLE
fix: CDユーザーの ssm:SendCommand を document/instance で分離

### DIFF
--- a/review-board/infra/iam.tf
+++ b/review-board/infra/iam.tf
@@ -134,15 +134,21 @@ data "aws_iam_policy_document" "cd_permissions" {
     resources = ["*"] #tfsec:ignore:aws-iam-no-policy-wildcards DescribeInstances は resource-level 非対応
   }
 
-  # cd-deploy: RunShellScript を Project タグ付きインスタンスにのみ送信。
+  # cd-deploy: SendCommand は document と instance の両方に許可が必要。
+  # AWS 管理ドキュメント AWS-RunShellScript には Project タグが無いため、タグ条件は
+  # instance 側だけに適用する（document に条件を付けると条件が偽になり拒否される）。
   statement {
-    sid     = "SendCommandToTaggedInstance"
-    effect  = "Allow"
-    actions = ["ssm:SendCommand"]
-    resources = [
-      "arn:aws:ssm:${var.aws_region}::document/AWS-RunShellScript",
-      "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*",
-    ]
+    sid       = "SendCommandDocument"
+    effect    = "Allow"
+    actions   = ["ssm:SendCommand"]
+    resources = ["arn:aws:ssm:${var.aws_region}::document/AWS-RunShellScript"]
+  }
+
+  statement {
+    sid       = "SendCommandToTaggedInstance"
+    effect    = "Allow"
+    actions   = ["ssm:SendCommand"]
+    resources = ["arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*"]
     condition {
       test     = "StringEquals"
       variable = "ssm:resourceTag/Project"


### PR DESCRIPTION
## 概要
cd-deploy 実機確認で SSM step が AccessDenied になった問題の修正。

## 真因
#198 の CDポリシーは `ssm:SendCommand` の resource に document＋instance を並べ、両方に `ssm:resourceTag/Project=review-board` 条件を付けた。だが AWS 管理ドキュメント `AWS-RunShellScript` には Project タグが無く条件が偽 → document で拒否。SendCommand は document と instance の双方に許可が必要なため失敗した。

```
not authorized to perform: ssm:SendCommand on resource: …document/AWS-RunShellScript
```

## 修正
SendCommand を2 statement に分割：
- `AWS-RunShellScript` document は条件なしで許可
- `instance/*` は `Project=review-board` タグ条件付きで許可（最小権限を維持）

## 検証
- validate 成功 / plan = **0 add・1 change(ポリシー in-place)・破棄0**

## apply 後（人間）
`terraform apply` → cd-deploy を手動 dispatch(sha＋confirm=deploy)で SSM 経由デプロイ成功を確認。

Closes #200
