### PR TITLE
feat: 成果物カードの自動サムネ化（demo_url をヘッドレス撮影・SSRF対策・フラグ式）

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/Post.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/Post.java
@@ -48,6 +48,15 @@ public class Post {
     @Column(name = "screenshot_key", length = 512)
     private String screenshotKey;
 
+    /** #218 自動サムネ：demo_url をヘッドレス撮影した画像の S3 キー（手動 screenshot_key とは別）。 */
+    @Column(name = "auto_screenshot_key", length = 512)
+    private String autoScreenshotKey;
+
+    /** カード表示に使う実効キー：手動アップロードを優先し、無ければ自動サムネを使う。 */
+    public String getEffectiveScreenshotKey() {
+        return (screenshotKey != null && !screenshotKey.isBlank()) ? screenshotKey : autoScreenshotKey;
+    }
+
     @Enumerated(EnumType.STRING)
     @Column(name = "recruit_status", nullable = false, length = 10)
     private RecruitStatus recruitStatus = RecruitStatus.OPEN;

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/PostController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/PostController.java
@@ -50,7 +50,8 @@ public class PostController {
     /** screenshotKey から署名付き URL を補い、閲覧者のいいね状態を添えて詳細レスポンスを組み立てる（SEC-8）。 */
     private PostResponse toResponse(Post post, AuthPrincipal principal) {
         boolean liked = postLikeRepository.existsByPostIdAndUserId(post.getId(), principal.userId());
-        return PostResponse.from(post, storageService.presignedGetUrl(post.getScreenshotKey()), liked);
+        // 表示は実効キー（手動アップロード優先・無ければ自動サムネ。#218）
+        return PostResponse.from(post, storageService.presignedGetUrl(post.getEffectiveScreenshotKey()), liked);
     }
 
     /** F-POST-01 作成 */
@@ -87,7 +88,7 @@ public class PostController {
                     .stream().map(PostLike::getPostId).collect(Collectors.toSet());
         return slice.map(p -> PostSummaryResponse.from(
                 p, authorNames.get(p.getAuthorUserId()),
-                storageService.presignedGetUrl(p.getScreenshotKey()),
+                storageService.presignedGetUrl(p.getEffectiveScreenshotKey()),
                 likedPostIds.contains(p.getId())));
     }
 

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/PostService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/PostService.java
@@ -33,14 +33,30 @@ public class PostService {
     private final ReviewRepository reviewRepository;
     private final AuditService auditService;
     private final com.reviewboard.domain.notification.NotificationService notificationService;
+    private final org.springframework.context.ApplicationEventPublisher events;
 
     public PostService(PostRepository postRepository, ReviewRepository reviewRepository,
                        AuditService auditService,
-                       com.reviewboard.domain.notification.NotificationService notificationService) {
+                       com.reviewboard.domain.notification.NotificationService notificationService,
+                       org.springframework.context.ApplicationEventPublisher events) {
         this.postRepository = postRepository;
         this.reviewRepository = reviewRepository;
         this.auditService = auditService;
         this.notificationService = notificationService;
+        this.events = events;
+    }
+
+    /**
+     * #218 自動サムネ：demo_url があり手動スクショが無い投稿は、保存コミット後に撮影を要求する
+     * （AFTER_COMMIT・@Async で実行）。フラグ OFF（本番既定）なら listener 側で no-op。
+     */
+    private void requestAutoThumbnail(Post post) {
+        boolean hasManual = post.getScreenshotKey() != null && !post.getScreenshotKey().isBlank();
+        boolean hasDemo = post.getDemoUrl() != null && !post.getDemoUrl().isBlank();
+        if (hasDemo && !hasManual) {
+            events.publishEvent(new com.reviewboard.thumbnail.PostThumbnailRequested(
+                    post.getId(), post.getCohortId(), post.getDemoUrl()));
+        }
     }
 
     /** F-POST-01 作成。cohort と author は principal（検証済み）から導出する。 */
@@ -61,6 +77,7 @@ public class PostService {
         post.setUpdatedAt(now);
         postRepository.save(post);
         auditService.record(principal, AuditAction.POST_CREATED, AuditTargetType.POST, post.getId());
+        requestAutoThumbnail(post);
         return post;
     }
 
@@ -116,6 +133,7 @@ public class PostService {
         applyReviewPreferences(post, req.reviewTones(), req.reviewAspects(), req.aiUsage());
         post.setUpdatedAt(OffsetDateTime.now());
         auditService.record(principal, AuditAction.POST_UPDATED, AuditTargetType.POST, postId);
+        requestAutoThumbnail(post);
         return post;
     }
 

--- a/review-board/backend/src/main/java/com/reviewboard/storage/StorageService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/storage/StorageService.java
@@ -81,6 +81,29 @@ public class StorageService {
         return key;
     }
 
+    /**
+     * #218 自動サムネ（ヘッドレス撮影した PNG）を private バケットに保存しキーを返す。
+     * 手動アップロードと同じく magic byte でPNG実体を確認し、cohort ごとにパスを分ける。
+     */
+    public String uploadAutoThumbnail(byte[] pngBytes, Long cohortId) {
+        if (pngBytes == null || pngBytes.length == 0) {
+            throw new InvalidRequestException("撮影画像が空です");
+        }
+        if (pngBytes.length > props.maxUploadBytes()) {
+            throw new InvalidRequestException("撮影画像が上限サイズを超えています");
+        }
+        ImageType type = sniff(pngBytes); // 実体確認（撮影結果は PNG 想定）
+        String key = "auto-thumbnails/" + cohortId + "/" + UUID.randomUUID() + type.extension();
+        s3.putObject(
+                PutObjectRequest.builder()
+                        .bucket(props.bucket())
+                        .key(key)
+                        .contentType(type.contentType())
+                        .build(),
+                RequestBody.fromBytes(pngBytes));
+        return key;
+    }
+
     /** 表示用の短命な署名付き GET URL。key が無ければ null。 */
     public String presignedGetUrl(String key) {
         if (key == null || key.isBlank()) {

--- a/review-board/backend/src/main/java/com/reviewboard/thumbnail/PostThumbnailRequested.java
+++ b/review-board/backend/src/main/java/com/reviewboard/thumbnail/PostThumbnailRequested.java
@@ -1,0 +1,8 @@
+package com.reviewboard.thumbnail;
+
+/**
+ * 投稿の保存後に自動サムネ撮影を要求するドメインイベント。
+ * PostService が（TX 内で）publish し、{@link ThumbnailCaptureService} が AFTER_COMMIT で受ける。
+ */
+public record PostThumbnailRequested(Long postId, Long cohortId, String demoUrl) {
+}

--- a/review-board/backend/src/main/java/com/reviewboard/thumbnail/ThumbnailCaptureService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/thumbnail/ThumbnailCaptureService.java
@@ -1,0 +1,141 @@
+package com.reviewboard.thumbnail;
+
+import com.reviewboard.domain.post.Post;
+import com.reviewboard.domain.post.PostRepository;
+import com.reviewboard.storage.StorageService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * #218 自動サムネ：投稿の demo_url をヘッドレス Chrome で開いて撮影し、S3 に保存して
+ * post.auto_screenshot_key へ反映する。★best-effort（失敗は握りつぶし投稿処理に影響させない）。
+ *
+ * <p>フラグ {@code app.thumbnail.auto-capture-enabled} が false（本番既定）なら何もしない。
+ * SSRF は {@link UrlSafetyValidator} で撮影前に遮断する（S軸）。
+ */
+@Service
+public class ThumbnailCaptureService {
+
+    private static final Logger log = LoggerFactory.getLogger(ThumbnailCaptureService.class);
+
+    private final ThumbnailProperties props;
+    private final UrlSafetyValidator urlSafety;
+    private final StorageService storageService;
+    private final PostRepository postRepository;
+
+    public ThumbnailCaptureService(ThumbnailProperties props, UrlSafetyValidator urlSafety,
+                                   StorageService storageService, PostRepository postRepository) {
+        this.props = props;
+        this.urlSafety = urlSafety;
+        this.storageService = storageService;
+        this.postRepository = postRepository;
+    }
+
+    /** 自動撮影の起動条件（フラグ ON かつ chrome パス設定あり）。呼び出し側の早期 return にも使う。 */
+    public boolean enabled() {
+        return props.autoCaptureEnabled() && props.chromePath() != null && !props.chromePath().isBlank();
+    }
+
+    /**
+     * 投稿の保存コミット後に撮影する。{@code @TransactionalEventListener(AFTER_COMMIT)} で
+     * 未コミット行を読む競合を防ぎ、{@code @Async} で投稿レスポンスをブロックしない。
+     * 例外は投げず、ログのみ（サムネは付加価値＝失敗しても投稿は成立済み）。
+     */
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onThumbnailRequested(PostThumbnailRequested event) {
+        Long postId = event.postId();
+        Long cohortId = event.cohortId();
+        String demoUrl = event.demoUrl();
+        if (!enabled() || demoUrl == null || demoUrl.isBlank()) {
+            return;
+        }
+        try {
+            urlSafety.verifyPublicHttpUrl(demoUrl); // ★SSRF 遮断（撮影前）
+            byte[] png = capture(demoUrl);
+            String key = storageService.uploadAutoThumbnail(png, cohortId);
+            // 別スレッド＝新しい永続コンテキスト。save() は単体で原子的に確定する。
+            Post post = postRepository.findById(postId).orElse(null);
+            if (post != null && post.getDeletedAt() == null) {
+                post.setAutoScreenshotKey(key);
+                postRepository.save(post);
+                log.info("auto thumbnail stored: postId={} key={}", postId, key);
+            }
+        } catch (Exception e) {
+            // SSRF 拒否・撮影失敗・到達不能などはすべてここ。投稿処理には影響させない。
+            log.warn("auto thumbnail skipped: postId={} reason={}", postId, e.toString());
+        }
+    }
+
+    /** ヘッドレス Chrome を一発起動して PNG を撮る。出力・プロファイルは一時ディレクトリに隔離。 */
+    private byte[] capture(String url) throws IOException, InterruptedException {
+        Path tmpDir = Files.createTempDirectory("rb-thumb-");
+        Path out = tmpDir.resolve("shot.png");
+        Path profile = tmpDir.resolve("profile");
+        try {
+            ProcessBuilder pb = new ProcessBuilder(
+                    props.chromePath(),
+                    // 旧 headless：--screenshot のワンショットに最適で --virtual-time-budget 後に確実に終了する。
+                    // （--headless=new は virtual-time-budget を無視し終了せずタイムアウトする）
+                    "--headless",
+                    "--disable-gpu",
+                    "--no-sandbox",
+                    "--hide-scrollbars",
+                    "--disable-extensions",
+                    "--no-first-run",              // 初回起動フローを省きコールドスタートを短縮
+                    "--no-default-browser-check",
+                    "--disable-dev-shm-usage",     // /dev/shm が小さい環境（コンテナ/EC2）での安定化
+                    "--user-data-dir=" + profile,
+                    "--window-size=" + props.viewportWidth() + "," + props.viewportHeight(),
+                    "--virtual-time-budget=4000", // ある程度の描画完了を待つ
+                    "--screenshot=" + out,
+                    url);
+            pb.redirectErrorStream(true);
+            Process p = pb.start();
+            try {
+                // Chrome は --screenshot で PNG を書いた後もプロセスが終了しないことがあるため、
+                // プロセス終了ではなく「出力ファイルの出現」を待つ。出たら即読んでプロセスを始末する。
+                long deadline = System.currentTimeMillis() + props.timeoutMs();
+                while (System.currentTimeMillis() < deadline) {
+                    if (Files.exists(out) && Files.size(out) > 0) {
+                        Thread.sleep(200); // 書き込み完了を待つ短い猶予
+                        return Files.readAllBytes(out);
+                    }
+                    if (!p.isAlive() && (!Files.exists(out) || Files.size(out) == 0)) {
+                        throw new IOException("撮影結果が空です（exit=" + p.exitValue() + "）: " + url);
+                    }
+                    Thread.sleep(150);
+                }
+                throw new IOException("撮影がタイムアウトしました: " + url);
+            } finally {
+                p.destroyForcibly(); // 終了しない Chrome を残さない（プロセスリーク防止）
+                p.waitFor(2, TimeUnit.SECONDS);
+            }
+        } finally {
+            deleteQuietly(tmpDir);
+        }
+    }
+
+    private void deleteQuietly(Path dir) {
+        try (var walk = Files.walk(dir)) {
+            walk.sorted((a, b) -> b.getNameCount() - a.getNameCount()).forEach(path -> {
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException ignored) {
+                    // 一時ファイルの後始末失敗は致命的でない
+                }
+            });
+        } catch (IOException ignored) {
+            // walk 失敗も無視（OS の temp 掃除に委ねる）
+        }
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/thumbnail/ThumbnailProperties.java
+++ b/review-board/backend/src/main/java/com/reviewboard/thumbnail/ThumbnailProperties.java
@@ -1,0 +1,22 @@
+package com.reviewboard.thumbnail;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * 自動サムネ撮影の設定（application.yml の app.thumbnail.*。env 駆動）。
+ *
+ * @param autoCaptureEnabled 自動撮影の有効化フラグ。既定 false。本番 t3.micro は当面 OFF
+ *                           （OOM / SSRF 面を出さない）。dev のみ ON にして検証する。
+ * @param chromePath         ヘッドレス Chrome/Chromium の実行ファイルパス（OS で異なる）。空なら撮影しない。
+ * @param viewportWidth      撮影ビューポート幅
+ * @param viewportHeight     撮影ビューポート高（カードのサムネ比率に合わせる）
+ * @param timeoutMs          1 撮影あたりの上限時間（超過でプロセス強制終了）
+ */
+@ConfigurationProperties(prefix = "app.thumbnail")
+public record ThumbnailProperties(
+        boolean autoCaptureEnabled,
+        String chromePath,
+        int viewportWidth,
+        int viewportHeight,
+        long timeoutMs) {
+}

--- a/review-board/backend/src/main/java/com/reviewboard/thumbnail/UrlSafetyValidator.java
+++ b/review-board/backend/src/main/java/com/reviewboard/thumbnail/UrlSafetyValidator.java
@@ -1,0 +1,88 @@
+package com.reviewboard.thumbnail;
+
+import com.reviewboard.common.InvalidRequestException;
+import org.springframework.stereotype.Component;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+
+/**
+ * ★SSRF 遮断（S軸）：ヘッドレス撮影でサーバーが開く URL の安全性を検証する。
+ *
+ * <p>demo_url は利用者入力のため、サーバーが任意 URL を開くと内部資源（クラウドメタデータ
+ * 169.254.169.254／localhost／プライベート IP／RDS 等）への到達に悪用されうる。次を満たさないURLは拒否：
+ * <ul>
+ *   <li>スキームは http / https のみ（file: などは不可）。</li>
+ *   <li>ホスト名を解決した <b>全ての</b> IP がグローバル（公開）であること。ループバック／リンクローカル
+ *       （169.254/fe80）／サイトローカル（10・172.16-31・192.168）／ユニークローカル（fc00::/7）／
+ *       any／マルチキャストはいずれも拒否。</li>
+ * </ul>
+ *
+ * <p>残存リスク：DNS リバインディング（検証時は公開IP、撮影時に内部IPへ再解決）は本検証だけでは防げない。
+ * このため本番では当面この機能を無効化し、有効化時は隔離された撮影ホスト（ADR 参照）で運用する。
+ */
+@Component
+public class UrlSafetyValidator {
+
+    /** 安全でなければ {@link InvalidRequestException} を投げる。安全なら正常 return。 */
+    public void verifyPublicHttpUrl(String url) {
+        if (url == null || url.isBlank()) {
+            throw new InvalidRequestException("URL が空です");
+        }
+        URI uri;
+        try {
+            uri = URI.create(url.trim());
+        } catch (IllegalArgumentException e) {
+            throw new InvalidRequestException("URL の形式が不正です");
+        }
+        String scheme = uri.getScheme();
+        if (scheme == null || !(scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https"))) {
+            throw new InvalidRequestException("http / https の URL のみ対応します");
+        }
+        String host = uri.getHost();
+        if (host == null || host.isBlank()) {
+            throw new InvalidRequestException("URL にホストがありません");
+        }
+        InetAddress[] addresses;
+        try {
+            addresses = InetAddress.getAllByName(host);
+        } catch (UnknownHostException e) {
+            throw new InvalidRequestException("ホストを解決できません");
+        }
+        for (InetAddress addr : addresses) {
+            if (!isGlobalUnicast(addr)) {
+                // 具体的なアドレスは伏せ、内部到達を試みる入力を一律で拒否する。
+                throw new InvalidRequestException("内部・非公開アドレスへの URL は指定できません");
+            }
+        }
+    }
+
+    /** 公開（グローバルユニキャスト）IP のみ true。内部到達に使える範囲はすべて false。 */
+    private boolean isGlobalUnicast(InetAddress addr) {
+        if (addr.isLoopbackAddress() || addr.isAnyLocalAddress()
+                || addr.isLinkLocalAddress() || addr.isSiteLocalAddress()
+                || addr.isMulticastAddress()) {
+            return false;
+        }
+        byte[] b = addr.getAddress();
+        if (b.length == 4) {
+            int o0 = b[0] & 0xFF;
+            int o1 = b[1] & 0xFF;
+            // クラウドメタデータ 169.254.169.254 は link-local で上記により拒否済みだが念のため明示。
+            if (o0 == 169 && o1 == 254) {
+                return false;
+            }
+            // 100.64.0.0/10（CGNAT・キャリアグレード NAT）は内部寄りのため拒否。
+            if (o0 == 100 && o1 >= 64 && o1 <= 127) {
+                return false;
+            }
+        } else if (b.length == 16) {
+            // ユニークローカル fc00::/7（最上位 7bit が 1111110）。
+            if ((b[0] & 0xFE) == 0xFC) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/review-board/backend/src/main/resources/application.yml
+++ b/review-board/backend/src/main/resources/application.yml
@@ -107,6 +107,26 @@ app:
       secret-key: ${S3_SECRET_KEY:minioadmin}
       presign-ttl-seconds: 600          # 表示用 署名 URL の寿命（10 分・短命）
       max-upload-bytes: 5242880         # 5MB（サービス側の二重チェック。下の multipart 上限と対）
+  # #218 自動サムネ（demo_url をヘッドレス撮影）。既定 OFF＝test/CI/本番で勝手に Chrome を起動しない。
+  # 本番 t3.micro は OOM/SSRF 面を出さないため当面 OFF（有効化は隔離撮影ホスト整備後・ADR 参照）。
+  # dev だけ下の dev プロファイルで ON にして検証する。
+  thumbnail:
+    auto-capture-enabled: ${THUMBNAIL_AUTO_CAPTURE:false}
+    chrome-path: ${CHROME_PATH:}
+    viewport-width: 1200
+    viewport-height: 750
+    timeout-ms: 20000                 # Chrome コールドスタート＋ネットワーク取得の余裕（撮影は非同期）
+
+---
+# dev プロファイル：自動サムネを ON にし、mac の Chrome を既定パスで使う（env で上書き可）。
+spring:
+  config:
+    activate:
+      on-profile: dev
+app:
+  thumbnail:
+    auto-capture-enabled: ${THUMBNAIL_AUTO_CAPTURE:true}
+    chrome-path: ${CHROME_PATH:/Applications/Google Chrome.app/Contents/MacOS/Google Chrome}
 
 ---
 # prod プロファイル（M-5：dev/prod 分離）。

--- a/review-board/backend/src/main/resources/db/migration/V13__add_post_auto_screenshot_key.sql
+++ b/review-board/backend/src/main/resources/db/migration/V13__add_post_auto_screenshot_key.sql
@@ -1,0 +1,3 @@
+-- #218 自動サムネ化：demo_url をヘッドレス撮影した画像の S3 キー。
+-- 手動アップロード（screenshot_key）とは別管理し、表示は手動 > 自動 > グラデの優先順。
+ALTER TABLE posts ADD COLUMN auto_screenshot_key VARCHAR(512);

--- a/review-board/backend/src/test/java/com/reviewboard/thumbnail/UrlSafetyValidatorTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/thumbnail/UrlSafetyValidatorTest.java
@@ -1,0 +1,61 @@
+package com.reviewboard.thumbnail;
+
+import com.reviewboard.common.InvalidRequestException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * ★SSRF 遮断（S軸）の単体テスト。内部到達に使える URL を確実に拒否することを担保する。
+ * IP リテラルは DNS を引かずに判定できるため、ネットワーク非依存で検証できる。
+ */
+class UrlSafetyValidatorTest {
+
+    private final UrlSafetyValidator validator = new UrlSafetyValidator();
+
+    /** 内部・非公開・危険なスキームはすべて拒否。 */
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://127.0.0.1/",            // ループバック
+            "http://localhost/",            // ループバック名
+            "http://169.254.169.254/latest/meta-data/", // クラウドメタデータ（link-local）
+            "http://10.0.0.5/",             // サイトローカル(10/8)
+            "http://192.168.1.1/",          // サイトローカル(192.168/16)
+            "http://172.16.0.10/",          // サイトローカル(172.16/12)
+            "http://100.64.0.1/",           // CGNAT(100.64/10)
+            "http://0.0.0.0/",              // any-local
+            "http://[::1]/",                // IPv6 ループバック
+            "file:///etc/passwd",           // 危険スキーム
+            "ftp://example.com/",           // 非 http(s)
+    })
+    void rejects_internal_or_dangerous(String url) {
+        assertThatThrownBy(() -> validator.verifyPublicHttpUrl(url))
+                .isInstanceOf(InvalidRequestException.class);
+    }
+
+    /** 空・null・ホスト無しも拒否。 */
+    @ParameterizedTest
+    @ValueSource(strings = {"", "   ", "http://", "https:///path"})
+    void rejects_blank_or_hostless(String url) {
+        assertThatThrownBy(() -> validator.verifyPublicHttpUrl(url))
+                .isInstanceOf(InvalidRequestException.class);
+    }
+
+    @Test
+    void rejects_null() {
+        assertThatThrownBy(() -> validator.verifyPublicHttpUrl(null))
+                .isInstanceOf(InvalidRequestException.class);
+    }
+
+    /** 公開 IP リテラルは許可（DNS 非依存で安定）。 */
+    @Test
+    void allows_public_ip_literal() {
+        assertThatCode(() -> validator.verifyPublicHttpUrl("https://8.8.8.8/"))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> validator.verifyPublicHttpUrl("http://1.1.1.1:8080/app"))
+                .doesNotThrowAnyException();
+    }
+}

--- a/review-board/docs/ADR/0003-自動サムネ撮影の設計と本番延期.md
+++ b/review-board/docs/ADR/0003-自動サムネ撮影の設計と本番延期.md
@@ -1,0 +1,45 @@
+# ADR-0003: 自動サムネ撮影（demo_url）の設計と本番延期
+
+- ステータス: Accepted（2026-05-25・Issue #218）
+- 関連: ADR-0002 / 脅威モデリング.md / 付録A判定表.md（SEC）/ インフラ構成.md
+
+## 背景
+
+成果物カードのサムネは手動アップロード時のみ実画像で、未アップロード時はグラデのプレースホルダ。
+`demo_url` がある投稿は公開トップ画面を自動撮影してサムネにしたい。実現には「サーバー側で
+利用者入力 URL をヘッドレスブラウザで開いて撮影」が必要で、2つの本質的リスクがある。
+
+1. **SSRF（S軸の重大リスク）**：`demo_url` は利用者入力。サーバーが任意 URL を開くと、クラウド
+   メタデータ（169.254.169.254）／localhost／プライベート IP／RDS 等への到達に悪用されうる。
+2. **本番のメモリ**：本番 EC2 は t3.micro（1GB・JVM ヒープも切り詰め＋swap）。ここに Chromium を
+   同居起動すると OOM の恐れ（1 レンダリング数百 MB）。加えて Chrome は `--screenshot` 後も終了
+   しないことがあり、プロセスリークの懸念もある。
+
+## 決定
+
+### パイプライン（フラグ式・dev 撮影 / 本番は当面 OFF）
+投稿作成・編集（`demo_url` あり・手動スクショ無し）→ `@TransactionalEventListener(AFTER_COMMIT)`
+＋`@Async` → **SSRF 検証** → ヘッドレス撮影 → S3（既存 private バケット）→ `posts.auto_screenshot_key`
+→ カードは既存 `screenshotUrl` 経由で表示（**手動 > 自動 > グラデ**の優先）。best-effort で、失敗は
+握りつぶし投稿処理に影響させない。
+
+### SSRF 対策（必須・`UrlSafetyValidator`）
+http/https のみ・ホスト解決後の全 IP がグローバル（公開）であることを要求し、ループバック／
+リンクローカル（169.254/fe80）／サイトローカル（10・172.16-31・192.168）／CGNAT（100.64/10）／
+ユニークローカル（fc00::/7）／any／マルチキャストを拒否。**残存リスク＝DNS リバインディング**は
+本検証だけでは防げないため、本番有効化は隔離撮影ホスト前提とする（下記）。
+
+### 本番延期（フラグ `app.thumbnail.auto-capture-enabled`・既定 false）
+test/CI/本番では既定 OFF（勝手に Chrome を起動しない）。**dev のみ ON**（mac の Chrome パス既定）。
+本番 ON は t3.micro 同居ではなく、**隔離撮影ホスト**（例：headless-chromium の AWS Lambda を
+非同期呼び出し→S3）を整備してから。Lambda 化すればアプリ本体からブラウザを分離でき、OOM と
+プロセスリークの懸念を本番から排除できる（Terraform で Lambda/IAM 追加＝人間 apply）。
+
+### 撮影の実装メモ
+- 旧 `--headless`（`--headless=new` は `--virtual-time-budget` を無視し終了しない）。
+- プロセス終了ではなく**出力ファイルの出現をポーリング**して読み、その後 `destroyForcibly`
+  （終了しない Chrome を残さない＝リーク防止）。
+
+## 結果
+- dev では実機で動作実証（example.com を撮影→MinIO 保存→カード表示）。
+- 本番は OFF のままなので OOM/SSRF 面を出さない。本番 ON は Lambda 等の整備後に本 ADR を更新して行う。


### PR DESCRIPTION
## 関連 Issue
Closes #218

## 変更の概要
`demo_url` がある投稿の公開トップ画面を自動撮影してカードのサムネにします。**手動アップロードが無い場合のみ**自動撮影し、表示優先は **手動 > 自動 > グラデ**。

- **migration V13**：`posts.auto_screenshot_key`（手動 `screenshot_key` と別管理）
- **UrlSafetyValidator（★SSRF遮断・重点軸）**：http/https 限定・ホスト解決後の全IPが公開であることを要求し、loopback/link-local/metadata(169.254.169.254)/private(10・172.16-31・192.168)/CGNAT(100.64/10)/unique-local(fc00::/7) を拒否。単体テスト付き。
- **ThumbnailCaptureService**：`@TransactionalEventListener(AFTER_COMMIT)`＋`@Async`（TX後・非ブロッキング）。旧 `--headless`＋**出力ファイルのポーリング読み取り**＋`destroyForcibly`（Chrome が `--screenshot` 後に終了しない問題＆プロセスリークに対処）。best-effort（失敗は投稿に影響させない）。
- **フラグ** `app.thumbnail.auto-capture-enabled`（既定 false）。**dev のみ ON**、本番 t3.micro は OOM/SSRF 面を出さないため当面 OFF（有効化は隔離撮影ホスト整備後）。
- PostController：カード/詳細の `screenshotUrl` を実効キー（手動>自動）に。
- **ADR-0003**：設計・本番延期・SSRF・将来の Lambda 化を文書化。

## 変更の種別
- [x] feat（新機能の追加）

## 動作確認チェックリスト
- [x] 全 backend テスト green（SSRF 単体テスト含む）
- [x] **dev 実機で動作実証**：demo_url=https://example.com の投稿作成→約8秒で自動撮影→MinIO 保存→カードに実スクショ表示を確認
- [x] フラグ既定 OFF で test/CI/本番は Chrome を起動しない
- [x] `.env`・パスワードをコミットしていない

## レビュー時に特に確認してほしい点
- SSRF 遮断の網羅（`UrlSafetyValidator`）。残存リスクの DNS リバインディングは本番 OFF＋将来の隔離ホストで対処（ADR-0003）。
- 本番で有効化しない方針（t3.micro 同居の OOM/プロセスリーク回避）。本番 ON は Lambda 等の整備後に別タスク。

🤖 Generated with [Claude Code](https://claude.com/claude-code)