### PR TITLE
feat: P-9 アクセシビリティ深掘り（フォームラベル関連付け・main・リンク名）

### DIFF
--- a/review-board/frontend/src/components/Header.jsx
+++ b/review-board/frontend/src/components/Header.jsx
@@ -65,7 +65,7 @@ export default function Header() {
                 </span>
               )}
             </Link>
-            <Link to={`/users/${user.id}/profile`} className="flex shrink-0 items-center gap-2 text-sm text-gray-700 hover:text-navy-700">
+            <Link to={`/users/${user.id}/profile`} aria-label={`${user.displayName} のプロフィール`} className="flex shrink-0 items-center gap-2 text-sm text-gray-700 hover:text-navy-700">
               <Avatar url={user.avatarUrl} name={user.displayName} size="md" />
               <span className="hidden font-medium xl:inline">{user.displayName}</span>
             </Link>

--- a/review-board/frontend/src/components/ReviewForm.jsx
+++ b/review-board/frontend/src/components/ReviewForm.jsx
@@ -59,16 +59,18 @@ export default function ReviewForm({ postId, onCreated }) {
       <h3 className="mac-h mb-3 text-base">レビューを書く <span className="text-xs font-normal text-gray-400">（マークダウン記法が使えます）</span></h3>
       {restored && <DraftNotice onDiscard={discardDraft} />}
       {error && <p className="mb-3 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
-      <label className="mac-label">✅ 良かった点（必須）</label>
+      <label htmlFor="review-good" className="mac-label">✅ 良かった点（必須）</label>
       <textarea
+        id="review-good"
         required
         value={good}
         onChange={(e) => setGood(e.target.value)}
         className="mac-input mb-3"
         rows={2}
       />
-      <label className="mac-label">💡 もっと良くなる点（必須）</label>
+      <label htmlFor="review-improvement" className="mac-label">💡 もっと良くなる点（必須）</label>
       <textarea
+        id="review-improvement"
         required
         value={improvement}
         onChange={(e) => setImprovement(e.target.value)}
@@ -78,8 +80,9 @@ export default function ReviewForm({ postId, onCreated }) {
       <p className="mb-2 text-xs text-gray-400">観点別コメント（任意・埋めたい軸だけでOK）</p>
       {AXES.map((a) => (
         <div key={a.key} className="mb-2">
-          <label className="mb-1 block text-xs text-gray-500">{a.label}</label>
+          <label htmlFor={`axis-${a.key}`} className="mb-1 block text-xs text-gray-500">{a.label}</label>
           <input
+            id={`axis-${a.key}`}
             value={axis[a.key] ?? ''}
             onChange={(e) => setAxis((prev) => ({ ...prev, [a.key]: e.target.value }))}
             className="mac-input py-1.5"

--- a/review-board/frontend/src/components/ScreenshotUploader.jsx
+++ b/review-board/frontend/src/components/ScreenshotUploader.jsx
@@ -27,8 +27,9 @@ export default function ScreenshotUploader({ initialUrl = '', onChange }) {
 
   return (
     <div className="mb-4">
-      <label className="mb-1 block text-sm text-gray-600">スクリーンショット（任意・PNG/JPEG/WebP・5MB まで）</label>
+      <label htmlFor="screenshot-file" className="mb-1 block text-sm text-gray-600">スクリーンショット（任意・PNG/JPEG/WebP・5MB まで）</label>
       <input
+        id="screenshot-file"
         type="file"
         accept="image/png,image/jpeg,image/webp"
         onChange={onSelect}

--- a/review-board/frontend/src/pages/LoginPage.jsx
+++ b/review-board/frontend/src/pages/LoginPage.jsx
@@ -28,7 +28,7 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center px-4">
+    <main className="flex min-h-screen items-center justify-center px-4">
       <div className="w-full max-w-sm">
         {/* ブランド */}
         <div className="mb-7 flex flex-col items-center text-center">
@@ -91,6 +91,6 @@ export default function LoginPage() {
           アカウントは管理者・講師が発行します
         </p>
       </div>
-    </div>
+    </main>
   );
 }

--- a/review-board/frontend/src/pages/NewPostPage.jsx
+++ b/review-board/frontend/src/pages/NewPostPage.jsx
@@ -61,14 +61,14 @@ export default function NewPostPage() {
       <form onSubmit={submit} className="mac-card p-6 sm:p-7">
         {restored && <DraftNotice onDiscard={discardDraft} />}
         {error && <p className="mb-3 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
-        <label className="mac-label">タイトル（必須）</label>
-        <input required value={form.title} onChange={set('title')} className="mac-input mb-4" />
-        <label className="mac-label">説明（必須）<span className="ml-1 text-xs text-gray-400">・マークダウン可</span></label>
-        <textarea required value={form.description} onChange={set('description')} rows={4} className="mac-input mb-4" />
-        <label className="mac-label">リポジトリ URL（任意）</label>
-        <input type="url" value={form.repoUrl} onChange={set('repoUrl')} className="mac-input mb-4" />
-        <label className="mac-label">デモ URL（任意）</label>
-        <input type="url" value={form.demoUrl} onChange={set('demoUrl')} className="mac-input mb-4" />
+        <label htmlFor="post-title" className="mac-label">タイトル（必須）</label>
+        <input id="post-title" required value={form.title} onChange={set('title')} className="mac-input mb-4" />
+        <label htmlFor="post-description" className="mac-label">説明（必須）<span className="ml-1 text-xs text-gray-400">・マークダウン可</span></label>
+        <textarea id="post-description" required value={form.description} onChange={set('description')} rows={4} className="mac-input mb-4" />
+        <label htmlFor="post-repo-url" className="mac-label">リポジトリ URL（任意）</label>
+        <input id="post-repo-url" type="url" value={form.repoUrl} onChange={set('repoUrl')} className="mac-input mb-4" />
+        <label htmlFor="post-demo-url" className="mac-label">デモ URL（任意）</label>
+        <input id="post-demo-url" type="url" value={form.demoUrl} onChange={set('demoUrl')} className="mac-input mb-4" />
         <ScreenshotUploader onChange={(key) => setForm((p) => ({ ...p, screenshotKey: key }))} />
         <ReviewPrefFields
           tones={form.reviewTones}

--- a/review-board/frontend/src/pages/PostEditPage.jsx
+++ b/review-board/frontend/src/pages/PostEditPage.jsx
@@ -66,14 +66,14 @@ export default function PostEditPage() {
       <h2 className="mac-h mb-5 text-2xl">投稿を編集</h2>
       <form onSubmit={submit} className="mac-card p-6 sm:p-7">
         {error && <p className="mb-3 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
-        <label className="mac-label">タイトル（必須）</label>
-        <input required value={form.title} onChange={set('title')} className="mac-input mb-4" />
-        <label className="mac-label">説明（必須）</label>
-        <textarea required value={form.description} onChange={set('description')} rows={4} className="mac-input mb-4" />
-        <label className="mac-label">リポジトリ URL（任意）</label>
-        <input type="url" value={form.repoUrl} onChange={set('repoUrl')} className="mac-input mb-4" />
-        <label className="mac-label">デモ URL（任意）</label>
-        <input type="url" value={form.demoUrl} onChange={set('demoUrl')} className="mac-input mb-4" />
+        <label htmlFor="edit-title" className="mac-label">タイトル（必須）</label>
+        <input id="edit-title" required value={form.title} onChange={set('title')} className="mac-input mb-4" />
+        <label htmlFor="edit-description" className="mac-label">説明（必須）</label>
+        <textarea id="edit-description" required value={form.description} onChange={set('description')} rows={4} className="mac-input mb-4" />
+        <label htmlFor="edit-repo-url" className="mac-label">リポジトリ URL（任意）</label>
+        <input id="edit-repo-url" type="url" value={form.repoUrl} onChange={set('repoUrl')} className="mac-input mb-4" />
+        <label htmlFor="edit-demo-url" className="mac-label">デモ URL（任意）</label>
+        <input id="edit-demo-url" type="url" value={form.demoUrl} onChange={set('demoUrl')} className="mac-input mb-4" />
         <ScreenshotUploader initialUrl={screenshotUrl} onChange={(key) => setForm((p) => ({ ...p, screenshotKey: key }))} />
         <ReviewPrefFields
           tones={form.reviewTones}

--- a/review-board/frontend/src/pages/ProfilePage.jsx
+++ b/review-board/frontend/src/pages/ProfilePage.jsx
@@ -156,19 +156,20 @@ function ProfileEditModal({ profile, onSaved, onCancel }) {
             <p className="text-xs text-gray-400">PNG / JPEG / WebP・5MB まで・正方形に切り抜き</p>
           </div>
 
-          {/* 表示名（読み取り専用） */}
+          {/* 表示名（読み取り専用＝コントロールが無いので label ではなく見出し用 div） */}
           <div>
-            <label className="mac-label">表示名</label>
+            <div className="mac-label">表示名</div>
             <div className="rounded-xl bg-gray-50 px-3 py-2 text-sm text-gray-500 ring-1 ring-black/5">{profile.displayName}</div>
           </div>
 
           {/* 自己紹介 */}
           <div>
             <div className="mb-1 flex items-center justify-between">
-              <label className="mac-label !mb-0">自己紹介</label>
+              <label htmlFor="profile-bio" className="mac-label !mb-0">自己紹介</label>
               <span className="text-xs tabular-nums text-gray-400">{bio.length}/500</span>
             </div>
             <textarea
+              id="profile-bio"
               value={bio}
               onChange={(e) => setBio(e.target.value)}
               rows={4}


### PR DESCRIPTION
## 概要
P-9（アクセシビリティ）の WCAG 深掘り監査。Lighthouse(snapshot)で全主要画面を実機監査し、残る実問題を解消した（#183 のコントラスト/select-name 対応に続く第2弾）。

## 見つけた実問題 → 修正
| 監査 | 内容 | 修正 |
|---|---|---|
| `label` | フォーム入力にラベル未関連付け（視覚ラベルのみ） | NewPost/PostEdit 各入力・ReviewForm(良かった点/改善点/観点別)・Profile 自己紹介・ScreenshotUploader に `htmlFor`/`id` |
| `landmark-one-main` | main ランドマーク欠落 | LoginPage ルートを `<main>` に |
| `link-name` | アバターのみのプロフィールリンクに名前なし | `aria-label` 付与 |
| - | Profile 表示名は読み取り専用でコントロール無し | `<label>`→`<div>` |

## 監査結果
- ログイン画面: 98 → **100**
- 投稿フォーム: 94 → **100**
- lint 0 error / build 成功

## 既知の非対象（実害なし）
- 一覧の `AppShot`（装飾スクショ風モック・**aria-hidden 済**）の color-contrast。axe は aria-hidden を contrast 対象外にしないため検出されるが SR ユーザーに実害なし。本実装で `post.screenshotUrl` の実画像に差し替え予定（別 follow-up）。
- SEO（meta-description/robots.txt）はクローズドSPA で公開不採用方針のため対象外。

Closes #202
