### PR TITLE
feat: k6 性能テストCI（P-1 継続検証）

### DIFF
--- a/.github/workflows/review-board-performance.yml
+++ b/.github/workflows/review-board-performance.yml
@@ -1,0 +1,126 @@
+name: review-board Performance (k6)
+
+# ============================================================
+# #163：k6 による性能テスト（P-1 継続検証）。docs/性能目標.md の P95 目標を
+# しきい値にし、超過したら fail させる。
+#
+# トリガ：手動（workflow_dispatch・VUs/duration 指定可）＋ perf 資産/本 workflow の
+# 変更 PR（スクリプト自体の妥当性確認）。backend 変更の全 PR では回さない（重く・ノイズ）。
+#
+# スタックは E2E と同じ Postgres + MinIO + backend(8082)。seed ユーザーでログインし、
+# k6 が一覧/詳細/成長記録/ログインの P95 を計測する。
+# ============================================================
+
+on:
+  workflow_dispatch:
+    inputs:
+      vus:
+        description: 同時実行 VU 数
+        required: false
+        default: '5'
+      duration:
+        description: 実行時間（例 30s, 1m）
+        required: false
+        default: '30s'
+  pull_request:
+    paths:
+      - 'review-board/perf/**'
+      - '.github/workflows/review-board-performance.yml'
+
+concurrency:
+  group: rb-perf-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  k6:
+    name: k6 性能テスト
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: reviewboard
+          POSTGRES_PASSWORD: ci-reviewboard-pass
+          POSTGRES_DB: reviewboard
+        ports:
+          - 5434:5432
+        options: >-
+          --health-cmd "pg_isready -U reviewboard -d reviewboard"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: jdbc:postgresql://localhost:5434/reviewboard
+      DATABASE_USERNAME: reviewboard
+      DATABASE_PASSWORD: ci-reviewboard-pass
+      JWT_SECRET: ci-only-secret-must-be-at-least-32-bytes-long-xx
+      S3_ENDPOINT: http://localhost:9002
+      S3_BUCKET: review-board
+      S3_REGION: ap-northeast-1
+      S3_ACCESS_KEY: minioadmin
+      S3_SECRET_KEY: minioadmin
+      SEED_PASSWORD: devpass12345
+      # dev プロファイルで seed（講師/受講生）を有効化する。
+      SPRING_PROFILES_ACTIVE: dev
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Start MinIO + create bucket
+        run: |
+          docker run -d --name minio \
+            -p 9002:9000 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            minio/minio:latest server /data
+          for i in {1..30}; do
+            curl -sf http://localhost:9002/minio/health/live >/dev/null && break
+            sleep 2
+          done
+          docker run --rm --network host --entrypoint /bin/sh minio/mc:latest -c "
+            mc alias set local http://localhost:9002 minioadmin minioadmin &&
+            mc mb --ignore-existing local/review-board
+          "
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Start backend (8082) and wait for health
+        working-directory: review-board/backend
+        run: |
+          nohup ./gradlew bootRun --no-daemon --quiet > /tmp/backend.log 2>&1 &
+          for i in {1..60}; do
+            curl -sf http://localhost:8082/actuator/health >/dev/null && exit 0
+            sleep 3
+          done
+          echo "Backend failed to start"; tail -120 /tmp/backend.log; exit 1
+
+      - name: Install k6 (pinned binary)
+        run: |
+          K6_VERSION=v0.50.0
+          curl -sL "https://github.com/grafana/k6/releases/download/${K6_VERSION}/k6-${K6_VERSION}-linux-amd64.tar.gz" | tar xz
+          sudo mv "k6-${K6_VERSION}-linux-amd64/k6" /usr/local/bin/k6
+          k6 version
+
+      - name: Run k6 load test（P95 しきい値超過で fail）
+        working-directory: review-board/perf/k6
+        env:
+          BASE_URL: http://localhost:8082
+          VUS: ${{ github.event.inputs.vus || '5' }}
+          DURATION: ${{ github.event.inputs.duration || '30s' }}
+        run: k6 run posts-load.js
+
+      - name: backend ログ（失敗時の調査用）
+        if: failure()
+        run: tail -200 /tmp/backend.log || true

--- a/review-board/perf/k6/posts-load.js
+++ b/review-board/perf/k6/posts-load.js
@@ -1,0 +1,85 @@
+// review-board 性能テスト（#163・k6）。docs/性能目標.md の P-1 P95 目標を CI で継続検証する。
+//
+// シナリオ：受講生でログイン → 投稿一覧 → 投稿詳細 → 自分の成長記録を回す。
+// しきい値は P-1 の P95 目標（読み取り≤200ms・成長記録≤250ms・ログイン≤600ms）。
+// setup() で 1 件投稿を用意し、一覧/詳細が空にならないようにする。
+//
+// 実行例（ローカル）：
+//   BASE_URL=http://localhost:8082 SEED_PASSWORD=devpass12345 k6 run posts-load.js
+import http from 'k6/http';
+import { check } from 'k6';
+
+const BASE = __ENV.BASE_URL || 'http://localhost:8082';
+const PASSWORD = __ENV.SEED_PASSWORD || 'devpass12345';
+const STUDENT = __ENV.PERF_STUDENT_EMAIL || 'student@example.com';
+
+export const options = {
+  scenarios: {
+    browse: {
+      executor: 'constant-vus',
+      vus: Number(__ENV.VUS || 5),
+      duration: __ENV.DURATION || '30s',
+    },
+  },
+  thresholds: {
+    // P-1 の P95 目標（CI 共有ランナーの余裕を見つつ、目標値そのものをガードに使う）。
+    'http_req_duration{endpoint:posts_list}': ['p(95)<200'],
+    'http_req_duration{endpoint:post_detail}': ['p(95)<200'],
+    'http_req_duration{endpoint:profile}': ['p(95)<250'],
+    'http_req_duration{endpoint:login}': ['p(95)<600'],
+    // 失敗率は 1% 未満（機能不全の早期検知）。
+    http_req_failed: ['rate<0.01'],
+  },
+};
+
+function login(email) {
+  const res = http.post(`${BASE}/api/auth/login`, JSON.stringify({ email, password: PASSWORD }), {
+    headers: { 'Content-Type': 'application/json' },
+    tags: { endpoint: 'login' },
+  });
+  check(res, { 'login 200': (r) => r.status === 200 });
+  let userId = null;
+  try { userId = res.json('id'); } catch { /* noop */ }
+  return userId;
+}
+
+// 一覧/詳細が空にならないよう、最低 1 件の投稿を用意する。
+export function setup() {
+  const res = http.post(`${BASE}/api/auth/login`, JSON.stringify({ email: STUDENT, password: PASSWORD }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (res.status !== 200) {
+    return { seeded: false };
+  }
+  http.post(`${BASE}/api/posts`, JSON.stringify({
+    title: 'perf seed post',
+    description: 'k6 性能テスト用のシード投稿です。',
+  }), { headers: { 'Content-Type': 'application/json' } });
+  return { seeded: true };
+}
+
+export default function () {
+  // 認証（cookie は VU の jar に保持され、以降の GET に自動付与）。
+  const userId = login(STUDENT);
+
+  // 投稿一覧（主役導線）。
+  const list = http.get(`${BASE}/api/posts`, { tags: { endpoint: 'posts_list' } });
+  check(list, { 'posts 200': (r) => r.status === 200 });
+
+  // 先頭の投稿で詳細を引く（Slice の content[0]）。
+  let firstId = null;
+  try {
+    const content = list.json('content');
+    if (content && content.length > 0) firstId = content[0].id;
+  } catch { /* noop */ }
+  if (firstId) {
+    const detail = http.get(`${BASE}/api/posts/${firstId}`, { tags: { endpoint: 'post_detail' } });
+    check(detail, { 'detail 200': (r) => r.status === 200 });
+  }
+
+  // 自分の成長記録（集約クエリ）。
+  if (userId) {
+    const profile = http.get(`${BASE}/api/users/${userId}/profile`, { tags: { endpoint: 'profile' } });
+    check(profile, { 'profile 200': (r) => r.status === 200 });
+  }
+}

--- a/review-board/perf/k6/posts-load.js
+++ b/review-board/perf/k6/posts-load.js
@@ -39,7 +39,7 @@ function login(email) {
   });
   check(res, { 'login 200': (r) => r.status === 200 });
   let userId = null;
-  try { userId = res.json('id'); } catch { /* noop */ }
+  try { userId = res.json('id'); } catch (e) { /* noop */ }
   return userId;
 }
 
@@ -71,7 +71,7 @@ export default function () {
   try {
     const content = list.json('content');
     if (content && content.length > 0) firstId = content[0].id;
-  } catch { /* noop */ }
+  } catch (e) { /* noop */ }
   if (firstId) {
     const detail = http.get(`${BASE}/api/posts/${firstId}`, { tags: { endpoint: 'post_detail' } });
     check(detail, { 'detail 200': (r) => r.status === 200 });


### PR DESCRIPTION
## 概要
`docs/性能目標.md` の P95 目標をしきい値にした **k6 負荷テストを CI に追加**。超過したら fail させ、性能デグレを継続検知する（P-1 の継続検証）。

## 変更
- **`review-board/perf/k6/posts-load.js`**：受講生ログイン→投稿一覧→投稿詳細→成長記録を回し、`endpoint` タグ別に P95 をしきい値判定
  - 一覧/詳細 ≤200ms・成長記録 ≤250ms・ログイン ≤600ms・失敗率 <1%（P-1 と対）
  - `setup()` で 1 件シードし、一覧/詳細が空にならないようにする
- **`review-board-performance.yml`**：E2E と同じ Postgres+MinIO+backend(8082) スタックで k6（pinned binary v0.50.0）を実行
  - トリガ＝**手動 dispatch**（VUs/duration 指定可）＋ **perf 資産/workflow 変更 PR**（backend 全 PR では回さない＝重さ・ノイズ回避）

## 検証
ローカル実測（VUS=3 / 10s・稼働 backend）：login p95=**107ms**・detail **5ms**・list **9ms**・profile **9ms**・失敗率 **0%**・checks 1044件 100% → **全しきい値 pass**。本 PR は perf workflow を `pull_request` トリガで CI 実走させて検証する。

Closes #163
