### PR TITLE
feat: メール通知 MVP（レビュー受領をメール送出・過疎化対策）

### DIFF
--- a/review-board/backend/build.gradle
+++ b/review-board/backend/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	// メール通知（#175・過疎化対策）。SMTP は env 駆動・app.mail.enabled で有効化（既定 false）。
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	// 4 ゴールデンシグナルの収集（母 §3-1）。http.server.requests（Latency/Traffic/Errors）と
 	// Hikari/JVM（Saturation）を Micrometer が Actuator 経由で /actuator/prometheus に公開する。
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'

--- a/review-board/backend/src/main/java/com/reviewboard/ReviewBoardApplication.java
+++ b/review-board/backend/src/main/java/com/reviewboard/ReviewBoardApplication.java
@@ -3,6 +3,7 @@ package com.reviewboard;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
@@ -12,6 +13,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @SpringBootApplication
 @ConfigurationPropertiesScan
 @EnableScheduling // S-3 カウンタ再計算バッチ等の定期実行
+@EnableAsync      // メール通知（#175）を TX 後に別スレッドで送る
 public class ReviewBoardApplication {
 
     public static void main(String[] args) {

--- a/review-board/backend/src/main/java/com/reviewboard/config/MailProperties.java
+++ b/review-board/backend/src/main/java/com/reviewboard/config/MailProperties.java
@@ -1,0 +1,18 @@
+package com.reviewboard.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * メール通知設定（application.yml の app.mail.*・#175）。
+ * SMTP 接続そのものは spring.mail.* が持ち、ここは「送るかどうか」と表示情報のみ。
+ *
+ * @param enabled  true で実送信。既定 false（dev/CI/未設定では no-op＝ログのみ）
+ * @param from     送信元アドレス
+ * @param baseUrl  メール本文のリンク用ベース URL（例 https://example.com）
+ */
+@ConfigurationProperties(prefix = "app.mail")
+public record MailProperties(
+        boolean enabled,
+        String from,
+        String baseUrl) {
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/notification/NotificationService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/notification/NotificationService.java
@@ -5,6 +5,7 @@ import com.reviewboard.domain.auth.AuthPrincipal;
 import com.reviewboard.domain.notification.dto.NotificationResponse;
 import com.reviewboard.domain.user.User;
 import com.reviewboard.domain.user.UserRepository;
+import com.reviewboard.mail.MailService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,13 +28,16 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
     private final com.reviewboard.storage.StorageService storageService;
+    private final MailService mailService;
 
     public NotificationService(NotificationRepository notificationRepository,
                                UserRepository userRepository,
-                               com.reviewboard.storage.StorageService storageService) {
+                               com.reviewboard.storage.StorageService storageService,
+                               MailService mailService) {
         this.notificationRepository = notificationRepository;
         this.userRepository = userRepository;
         this.storageService = storageService;
+        this.mailService = mailService;
     }
 
     /**
@@ -54,6 +58,28 @@ public class NotificationService {
         n.setReviewId(reviewId);
         n.setCreatedAt(OffsetDateTime.now());
         notificationRepository.save(n);
+
+        // #175 過疎化対策：核となるイベント（レビューを受け取った）だけ外向きにメールも送る。
+        // 無効時（既定）は何もしない。送信は @Async＝この TX をブロックしない・失敗は握りつぶす。
+        if (mailService.enabled() && type == NotificationType.REVIEW_RECEIVED) {
+            sendReviewReceivedEmail(recipientUserId, actorUserId, postId);
+        }
+    }
+
+    /** レビュー受領メールを組み立てて送る（宛先・本文は文字列で MailService に渡す）。 */
+    private void sendReviewReceivedEmail(Long recipientUserId, Long actorUserId, Long postId) {
+        User recipient = userRepository.findById(recipientUserId).orElse(null);
+        if (recipient == null || recipient.getEmail() == null) {
+            return;
+        }
+        String actorName = userRepository.findById(actorUserId)
+                .map(User::getDisplayName).orElse("どなたか");
+        String link = mailService.baseUrl().isBlank() ? "" : mailService.baseUrl() + "/posts/" + postId;
+        String body = recipient.getDisplayName() + " さん\n\n"
+                + actorName + " さんがあなたの成果物にレビューを投稿しました。\n"
+                + (link.isBlank() ? "アプリで確認してみましょう。" : link)
+                + "\n\n— review-board";
+        mailService.send(recipient.getEmail(), "あなたの成果物にレビューが届きました", body);
     }
 
     /**

--- a/review-board/backend/src/main/java/com/reviewboard/mail/MailService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/mail/MailService.java
@@ -1,0 +1,74 @@
+package com.reviewboard.mail;
+
+import com.reviewboard.config.MailProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+/**
+ * メール送信（#175・過疎化対策の外向きチャネル）。
+ *
+ * <p>設計方針：
+ *  - {@code app.mail.enabled=false}（既定）では実送信せずログのみ（dev/CI/SMTP 未設定でも安全）。
+ *  - 送信は {@link Async}＝ドメイン処理のリクエストをブロックしない。呼び出しは TX コミット後の通知生成からで、
+ *    例外は内部で握りつぶす（メール失敗が業務処理を巻き戻さない・通知本体は残す）。
+ *  - 本文・宛先は呼び出し側が文字列で渡す（lazy ロードや TX 依存を持ち込まない）。
+ */
+@Service
+public class MailService {
+
+    private static final Logger log = LoggerFactory.getLogger(MailService.class);
+
+    private final MailProperties props;
+    private final ObjectProvider<JavaMailSender> mailSenderProvider;
+
+    public MailService(MailProperties props, ObjectProvider<JavaMailSender> mailSenderProvider) {
+        this.props = props;
+        this.mailSenderProvider = mailSenderProvider;
+    }
+
+    /** プレーンテキストメールを送る。無効時は no-op、失敗時はログのみ（例外を投げない）。 */
+    @Async
+    public void send(String to, String subject, String body) {
+        if (!props.enabled()) {
+            log.debug("mail disabled; skip send to={} subject={}", to, subject);
+            return;
+        }
+        if (to == null || to.isBlank()) {
+            return;
+        }
+        try {
+            JavaMailSender sender = mailSenderProvider.getIfAvailable();
+            if (sender == null) {
+                log.warn("app.mail.enabled=true だが JavaMailSender が無い。spring.mail.* を設定してください。");
+                return;
+            }
+            SimpleMailMessage msg = new SimpleMailMessage();
+            if (props.from() != null && !props.from().isBlank()) {
+                msg.setFrom(props.from());
+            }
+            msg.setTo(to);
+            msg.setSubject(subject);
+            msg.setText(body);
+            sender.send(msg);
+            log.info("mail sent to={} subject={}", to, subject);
+        } catch (Exception e) {
+            // メール失敗は通知本体に影響させない（過疎化対策の付帯機能・ベストエフォート）。
+            log.warn("mail send failed to={} subject={}: {}", to, subject, e.toString());
+        }
+    }
+
+    /** 実送信が有効か（呼び出し側が無駄な本文組み立て/DB 取得を避けるために使う）。 */
+    public boolean enabled() {
+        return props.enabled();
+    }
+
+    /** メール本文中のリンク用ベース URL（未設定なら相対導線のみ）。 */
+    public String baseUrl() {
+        return props.baseUrl() != null ? props.baseUrl() : "";
+    }
+}

--- a/review-board/backend/src/main/resources/application.yml
+++ b/review-board/backend/src/main/resources/application.yml
@@ -23,6 +23,16 @@ spring:
       # SEC-8：multipart 段でサイズを弾く（サービス側 max-upload-bytes と二重防御）。
       max-file-size: 5MB
       max-request-size: 6MB
+  # メール通知（#175）。host 未設定なら JavaMailSender は生成されない（=送信しない）。
+  # 機密（user/password）はデフォルトを持たせず env 駆動（SEC-9）。
+  mail:
+    host: ${SMTP_HOST:}
+    port: ${SMTP_PORT:587}
+    username: ${SMTP_USERNAME:}
+    password: ${SMTP_PASSWORD:}
+    properties:
+      mail.smtp.auth: true
+      mail.smtp.starttls.enable: true
 
 server:
   port: 8082
@@ -34,6 +44,11 @@ management:
         # health は監視プローブ用（SecurityConfig で permitAll）。
         # metrics/prometheus は運用観測（SecurityConfig で ROLE_TEACHER 限定）。
         include: health,info,metrics,prometheus
+  health:
+    # mail は best-effort の付帯機能（#175）。SMTP 到達性で liveness を落とさない
+    # （health はアプリ稼働の可否のみを示す。SMTP 障害でプローブを失敗させない）。
+    mail:
+      enabled: false
   metrics:
     tags:
       application: review-board
@@ -64,6 +79,11 @@ app:
   # 顧客オリジンを設定すると CSP frame-ancestors で限定的に埋め込みを解放する。
   embedding:
     frame-ancestors: ${EMBEDDING_FRAME_ANCESTORS:'none'}
+  # メール通知（#175）。既定 false＝no-op（dev/CI/SMTP 未設定でも安全）。本番で MAIL_ENABLED=true。
+  mail:
+    enabled: ${MAIL_ENABLED:false}
+    from: ${MAIL_FROM:no-reply@review-board.local}
+    base-url: ${PUBLIC_ORIGIN:}
   # 初期管理者の bootstrap（デプロイ直後の「最初の1人」を作る。未設定＝何もしない・冪等）。
   bootstrap:
     admin-email: ${BOOTSTRAP_ADMIN_EMAIL:}

--- a/review-board/backend/src/test/java/com/reviewboard/mail/MailServiceTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/mail/MailServiceTest.java
@@ -1,0 +1,76 @@
+package com.reviewboard.mail;
+
+import com.reviewboard.config.MailProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * MailService の境界（#175）。Spring を起動しない純粋単体（@Async は直接 new では効かず同期実行）。
+ * ★方針の検証：無効時は no-op／有効時のみ送信／sender 不在・送信失敗でも例外を投げない。
+ */
+class MailServiceTest {
+
+    @SuppressWarnings("unchecked")
+    private ObjectProvider<JavaMailSender> providerOf(JavaMailSender sender) {
+        ObjectProvider<JavaMailSender> p = mock(ObjectProvider.class);
+        when(p.getIfAvailable()).thenReturn(sender);
+        return p;
+    }
+
+    @Test
+    void disabled_does_not_send() {
+        JavaMailSender sender = mock(JavaMailSender.class);
+        MailService svc = new MailService(new MailProperties(false, "from@x", ""), providerOf(sender));
+
+        svc.send("to@x", "subj", "body");
+
+        verifyNoInteractions(sender);
+    }
+
+    @Test
+    void enabled_sends_with_from_and_fields() {
+        JavaMailSender sender = mock(JavaMailSender.class);
+        MailService svc = new MailService(new MailProperties(true, "from@x", "https://app"), providerOf(sender));
+
+        svc.send("to@x", "件名", "本文");
+
+        SimpleMailMessage expected = new SimpleMailMessage();
+        expected.setFrom("from@x");
+        expected.setTo("to@x");
+        expected.setSubject("件名");
+        expected.setText("本文");
+        verify(sender).send(expected);
+    }
+
+    @Test
+    void enabled_but_no_sender_does_not_throw() {
+        MailService svc = new MailService(new MailProperties(true, "from@x", ""), providerOf(null));
+        assertThatCode(() -> svc.send("to@x", "s", "b")).doesNotThrowAnyException();
+    }
+
+    @Test
+    void send_failure_is_swallowed() {
+        JavaMailSender sender = mock(JavaMailSender.class);
+        doThrow(new RuntimeException("smtp down")).when(sender).send(any(SimpleMailMessage.class));
+        MailService svc = new MailService(new MailProperties(true, "from@x", ""), providerOf(sender));
+
+        // メール失敗は業務処理を巻き戻さない＝例外を投げないこと。
+        assertThatCode(() -> svc.send("to@x", "s", "b")).doesNotThrowAnyException();
+    }
+
+    @Test
+    void blank_recipient_is_skipped() {
+        JavaMailSender sender = mock(JavaMailSender.class);
+        MailService svc = new MailService(new MailProperties(true, "from@x", ""), providerOf(sender));
+
+        svc.send("", "s", "b");
+
+        verifyNoInteractions(sender);
+    }
+}


### PR DESCRIPTION
## 概要
アプリ内ポーリング通知の**外向きチャネル**。過疎化対策として、最重要イベント「自分の成果物にレビューが届いた」をメールでも届ける（エンゲージメントの核）。MVP スコープ。

## 変更
- `spring-boot-starter-mail` ＋ `@EnableAsync`
- `MailProperties`（`app.mail.enabled` 既定 **false**・from・base-url）／`MailService`
  - 無効時 **no-op**（dev/CI/SMTP 未設定で安全）
  - `@Async`＝ドメイン TX をブロックしない
  - 送信失敗は握りつぶし、**通知本体に影響させない**（best-effort）
  - SMTP は **env 駆動**で機密ハードコードなし（SEC-9）
- `NotificationService` が `REVIEW_RECEIVED` 時のみメール送出（`enabled` かつ該当型のみ＝無駄な DB 取得も回避）
- mail ヘルスインジケータを無効化（**health は liveness のみ**を示し、SMTP 到達性でプローブを落とさない・#122 観測性方針と整合）

## テスト
`MailServiceTest` 5件（無効=no-op／有効=送信／sender 不在・送信失敗で例外なし／空宛先 skip）。**全 121 テスト green**（回帰なし）。

## スコープ / 非対象（follow-up）
- MVP＝核イベント1通＋基盤。**週次ダイジェスト・種別別の通知設定（opt-out）は分離**（受信者モデル・配信停止設計が要る）
- 本番送信基盤（SES/外部 SMTP）は env 設定で対応。ローカルは SMTP 無で no-op のため**実メール受信の実機検証は本番環境で実施**

Closes #175
