### PR TITLE
feat: 招待フロー（講師が招待コード発行→受講生が自己登録）

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/config/SecurityConfig.java
+++ b/review-board/backend/src/main/java/com/reviewboard/config/SecurityConfig.java
@@ -61,7 +61,8 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 // health は監視プローブ用に開放（liveness/readiness）。
                 .requestMatchers("/actuator/health",
-                        "/api/auth/login", "/api/auth/refresh", "/api/auth/logout").permitAll()
+                        "/api/auth/login", "/api/auth/refresh", "/api/auth/logout",
+                        "/api/auth/register").permitAll()
                 // 運用メトリクスは情報漏えいを避けるため運用ロール（講師）限定（SEC-2/SEC-11）。
                 // 誰でも JVM ヒープ・Hikari プール・流量を覗ける状態にしない。
                 .requestMatchers("/actuator/**").hasRole("TEACHER")

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/AuthController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/AuthController.java
@@ -1,6 +1,7 @@
 package com.reviewboard.domain.auth;
 
 import com.reviewboard.domain.auth.dto.LoginRequest;
+import com.reviewboard.domain.auth.dto.RegisterRequest;
 import com.reviewboard.domain.auth.dto.UserResponse;
 import com.reviewboard.domain.user.User;
 import com.reviewboard.domain.user.UserRepository;
@@ -37,6 +38,17 @@ public class AuthController {
     public ResponseEntity<UserResponse> login(@Valid @RequestBody LoginRequest request) {
         AuthService.LoginResult result = authService.login(request.email(), request.password());
         return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookies.access(result.accessToken()).toString())
+                .header(HttpHeaders.SET_COOKIE, cookies.refresh(result.refreshToken()).toString())
+                .body(UserResponse.from(result.user(), storageService.presignedGetUrl(result.user().getAvatarKey())));
+    }
+
+    /** F-AUTH-02 招待コードによる受講生の自己登録（公開）。成功時はそのままログイン状態にする。 */
+    @PostMapping("/register")
+    public ResponseEntity<UserResponse> register(@Valid @RequestBody RegisterRequest request) {
+        AuthService.LoginResult result = authService.register(
+                request.code(), request.email(), request.displayName(), request.password());
+        return ResponseEntity.status(201)
                 .header(HttpHeaders.SET_COOKIE, cookies.access(result.accessToken()).toString())
                 .header(HttpHeaders.SET_COOKIE, cookies.refresh(result.refreshToken()).toString())
                 .body(UserResponse.from(result.user(), storageService.presignedGetUrl(result.user().getAvatarKey())));

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/AuthService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/AuthService.java
@@ -1,7 +1,10 @@
 package com.reviewboard.domain.auth;
 
+import com.reviewboard.common.InvalidRequestException;
+import com.reviewboard.domain.invite.InviteService;
 import com.reviewboard.domain.user.User;
 import com.reviewboard.domain.user.UserRepository;
+import com.reviewboard.domain.user.UserRole;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,13 +20,44 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtService jwtService;
     private final RefreshTokenService refreshTokenService;
+    private final InviteService inviteService;
 
     public AuthService(UserRepository userRepository, PasswordEncoder passwordEncoder,
-                       JwtService jwtService, RefreshTokenService refreshTokenService) {
+                       JwtService jwtService, RefreshTokenService refreshTokenService,
+                       InviteService inviteService) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.jwtService = jwtService;
         this.refreshTokenService = refreshTokenService;
+        this.inviteService = inviteService;
+    }
+
+    /**
+     * F-AUTH-02 招待コードによる受講生の自己登録（Issue #165・公開）。
+     * 招待を原子的に消費して登録先 cohort を決め、role は常に STUDENT で作成、そのままログイン状態にする。
+     * email 重複は 400。無効な招待は InviteService が 400（条件は漏らさない）。
+     */
+    @Transactional
+    public LoginResult register(String rawCode, String email, String displayName, String rawPassword) {
+        Long cohortId = inviteService.validateAndConsume(rawCode);
+        String normalizedEmail = email.trim().toLowerCase();
+        if (userRepository.existsByEmail(normalizedEmail)) {
+            throw new InvalidRequestException("この email は既に使われています");
+        }
+        java.time.OffsetDateTime now = java.time.OffsetDateTime.now();
+        User user = new User();
+        user.setEmail(normalizedEmail);
+        user.setPasswordHash(passwordEncoder.encode(rawPassword));
+        user.setDisplayName(displayName.trim());
+        user.setRole(UserRole.STUDENT);
+        user.setCohortId(cohortId);
+        user.setCreatedAt(now);
+        user.setUpdatedAt(now);
+        userRepository.save(user);
+
+        String access = jwtService.issueAccessToken(user.getId(), user.getRole(), user.getCohortId());
+        String refresh = refreshTokenService.issue(user.getId());
+        return new LoginResult(user, access, refresh);
     }
 
     /** F-AUTH-01 ログイン。失敗は存在を漏らさない汎用エラー（BadCredentials）。 */

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/dto/RegisterRequest.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/dto/RegisterRequest.java
@@ -1,0 +1,16 @@
+package com.reviewboard.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 招待コードによる受講生の自己登録リクエスト（F-AUTH-02 / Issue #165・公開エンドポイント）。
+ * code で cohort と発行枠を解決する。role は常に STUDENT（公開サインアップで講師/管理者は作らせない）。
+ */
+public record RegisterRequest(
+        @NotBlank String code,
+        @NotBlank @Email @Size(max = 255) String email,
+        @NotBlank @Size(max = 50) String displayName,
+        @NotBlank @Size(min = 8, max = 72) String password) {
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/invite/CohortInvite.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/invite/CohortInvite.java
@@ -1,0 +1,62 @@
+package com.reviewboard.domain.invite;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+
+/**
+ * cohort 招待コード（F-AUTH-02 / Issue #165）。講師・管理者が発行し、受講生が登録に使う。
+ * 生コードは保存せず SHA-256 hex のみ保持（refresh token と同方針）。
+ * 失効判定は {@link #isUsable(OffsetDateTime)}（revoked / expired / max_uses 到達）。
+ */
+@Entity
+@Table(name = "cohort_invites")
+@Getter
+@Setter
+@NoArgsConstructor
+public class CohortInvite {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "cohort_id", nullable = false)
+    private Long cohortId;
+
+    @Column(name = "code_hash", nullable = false, unique = true, length = 64)
+    private String codeHash;
+
+    /** 発行者（退会時は DB 側で SET NULL）。 */
+    @Column(name = "created_by")
+    private Long createdBy;
+
+    @Column(name = "expires_at", nullable = false)
+    private OffsetDateTime expiresAt;
+
+    @Column(name = "max_uses", nullable = false)
+    private int maxUses;
+
+    @Column(name = "current_uses", nullable = false)
+    private int currentUses;
+
+    @Column(name = "revoked_at")
+    private OffsetDateTime revokedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    void onCreate() {
+        if (createdAt == null) {
+            createdAt = OffsetDateTime.now();
+        }
+    }
+
+    /** 今この招待で登録できるか（未失効・未期限切れ・使用回数に余裕あり）。 */
+    public boolean isUsable(OffsetDateTime now) {
+        return revokedAt == null && expiresAt.isAfter(now) && currentUses < maxUses;
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/invite/CohortInviteRepository.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/invite/CohortInviteRepository.java
@@ -1,0 +1,28 @@
+package com.reviewboard.domain.invite;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface CohortInviteRepository extends JpaRepository<CohortInvite, Long> {
+
+    /** 登録時の検証は raw 比較ではなく hash の UNIQUE lookup で行う（timing 比較なし）。 */
+    Optional<CohortInvite> findByCodeHash(String codeHash);
+
+    /** 講師/管理者の招待一覧（自 cohort・新しい順）。 */
+    List<CohortInvite> findByCohortIdOrderByCreatedAtDesc(Long cohortId);
+
+    /**
+     * 使用回数を原子的に +1（未失効・未期限切れ・枠あり が WHERE 条件）。
+     * 返り値 1=消費成功 / 0=利用不可（同時登録で maxUses を超えない・S軸の競合対策）。
+     */
+    @Modifying
+    @Query("update CohortInvite c set c.currentUses = c.currentUses + 1 "
+            + "where c.id = :id and c.revokedAt is null and c.expiresAt > :now and c.currentUses < c.maxUses")
+    int tryConsume(@Param("id") Long id, @Param("now") OffsetDateTime now);
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/invite/InviteCodeGenerator.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/invite/InviteCodeGenerator.java
@@ -1,0 +1,48 @@
+package com.reviewboard.domain.invite;
+
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+/**
+ * 招待コード生成（Issue #165）。{@link SecureRandom}（CSPRNG）で 32 byte の乱数を
+ * URL-safe Base64（パディングなし・約 43 文字）にエンコードする。{@code Math.random()} は使わない。
+ *
+ * <p>生コードは発行時に 1 度だけ返し、DB には {@link #hash(String)}（SHA-256 hex）で保存する。
+ * 検証は raw 比較ではなく hash の UNIQUE lookup で行う（refresh token と同方針・timing 比較なし）。
+ */
+@Component
+public class InviteCodeGenerator {
+
+    /** 32 byte = 256 bit。Base64url（パディングなし）で約 43 文字。 */
+    private static final int CODE_BYTES = 32;
+
+    private final SecureRandom secureRandom = new SecureRandom();
+    private final Base64.Encoder urlEncoder = Base64.getUrlEncoder().withoutPadding();
+
+    /** 新しい生招待コードを生成する（呼び出し側で {@link #hash(String)} して保存）。 */
+    public String generateRawCode() {
+        byte[] bytes = new byte[CODE_BYTES];
+        secureRandom.nextBytes(bytes);
+        return urlEncoder.encodeToString(bytes);
+    }
+
+    /** 生コードを CHAR(64) の SHA-256 hex に変換する（DB 保管・検索キー）。 */
+    public String hash(String rawCode) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(rawCode.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(digest.length * 2);
+            for (byte b : digest) {
+                sb.append(Character.forDigit((b >> 4) & 0xF, 16));
+                sb.append(Character.forDigit(b & 0xF, 16));
+            }
+            return sb.toString();
+        } catch (Exception e) {
+            throw new IllegalStateException("SHA-256 が利用できません", e);
+        }
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/invite/InviteController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/invite/InviteController.java
@@ -1,0 +1,56 @@
+package com.reviewboard.domain.invite;
+
+import com.reviewboard.domain.auth.AuthPrincipal;
+import com.reviewboard.domain.invite.dto.InviteCreateRequest;
+import com.reviewboard.domain.invite.dto.InviteResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * 招待コード管理 API（★S軸・講師/管理者のみ・Issue #165）。
+ * クラス全体を {@code hasAnyRole('TEACHER','ADMIN')} で保護し、受講生は 403。
+ * 対象は常に呼び出し元の cohort（cohort 境界は Service 側で担保）。
+ */
+@RestController
+@RequestMapping("/api/invites")
+@PreAuthorize("hasAnyRole('TEACHER','ADMIN')")
+public class InviteController {
+
+    private final InviteService inviteService;
+
+    public InviteController(InviteService inviteService) {
+        this.inviteService = inviteService;
+    }
+
+    /** 招待コードを発行する。生コードはこのレスポンスでのみ返す（再表示不可）。 */
+    @PostMapping
+    public ResponseEntity<InviteResponse> create(@AuthenticationPrincipal AuthPrincipal principal,
+                                                 @Valid @RequestBody(required = false) InviteCreateRequest request) {
+        InviteCreateRequest req = request != null ? request : new InviteCreateRequest(null, null);
+        InviteService.Issued issued = inviteService.issue(principal, req.maxUsesOrDefault(), req.expiresInDaysOrDefault());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(InviteResponse.withRawCode(issued.invite(), issued.rawCode(), OffsetDateTime.now()));
+    }
+
+    /** 自 cohort の招待一覧（生コードは含まない）。 */
+    @GetMapping
+    public List<InviteResponse> list(@AuthenticationPrincipal AuthPrincipal principal) {
+        OffsetDateTime now = OffsetDateTime.now();
+        return inviteService.list(principal).stream().map(i -> InviteResponse.of(i, now)).toList();
+    }
+
+    /** 招待を失効させる（自 cohort 以外は 404）。 */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> revoke(@AuthenticationPrincipal AuthPrincipal principal,
+                                       @PathVariable Long id) {
+        inviteService.revoke(principal, id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/invite/InviteService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/invite/InviteService.java
@@ -1,0 +1,78 @@
+package com.reviewboard.domain.invite;
+
+import com.reviewboard.common.InvalidRequestException;
+import com.reviewboard.common.ResourceNotFoundException;
+import com.reviewboard.domain.auth.AuthPrincipal;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * 招待コードの発行・一覧・失効と、登録時の消費（Issue #165）。
+ * ★S軸：発行/一覧/失効は呼び出し元 principal の cohort に限定（cohort 境界）。
+ * 生コードは発行時にしか存在せず、保存・検証は SHA-256 hash で行う。
+ */
+@Service
+public class InviteService {
+
+    private final CohortInviteRepository inviteRepository;
+    private final InviteCodeGenerator codeGenerator;
+
+    public InviteService(CohortInviteRepository inviteRepository, InviteCodeGenerator codeGenerator) {
+        this.inviteRepository = inviteRepository;
+        this.codeGenerator = codeGenerator;
+    }
+
+    /** 招待を発行する（自 cohort）。生コードは戻り値でのみ返す（保存は hash）。 */
+    @Transactional
+    public Issued issue(AuthPrincipal principal, int maxUses, int expiresInDays) {
+        String rawCode = codeGenerator.generateRawCode();
+        CohortInvite invite = new CohortInvite();
+        invite.setCohortId(principal.cohortId());
+        invite.setCodeHash(codeGenerator.hash(rawCode));
+        invite.setCreatedBy(principal.userId());
+        invite.setExpiresAt(OffsetDateTime.now().plusDays(expiresInDays));
+        invite.setMaxUses(maxUses);
+        invite.setCurrentUses(0);
+        inviteRepository.save(invite);
+        return new Issued(invite, rawCode);
+    }
+
+    /** 自 cohort の招待一覧（新しい順）。 */
+    @Transactional(readOnly = true)
+    public List<CohortInvite> list(AuthPrincipal principal) {
+        return inviteRepository.findByCohortIdOrderByCreatedAtDesc(principal.cohortId());
+    }
+
+    /** 招待を失効させる。自 cohort 以外・存在しないものは 404（存在を漏らさない）。 */
+    @Transactional
+    public void revoke(AuthPrincipal principal, Long inviteId) {
+        CohortInvite invite = inviteRepository.findById(inviteId)
+                .filter(i -> i.getCohortId().equals(principal.cohortId()))
+                .orElseThrow(() -> new ResourceNotFoundException("招待が見つかりません"));
+        if (invite.getRevokedAt() == null) {
+            invite.setRevokedAt(OffsetDateTime.now());
+        }
+    }
+
+    /**
+     * 登録時にコードを検証し原子的に消費する。無効（未存在/失効/期限切れ/枠超過）はすべて 400 で
+     * 同一メッセージ（どの条件かを漏らさない）。成功時は登録先 cohortId を返す。
+     */
+    @Transactional
+    public Long validateAndConsume(String rawCode) {
+        CohortInvite invite = inviteRepository.findByCodeHash(codeGenerator.hash(rawCode))
+                .orElseThrow(() -> new InvalidRequestException("招待コードが無効です"));
+        int consumed = inviteRepository.tryConsume(invite.getId(), OffsetDateTime.now());
+        if (consumed == 0) {
+            throw new InvalidRequestException("招待コードが無効です");
+        }
+        return invite.getCohortId();
+    }
+
+    /** 発行結果（生コードは 1 度だけ返す）。 */
+    public record Issued(CohortInvite invite, String rawCode) {
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/invite/dto/InviteCreateRequest.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/invite/dto/InviteCreateRequest.java
@@ -1,0 +1,21 @@
+package com.reviewboard.domain.invite.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+/**
+ * 招待コード発行リクエスト（講師/管理者・Issue #165）。
+ * いずれも任意。未指定なら maxUses=30・有効 7 日（実運用の 1 期分を想定した既定）。
+ */
+public record InviteCreateRequest(
+        @Min(1) @Max(500) Integer maxUses,
+        @Min(1) @Max(90) Integer expiresInDays) {
+
+    public int maxUsesOrDefault() {
+        return maxUses != null ? maxUses : 30;
+    }
+
+    public int expiresInDaysOrDefault() {
+        return expiresInDays != null ? expiresInDays : 7;
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/invite/dto/InviteResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/invite/dto/InviteResponse.java
@@ -1,0 +1,43 @@
+package com.reviewboard.domain.invite.dto;
+
+import com.reviewboard.domain.invite.CohortInvite;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 招待レスポンス（Issue #165）。
+ * {@code rawCode} は発行直後の 1 度だけ値が入り（受講生に渡す元データ）、一覧では常に null。
+ * {@code status} は ACTIVE / EXPIRED / USED_UP / REVOKED を読み側で算出。
+ */
+public record InviteResponse(
+        Long id,
+        Long cohortId,
+        String rawCode,
+        int maxUses,
+        int currentUses,
+        OffsetDateTime expiresAt,
+        OffsetDateTime revokedAt,
+        OffsetDateTime createdAt,
+        String status) {
+
+    /** 一覧用（rawCode は保持していないので null）。 */
+    public static InviteResponse of(CohortInvite inv, OffsetDateTime now) {
+        return new InviteResponse(inv.getId(), inv.getCohortId(), null,
+                inv.getMaxUses(), inv.getCurrentUses(), inv.getExpiresAt(), inv.getRevokedAt(),
+                inv.getCreatedAt(), status(inv, now));
+    }
+
+    /** 発行直後用（生コードを 1 度だけ返す）。 */
+    public static InviteResponse withRawCode(CohortInvite inv, String rawCode, OffsetDateTime now) {
+        return new InviteResponse(inv.getId(), inv.getCohortId(), rawCode,
+                inv.getMaxUses(), inv.getCurrentUses(), inv.getExpiresAt(), inv.getRevokedAt(),
+                inv.getCreatedAt(), status(inv, now));
+    }
+
+    private static String status(CohortInvite inv, OffsetDateTime now) {
+        if (inv.getRevokedAt() != null) return "REVOKED";
+        if (!inv.getExpiresAt().isAfter(now)) return "EXPIRED";
+        if (inv.getCurrentUses() >= inv.getMaxUses()) return "USED_UP";
+        return "ACTIVE";
+    }
+}

--- a/review-board/backend/src/main/resources/db/migration/V12__add_cohort_invites.sql
+++ b/review-board/backend/src/main/resources/db/migration/V12__add_cohort_invites.sql
@@ -1,0 +1,23 @@
+-- F-AUTH-02 招待フロー（Issue #165）。講師/管理者が cohort 単位で招待コードを発行し、
+-- 受講生が自分で登録できるようにする（管理者が 1 人ずつ手動発行する運用の入口を開く）。
+--
+-- セキュリティ（S軸）：
+--  - 生コードは発行時に 1 度だけ返し、DB には SHA-256 hex（CHAR 64）で保存（URL/ログ漏洩耐性・refresh token と同方針）。
+--  - 検証は raw 比較ではなく code_hash の UNIQUE lookup で行う（timing 比較なし）。
+--  - cohort_id は cohort 削除時 CASCADE。created_by は発行者退会時 SET NULL（未使用招待は失効させない）。
+--  - 失効は max_uses / expires_at / revoked_at の 3 条件で判定。
+
+CREATE TABLE cohort_invites (
+    id            BIGSERIAL   PRIMARY KEY,
+    cohort_id     BIGINT      NOT NULL REFERENCES cohorts(id) ON DELETE CASCADE,
+    code_hash     CHAR(64)    NOT NULL,
+    created_by    BIGINT      REFERENCES users(id) ON DELETE SET NULL,
+    expires_at    TIMESTAMPTZ NOT NULL,
+    max_uses      INT         NOT NULL DEFAULT 30 CHECK (max_uses > 0),
+    current_uses  INT         NOT NULL DEFAULT 0  CHECK (current_uses >= 0),
+    revoked_at    TIMESTAMPTZ,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX uniq_cohort_invites_hash    ON cohort_invites (code_hash);
+CREATE        INDEX idx_cohort_invites_cohort   ON cohort_invites (cohort_id, expires_at);

--- a/review-board/backend/src/test/java/com/reviewboard/domain/invite/InviteFlowIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/invite/InviteFlowIntegrationTest.java
@@ -1,0 +1,155 @@
+package com.reviewboard.domain.invite;
+
+import com.jayway.jsonpath.JsonPath;
+import com.reviewboard.domain.cohort.Cohort;
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRepository;
+import com.reviewboard.domain.user.UserRole;
+import com.reviewboard.support.AbstractIntegrationTest;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 招待フロー（Issue #165）の認可・登録検証。★S軸：発行/失効は自 cohort 限定、
+ * 受講生は発行 403、別 cohort の招待失効は 404、登録は招待消費・cohort 紐付け・重複/無効を拒否。
+ */
+class InviteFlowIntegrationTest extends AbstractIntegrationTest {
+
+    private String issueCode(Cookie teacher, String bodyJson) throws Exception {
+        MvcResult res = mockMvc.perform(post("/api/invites").cookie(teacher)
+                        .contentType("application/json").content(bodyJson))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("ACTIVE"))
+                .andReturn();
+        return JsonPath.parse(res.getResponse().getContentAsString()).read("$.rawCode");
+    }
+
+    @Test
+    void teacher_issues_and_student_registers_into_that_cohort() throws Exception {
+        Cohort a = newCohort("A");
+        newUser("teacher-a@test", UserRole.TEACHER, a.getId());
+        Cookie teacher = login("teacher-a@test");
+
+        String code = issueCode(teacher, "{}");
+
+        // 受講生が招待コードで登録 → 201・STUDENT・cohort A・Cookie 発行
+        MvcResult reg = mockMvc.perform(post("/api/auth/register")
+                        .contentType("application/json")
+                        .content("{\"code\":\"" + code + "\",\"email\":\"newbie@test\","
+                                + "\"displayName\":\"新人\",\"password\":\"register-pass-1\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.role").value("STUDENT"))
+                .andReturn();
+        assertThat(reg.getResponse().getCookie("access_token")).isNotNull();
+
+        User created = userRepository.findByEmail("newbie@test").orElseThrow();
+        assertThat(created.getCohortId()).isEqualTo(a.getId());
+        assertThat(created.getRole()).isEqualTo(UserRole.STUDENT);
+    }
+
+    @Test
+    void student_cannot_issue_invite_403() throws Exception {
+        Cohort a = newCohort("A");
+        newUser("student-a@test", UserRole.STUDENT, a.getId());
+        Cookie student = login("student-a@test");
+
+        mockMvc.perform(post("/api/invites").cookie(student)
+                        .contentType("application/json").content("{}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void unauthenticated_cannot_list_invites_401() throws Exception {
+        mockMvc.perform(get("/api/invites")).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void teacher_cannot_revoke_other_cohort_invite_404() throws Exception {
+        Cohort a = newCohort("A");
+        Cohort b = newCohort("B");
+        newUser("teacher-a@test", UserRole.TEACHER, a.getId());
+        newUser("teacher-b@test", UserRole.TEACHER, b.getId());
+        Cookie teacherA = login("teacher-a@test");
+        Cookie teacherB = login("teacher-b@test");
+
+        issueCode(teacherA, "{}");
+        // A の招待 id を A 自身の一覧から取得
+        MvcResult list = mockMvc.perform(get("/api/invites").cookie(teacherA))
+                .andExpect(status().isOk()).andReturn();
+        int inviteId = JsonPath.parse(list.getResponse().getContentAsString()).read("$[0].id");
+
+        // 別 cohort の講師は存在を漏らさず 404
+        mockMvc.perform(delete("/api/invites/" + inviteId).cookie(teacherB))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void revoked_invite_cannot_be_used_400() throws Exception {
+        Cohort a = newCohort("A");
+        newUser("teacher-a@test", UserRole.TEACHER, a.getId());
+        Cookie teacher = login("teacher-a@test");
+
+        String code = issueCode(teacher, "{}");
+        MvcResult list = mockMvc.perform(get("/api/invites").cookie(teacher))
+                .andExpect(status().isOk()).andReturn();
+        int inviteId = JsonPath.parse(list.getResponse().getContentAsString()).read("$[0].id");
+
+        mockMvc.perform(delete("/api/invites/" + inviteId).cookie(teacher))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(post("/api/auth/register").contentType("application/json")
+                        .content("{\"code\":\"" + code + "\",\"email\":\"x@test\","
+                                + "\"displayName\":\"x\",\"password\":\"register-pass-1\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void invalid_code_is_rejected_400() throws Exception {
+        mockMvc.perform(post("/api/auth/register").contentType("application/json")
+                        .content("{\"code\":\"not-a-real-code\",\"email\":\"x@test\","
+                                + "\"displayName\":\"x\",\"password\":\"register-pass-1\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void code_cannot_exceed_max_uses_400() throws Exception {
+        Cohort a = newCohort("A");
+        newUser("teacher-a@test", UserRole.TEACHER, a.getId());
+        Cookie teacher = login("teacher-a@test");
+
+        String code = issueCode(teacher, "{\"maxUses\":1}");
+
+        mockMvc.perform(post("/api/auth/register").contentType("application/json")
+                        .content("{\"code\":\"" + code + "\",\"email\":\"first@test\","
+                                + "\"displayName\":\"一人目\",\"password\":\"register-pass-1\"}"))
+                .andExpect(status().isCreated());
+
+        // 2 人目は maxUses=1 を超えるため 400
+        mockMvc.perform(post("/api/auth/register").contentType("application/json")
+                        .content("{\"code\":\"" + code + "\",\"email\":\"second@test\","
+                                + "\"displayName\":\"二人目\",\"password\":\"register-pass-1\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void duplicate_email_is_rejected_400() throws Exception {
+        Cohort a = newCohort("A");
+        newUser("teacher-a@test", UserRole.TEACHER, a.getId());
+        newUser("taken@test", UserRole.STUDENT, a.getId());
+        Cookie teacher = login("teacher-a@test");
+
+        String code = issueCode(teacher, "{}");
+        mockMvc.perform(post("/api/auth/register").contentType("application/json")
+                        .content("{\"code\":\"" + code + "\",\"email\":\"taken@test\","
+                                + "\"displayName\":\"重複\",\"password\":\"register-pass-1\"}"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/review-board/backend/src/test/java/com/reviewboard/support/AbstractIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/support/AbstractIntegrationTest.java
@@ -89,6 +89,7 @@ public abstract class AbstractIntegrationTest {
     @Autowired protected NotificationRepository notificationRepository;
     @Autowired protected AuditLogRepository auditLogRepository;
     @Autowired protected RefreshTokenRepository refreshTokenRepository;
+    @Autowired protected com.reviewboard.domain.invite.CohortInviteRepository inviteRepository;
     @Autowired protected org.springframework.security.crypto.password.PasswordEncoder passwordEncoder;
 
     /** FK 依存順（子 → 親）に全テーブルを掃除する。サブクラスで追加掃除が要れば override 可。 */
@@ -103,6 +104,7 @@ public abstract class AbstractIntegrationTest {
         reviewRepository.deleteAll();
         postRepository.deleteAll();
         refreshTokenRepository.deleteAll();
+        inviteRepository.deleteAll();
         userRepository.deleteAll();
         cohortRepository.deleteAll();
     }

--- a/review-board/frontend/src/App.jsx
+++ b/review-board/frontend/src/App.jsx
@@ -4,6 +4,8 @@ import { AuthProvider } from './context/AuthContext';
 import ProtectedRoute from './components/ProtectedRoute';
 import Header from './components/Header';
 import LoginPage from './pages/LoginPage';
+import RegisterPage from './pages/RegisterPage';
+import InvitesPage from './pages/InvitesPage';
 import PostsPage from './pages/PostsPage';
 import NewPostPage from './pages/NewPostPage';
 import PostEditPage from './pages/PostEditPage';
@@ -39,7 +41,9 @@ export default function App() {
       <ScrollToTop />
       <Routes>
         <Route path="/login" element={<LoginPage />} />
+        <Route path="/register" element={<RegisterPage />} />
         <Route path="/" element={<Shell><PostsPage /></Shell>} />
+        <Route path="/invites" element={<Shell><InvitesPage /></Shell>} />
         <Route path="/posts/new" element={<Shell><NewPostPage /></Shell>} />
         <Route path="/posts/:id/edit" element={<Shell><PostEditPage /></Shell>} />
         <Route path="/posts/:id" element={<Shell><PostDetailPage /></Shell>} />

--- a/review-board/frontend/src/api/auth.js
+++ b/review-board/frontend/src/api/auth.js
@@ -4,6 +4,10 @@ import client from './client';
 export const login = (email, password) =>
   client.post('/auth/login', { email, password }).then((r) => r.data);
 
+// F-AUTH-02 招待コードによる受講生の自己登録（公開）。成功時はそのままログイン状態（Cookie）になる。
+export const register = (payload) =>
+  client.post('/auth/register', payload).then((r) => r.data);
+
 export const logout = () => client.post('/auth/logout');
 
 export const fetchMe = () => client.get('/auth/me').then((r) => r.data);

--- a/review-board/frontend/src/api/invites.js
+++ b/review-board/frontend/src/api/invites.js
@@ -1,0 +1,10 @@
+import client from './client';
+
+// 招待コード管理（講師/管理者・Issue #165）。
+// 発行レスポンスにだけ rawCode が入る（再表示不可）。一覧では rawCode は null。
+export const createInvite = (payload = {}) =>
+  client.post('/invites', payload).then((r) => r.data);
+
+export const fetchInvites = () => client.get('/invites').then((r) => r.data);
+
+export const revokeInvite = (id) => client.delete(`/invites/${id}`);

--- a/review-board/frontend/src/components/Header.jsx
+++ b/review-board/frontend/src/components/Header.jsx
@@ -57,6 +57,9 @@ export default function Header() {
               <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">🔍</span>
             </form>
             <Link to="/posts/new" className="hidden shrink-0 whitespace-nowrap rounded-lg bg-brand-500 px-3.5 py-2 text-sm font-bold text-white shadow-sm transition hover:bg-brand-600 sm:inline-flex">＋ 投稿する</Link>
+            {(user.role === 'TEACHER' || user.role === 'ADMIN') && (
+              <Link to="/invites" className="hidden shrink-0 whitespace-nowrap text-sm font-medium text-gray-600 transition hover:text-navy-700 lg:inline">招待</Link>
+            )}
             <Link to="/notifications" className="relative text-gray-500 transition hover:text-navy-700" aria-label={`通知${unread > 0 ? `（未読 ${unread} 件）` : ''}`}>
               <span className="inline-block text-xl leading-none">🔔</span>
               {unread > 0 && (

--- a/review-board/frontend/src/context/AuthContext.jsx
+++ b/review-board/frontend/src/context/AuthContext.jsx
@@ -22,6 +22,13 @@ export function AuthProvider({ children }) {
     return u;
   }, []);
 
+  // F-AUTH-02 招待コードで登録 → そのままログイン状態にする。
+  const register = useCallback(async (payload) => {
+    const u = await authApi.register(payload);
+    setUser(u);
+    return u;
+  }, []);
+
   const logout = useCallback(async () => {
     try {
       await authApi.logout();
@@ -38,7 +45,7 @@ export function AuthProvider({ children }) {
   }, []);
 
   return (
-    <AuthContext.Provider value={{ user, loading, login, logout, refreshUser }}>
+    <AuthContext.Provider value={{ user, loading, login, register, logout, refreshUser }}>
       {children}
     </AuthContext.Provider>
   );

--- a/review-board/frontend/src/pages/InvitesPage.jsx
+++ b/review-board/frontend/src/pages/InvitesPage.jsx
@@ -1,0 +1,148 @@
+import { useEffect, useState, useCallback } from 'react';
+import { createInvite, fetchInvites, revokeInvite } from '../api/invites';
+
+// 招待コード管理（講師/管理者・Issue #165）。発行→受講生に共有→失効まで。
+// 生コードは発行直後の 1 度しか表示できないため、発行時に共有リンクを目立たせる。
+const STATUS_LABEL = {
+  ACTIVE: { text: '有効', cls: 'bg-emerald-50 text-emerald-700' },
+  EXPIRED: { text: '期限切れ', cls: 'bg-gray-100 text-gray-500' },
+  USED_UP: { text: '上限到達', cls: 'bg-gray-100 text-gray-500' },
+  REVOKED: { text: '失効済み', cls: 'bg-rose-50 text-rose-600' },
+};
+
+function fmt(dt) {
+  return dt ? new Date(dt).toLocaleString('ja-JP', { dateStyle: 'medium', timeStyle: 'short' }) : '—';
+}
+
+export default function InvitesPage() {
+  const [invites, setInvites] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [maxUses, setMaxUses] = useState(30);
+  const [expiresInDays, setExpiresInDays] = useState(7);
+  const [issued, setIssued] = useState(null); // 発行直後の生コード（1 度だけ）
+  const [copied, setCopied] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      setInvites(await fetchInvites());
+    } catch {
+      setError('招待一覧の取得に失敗しました。');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const shareLink = (code) => `${window.location.origin}/register?code=${encodeURIComponent(code)}`;
+
+  const onIssue = async () => {
+    setBusy(true);
+    setError('');
+    setCopied(false);
+    try {
+      const inv = await createInvite({ maxUses: Number(maxUses), expiresInDays: Number(expiresInDays) });
+      setIssued(inv);
+      await load();
+    } catch {
+      setError('招待の発行に失敗しました。');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onCopy = async () => {
+    if (!issued) return;
+    try {
+      await navigator.clipboard.writeText(shareLink(issued.rawCode));
+      setCopied(true);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  const onRevoke = async (id) => {
+    setError('');
+    try {
+      await revokeInvite(id);
+      await load();
+    } catch {
+      setError('失効に失敗しました。');
+    }
+  };
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-8">
+      <p className="mac-eyebrow text-left">INVITE</p>
+      <h2 className="mac-h mb-1 text-2xl">受講生を招待</h2>
+      <p className="mb-5 text-sm text-gray-500">招待リンクを受講生に共有すると、各自でアカウント登録できます（あなたの期に参加）。</p>
+
+      {error && <p className="mb-3 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+
+      {/* 発行フォーム */}
+      <div className="mac-card mb-5 p-6">
+        <div className="flex flex-wrap items-end gap-4">
+          <div>
+            <label htmlFor="inv-max" className="mac-label">利用上限（人数）</label>
+            <input id="inv-max" type="number" min={1} max={500} value={maxUses}
+              onChange={(e) => setMaxUses(e.target.value)} className="mac-input w-32" />
+          </div>
+          <div>
+            <label htmlFor="inv-days" className="mac-label">有効日数</label>
+            <input id="inv-days" type="number" min={1} max={90} value={expiresInDays}
+              onChange={(e) => setExpiresInDays(e.target.value)} className="mac-input w-32" />
+          </div>
+          <button onClick={onIssue} disabled={busy} className="mac-btn-brand">
+            {busy ? '発行中…' : '招待リンクを発行'}
+          </button>
+        </div>
+
+        {issued && (
+          <div className="mt-4 rounded-xl border border-brand-200 bg-brand-50/60 p-4">
+            <p className="mb-1 text-sm font-semibold text-navy-700">招待リンクを発行しました（この画面でのみ表示）</p>
+            <p className="mb-2 text-xs text-gray-500">このリンクを受講生に共有してください。上限 {issued.maxUses} 名・{fmt(issued.expiresAt)} まで有効。</p>
+            <div className="flex items-center gap-2">
+              <input readOnly value={shareLink(issued.rawCode)}
+                className="mac-input flex-1 font-mono text-xs" aria-label="招待リンク" />
+              <button onClick={onCopy} className="mac-btn-navy whitespace-nowrap px-4 py-2 text-sm">
+                {copied ? 'コピー済み ✓' : 'コピー'}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* 一覧 */}
+      <h3 className="mac-h mb-3 text-lg">発行済みの招待</h3>
+      {loading ? (
+        <p className="py-8 text-center text-gray-400">読み込み中…</p>
+      ) : invites.length === 0 ? (
+        <p className="py-8 text-center text-gray-400">まだ招待はありません。</p>
+      ) : (
+        <ul className="space-y-2">
+          {invites.map((inv) => {
+            const s = STATUS_LABEL[inv.status] ?? STATUS_LABEL.EXPIRED;
+            return (
+              <li key={inv.id} className="mac-card flex flex-wrap items-center justify-between gap-3 p-4">
+                <div className="text-sm">
+                  <span className={`mr-2 rounded-full px-2 py-0.5 text-xs font-bold ${s.cls}`}>{s.text}</span>
+                  <span className="text-gray-700">利用 {inv.currentUses}/{inv.maxUses}</span>
+                  <span className="ml-3 text-xs text-gray-400">期限 {fmt(inv.expiresAt)}</span>
+                </div>
+                {inv.status === 'ACTIVE' && (
+                  <button onClick={() => onRevoke(inv.id)}
+                    className="rounded-lg border border-black/10 bg-white px-3 py-1.5 text-sm font-medium text-rose-600 transition hover:bg-rose-50">
+                    失効させる
+                  </button>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/review-board/frontend/src/pages/LoginPage.jsx
+++ b/review-board/frontend/src/pages/LoginPage.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import ShibaIcon from '../components/ShibaIcon';
 
@@ -88,7 +88,7 @@ export default function LoginPage() {
         </form>
 
         <p className="mt-6 text-center text-xs text-gray-400">
-          アカウントは管理者・講師が発行します
+          招待コードをお持ちの方は <Link to="/register" className="font-semibold text-navy-700 hover:underline">こちらから登録</Link>
         </p>
       </div>
     </main>

--- a/review-board/frontend/src/pages/RegisterPage.jsx
+++ b/review-board/frontend/src/pages/RegisterPage.jsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import { useNavigate, useSearchParams, Link } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import ShibaIcon from '../components/ShibaIcon';
+
+// F-AUTH-02 招待コードによる受講生の自己登録（公開・Issue #165）。
+// 講師が配布した URL（/register?code=...）から開くとコードが自動入力される。
+export default function RegisterPage() {
+  const { register } = useAuth();
+  const navigate = useNavigate();
+  const [params] = useSearchParams();
+  const [code, setCode] = useState(params.get('code') ?? '');
+  const [displayName, setDisplayName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    setSubmitting(true);
+    try {
+      await register({ code: code.trim(), email, displayName, password });
+      navigate('/');
+    } catch (err) {
+      const msg = err?.response?.data?.error?.message;
+      setError(msg || '登録に失敗しました。招待コードや入力内容をご確認ください。');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <main className="flex min-h-screen items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        <div className="mb-7 flex flex-col items-center text-center">
+          <div className="mb-3 flex h-16 w-16 items-center justify-center rounded-[20px] bg-[#fff3e8] shadow-mac ring-1 ring-black/5">
+            <ShibaIcon className="h-12 w-12" />
+          </div>
+          <h1 className="text-2xl font-extrabold tracking-tight text-navy-700">アカウント登録</h1>
+          <p className="mt-1 text-sm text-gray-500">招待コードで受講生として参加します</p>
+        </div>
+
+        <form onSubmit={onSubmit} className="mac-card p-7">
+          {error && (
+            <p className="mb-4 rounded-xl border border-red-100 bg-red-50/80 px-3.5 py-2.5 text-sm text-red-600">
+              {error}
+            </p>
+          )}
+
+          <label htmlFor="reg-code" className="mac-label">招待コード</label>
+          <input id="reg-code" required value={code} onChange={(e) => setCode(e.target.value)}
+            placeholder="講師から受け取ったコード" className="mac-input mb-4" />
+
+          <label htmlFor="reg-name" className="mac-label">表示名</label>
+          <input id="reg-name" required maxLength={50} value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)} placeholder="山田 太郎" className="mac-input mb-4" />
+
+          <label htmlFor="reg-email" className="mac-label">メールアドレス</label>
+          <input id="reg-email" type="email" required autoComplete="email" value={email}
+            onChange={(e) => setEmail(e.target.value)} placeholder="you@example.com" className="mac-input mb-4" />
+
+          <label htmlFor="reg-password" className="mac-label">パスワード（8文字以上）</label>
+          <div className="relative mb-6">
+            <input id="reg-password" type={showPassword ? 'text' : 'password'} required minLength={8}
+              autoComplete="new-password" value={password} onChange={(e) => setPassword(e.target.value)}
+              placeholder="••••••••" className="mac-input pr-12" />
+            <button type="button" onClick={() => setShowPassword((v) => !v)}
+              aria-label={showPassword ? 'パスワードを隠す' : 'パスワードを表示'} aria-pressed={showPassword}
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded-lg px-2.5 py-1 text-xs font-semibold text-gray-500 transition hover:bg-black/[0.05] hover:text-navy-700">
+              {showPassword ? '非表示' : '表示'}
+            </button>
+          </div>
+
+          <button type="submit" disabled={submitting} className="mac-btn-navy w-full py-2.5">
+            {submitting ? '登録中…' : '登録して始める'}
+          </button>
+        </form>
+
+        <p className="mt-6 text-center text-xs text-gray-400">
+          すでにアカウントをお持ちの方は <Link to="/login" className="font-semibold text-navy-700 hover:underline">ログイン</Link>
+        </p>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## 概要
本番デプロイ後、アカウントが管理者手動発行のみで実運用の入口が塞がっていた問題を解消。講師/管理者が招待コードを発行し、受講生が招待リンクから自分で登録できるようにする（F-AUTH-02）。

## backend
- migration **V12 `cohort_invites`**（`code_hash` CHAR64 UNIQUE・`max_uses`/`expires_at`/`revoked_at` で失効判定・cohort CASCADE・created_by SET NULL）
- `InviteCodeGenerator`（**CSPRNG** 32byte→Base64url・**SHA-256 hex 保存**・raw 比較せず hash lookup＝refresh token と同方針）
- `InviteService`（発行/一覧/失効＝**自 cohort 限定**・`tryConsume` で原子的消費＝同時登録でも max_uses 超えない）
- `POST/GET /api/invites`・`DELETE /api/invites/{id}`（`hasAnyRole('TEACHER','ADMIN')`）
- 公開 `POST /api/auth/register`（招待消費→STUDENT 作成→そのままログイン）

## frontend
- 講師の招待管理ページ `/invites`（発行・共有リンクコピー・一覧・失効）
- 公開登録ページ `/register?code=...`（コード自動入力・a11y ラベル・`<main>`）
- ヘッダーに講師/管理者向け「招待」リンク・ログインに登録導線

## 重点軸・テスト
認可テスト **9件 green**：受講生の発行 403・別 cohort の失効 404・無効/失効/上限到達/重複 email → 400・登録で cohort 紐付け。バックエンド全テスト回帰なし。

## 実機確認
講師発行→招待リンクで受講生登録→自動ログイン→講師と同 cohort(2)・招待消費 1/30・console error 0。

## 非対象（follow-up）
「kick（登録済みメンバーの無効化）」は user 状態モデルの追加が要るため分離。

Closes #165
