### PR TITLE
chore: CD滞留の再発防止（デプロイ済みSHA記録＋cd-buildでドリフト検知）

### DIFF
--- a/.github/workflows/review-board-cd-build.yml
+++ b/.github/workflows/review-board-cd-build.yml
@@ -143,6 +143,41 @@ jobs:
           aws s3 sync "artifact/$TAG/" "s3://$ARTIFACTS_BUCKET/$TAG/" --only-show-errors
           echo "::notice title=pushed to S3::s3://$ARTIFACTS_BUCKET/$TAG/"
 
+      # #212 ドリフト検知：本番にデプロイ済みの SHA（cd-deploy が記録したマーカー）と、いま発行した
+      # アーティファクトの SHA を比較する。乖離していれば「未デプロイの滞留」を警告し、見逃しを防ぐ。
+      # ★手動承認ゲートは維持（ここでは自動デプロイしない）。警告のみでビルドは失敗させない。
+      - name: 本番デプロイとのドリフト検知（未デプロイの滞留を警告）
+        if: steps.guard.outputs.ready == 'true'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.RB_CD_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.RB_CD_AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ap-northeast-1
+          ARTIFACTS_BUCKET: ${{ vars.RB_ARTIFACTS_BUCKET }}
+        run: |
+          TAG="${{ steps.meta.outputs.tag }}"
+          # マーカーが無ければ「未デプロイ（初回）」として扱う。
+          DEPLOYED="(none)"
+          if aws s3 cp "s3://$ARTIFACTS_BUCKET/deployed/current.txt" deployed-current.txt --only-show-errors 2>/dev/null; then
+            DEPLOYED="$(tr -d '[:space:]' < deployed-current.txt)"
+          fi
+          if [ "$DEPLOYED" = "$TAG" ]; then
+            echo "## ✅ 本番は最新（ドリフトなし）" >> "$GITHUB_STEP_SUMMARY"
+            echo "本番デプロイ済み SHA = 最新アーティファクト SHA = \`$TAG\`" >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "## ⚠️ 未デプロイのアーティファクトがあります"
+              echo ""
+              echo "| | SHA |"
+              echo "|---|---|"
+              echo "| 本番デプロイ済み | \`$DEPLOYED\` |"
+              echo "| 最新アーティファクト（このビルド） | \`$TAG\` |"
+              echo ""
+              echo "**本番反映するには cd-deploy を手動 dispatch してください**（sha=\`$TAG\` / confirm=\`deploy\`）。"
+              echo "手動承認ゲートは維持しているため、マージだけでは本番に反映されません。"
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning title=deploy pending::本番=$DEPLOYED / 最新=$TAG。cd-deploy で sha=$TAG を昇格してください（マージ＝本番反映ではありません）。"
+          fi
+
       - name: 次の手動デプロイで使う SHA を表示
         run: |
           echo "::notice title=artifact ready::SHA=${{ steps.meta.outputs.tag }} を review-board-cd-deploy の sha 入力に渡して昇格する"

--- a/.github/workflows/review-board-cd-deploy.yml
+++ b/.github/workflows/review-board-cd-deploy.yml
@@ -111,6 +111,27 @@ jobs:
             --command-id "$CMD_ID" --instance-id "${{ steps.ec2.outputs.id }}" \
             --query 'StandardOutputContent' --output text
 
+      # #212 ドリフト検知の真実ソース：昇格に成功した SHA を S3 に記録する。
+      # cd-build がこのマーカーと最新 SHA を比較し、未デプロイの滞留を警告する。
+      # 失敗してもデプロイ自体は完了しているので、記録失敗で job を落とさない（警告のみ）。
+      - name: 本番デプロイ済み SHA を記録（ドリフト検知用）
+        if: steps.guard.outputs.ready == 'true'
+        env:
+          ARTIFACTS_BUCKET: ${{ vars.RB_ARTIFACTS_BUCKET }}
+        run: |
+          SHA='${{ github.event.inputs.sha }}'
+          if [ -z "${ARTIFACTS_BUCKET}" ]; then
+            echo "::warning title=marker skipped::RB_ARTIFACTS_BUCKET 未設定のためデプロイ済み SHA を記録できませんでした"
+          else
+            printf '%s\n' "$SHA" > deployed-current.txt
+            if aws s3 cp deployed-current.txt "s3://$ARTIFACTS_BUCKET/deployed/current.txt" \
+                 --content-type text/plain --only-show-errors; then
+              echo "::notice title=marker updated::本番デプロイ済み SHA=$SHA を記録しました（s3://$ARTIFACTS_BUCKET/deployed/current.txt）"
+            else
+              echo "::warning title=marker failed::デプロイ済み SHA の S3 記録に失敗しました（デプロイ自体は成功）"
+            fi
+          fi
+
       - name: 昇格結果
         if: steps.guard.outputs.ready == 'true'
         # deploy.sh が localhost の actuator/health を権威的にチェックし、失敗時は非ゼロ終了する


### PR DESCRIPTION
## 関連 Issue

Closes #212

---

## 変更の概要

CD は manual promotion 設計（cd-build=自動でS3発行 / cd-deploy=手動昇格）のため、main マージが本番未反映のまま滞留しても気づけませんでした。実際 #206〜#210 の5マージ分が長く未反映でした。**手動承認ゲート（CLAUDE.md §6/§12）は維持**し、ドリフトを「見逃せなくする」検知だけを追加します（自動デプロイはしない）。

- **cd-deploy**：昇格成功時に本番デプロイ済み SHA を `s3://<artifacts>/deployed/current.txt` に記録（本番の真実の単一ソース）。記録失敗ではジョブを落とさず警告のみ。
- **cd-build**：毎マージ時にマーカーと最新 SHA を比較し、乖離していれば Step Summary＋`::warning::` で「未デプロイあり・cd-deploy で sha=… を昇格せよ」と警告。ビルドは失敗させない。

既存 CD ユーザー権限（artifacts への Put/Get/List・`infra/iam.tf:125`）で足り、**infra apply 不要**。

---

## 変更の種別

- [x] chore（CI・運用ツールの改善）

---

## 動作確認チェックリスト

- [x] 両ワークフロー YAML のパース確認（ruby YAML.load_file で OK）
- [x] 既存機能（アプリ・テスト）への影響なし（ワークフロー変更のみ）
- [x] `.env`・パスワードをコミットしていない

---

## レビュー時に特に確認してほしい点

- マーカーの読み書き先 `deployed/current.txt` と CD ユーザー権限の整合（Put/Get/List）
- 既知の軽微な仕様：ワークフローのみの変更でも cd-build が走り「未デプロイ」を警告し得る（過剰警告＝安全側。アプリ滞留の見逃しは防ぐ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)