### PR TITLE
style: 「投稿する」「成果物を見る」系ボタンを WR Blue Pearl に統一

### DIFF
--- a/review-board/frontend/src/components/Header.jsx
+++ b/review-board/frontend/src/components/Header.jsx
@@ -57,7 +57,7 @@ export default function Header() {
               />
               <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">🔍</span>
             </form>
-            <Link to="/posts/new" className="hidden shrink-0 whitespace-nowrap rounded-lg bg-brand-500 px-3.5 py-2 text-sm font-bold text-white shadow-sm transition hover:bg-brand-600 sm:inline-flex">＋ 投稿する</Link>
+            <Link to="/posts/new" className="hidden shrink-0 whitespace-nowrap rounded-lg bg-wrblue-500 px-3.5 py-2 text-sm font-bold text-white shadow-sm transition hover:bg-wrblue-600 sm:inline-flex">＋ 投稿する</Link>
             {(user.role === 'TEACHER' || user.role === 'ADMIN') && (
               <Link to="/invites" className="hidden shrink-0 whitespace-nowrap text-sm font-medium text-gray-600 transition hover:text-navy-700 lg:inline">招待</Link>
             )}

--- a/review-board/frontend/src/components/WorksList.jsx
+++ b/review-board/frontend/src/components/WorksList.jsx
@@ -52,7 +52,11 @@ export default function WorksList({ posts, loading, error, applied, setFilter, o
             <button onClick={() => setFilter({ approved: false })} className="ml-1.5 font-bold" aria-label="合格作品の絞り込みを解除">×</button>
           </span>
         )}
-        <Link to="/posts/new" className="mac-btn-brand ml-auto">＋ 投稿する</Link>
+        {/* 「＋ 投稿する」は WR Blue Pearl（mac-btn-brand は他ボタンと共有のため使わず個別指定）。 */}
+        <Link to="/posts/new"
+          className="ml-auto inline-flex items-center justify-center gap-1.5 rounded-xl bg-wrblue-500 px-4 py-2.5 text-sm font-bold text-white shadow-mac-sm transition hover:bg-wrblue-600 active:scale-[0.98]">
+          ＋ 投稿する
+        </Link>
       </div>
 
       <div className="mt-6">

--- a/review-board/frontend/src/index.css
+++ b/review-board/frontend/src/index.css
@@ -33,6 +33,11 @@
   --color-cherry-500: #d2042d; /* バッジ/ドット地色（白文字 ≒5.7:1） */
   --color-cherry-600: #a80224; /* hover/濃いめ */
 
+  /* WR Blue Pearl（スバルのラリーブルー系）。「投稿する」系の主アクション専用アクセント。
+     白文字で十分なコントラスト（≒7:1）。 */
+  --color-wrblue-500: #0050b5; /* 地色 */
+  --color-wrblue-600: #003e8c; /* hover/濃いめ */
+
   /* キャンバス（Apple グレー） */
   --color-canvas: #f5f5f7;
 

--- a/review-board/frontend/src/pages/PostsPage.jsx
+++ b/review-board/frontend/src/pages/PostsPage.jsx
@@ -105,7 +105,7 @@ export default function PostsPage() {
               受講生どうし・講師が成果物をレビュー。<br className="hidden sm:block" />その積み重ねが、あなたの「成長の証跡」になります。
             </p>
             <div className="mt-7 flex flex-wrap gap-3">
-              <Link to="/posts/new" className="rounded-xl bg-navy-700 px-6 py-3 text-sm font-bold text-white shadow-md transition hover:bg-navy-800">成果物を投稿する</Link>
+              <Link to="/posts/new" className="rounded-xl bg-wrblue-500 px-6 py-3 text-sm font-bold text-white shadow-md transition hover:bg-wrblue-600">成果物を投稿する</Link>
               <button onClick={scrollToWorks} className="rounded-xl border-2 border-navy-700 px-6 py-3 text-sm font-bold text-navy-700 transition hover:bg-navy-700/5">成果物を見る ›</button>
             </div>
           </div>
@@ -225,7 +225,8 @@ export default function PostsPage() {
         <div className="mx-auto max-w-3xl text-center">
           <h2 className="text-[26px] font-extrabold leading-tight text-white">まずは成果物を投稿して、<br />レビューを受けてみよう。</h2>
           <p className="mt-3 text-sm text-white/70">レビューし合うほど、あなたの成長が積み上がる。</p>
-          <Link to="/posts/new" className="mt-7 inline-block rounded-xl bg-brand-500 px-8 py-3.5 text-sm font-bold text-white shadow-lg transition hover:bg-brand-600">成果物を投稿する</Link>
+          {/* 濃紺帯の上なので WR ブルーが埋もれないよう白の細リングで分離する。 */}
+          <Link to="/posts/new" className="mt-7 inline-block rounded-xl bg-wrblue-500 px-8 py-3.5 text-sm font-bold text-white shadow-lg ring-1 ring-inset ring-white/30 transition hover:bg-wrblue-600">成果物を投稿する</Link>
         </div>
       </section>
     </main>

--- a/review-board/frontend/src/pages/PostsPage.jsx
+++ b/review-board/frontend/src/pages/PostsPage.jsx
@@ -106,7 +106,7 @@ export default function PostsPage() {
             </p>
             <div className="mt-7 flex flex-wrap gap-3">
               <Link to="/posts/new" className="rounded-xl bg-wrblue-500 px-6 py-3 text-sm font-bold text-white shadow-md transition hover:bg-wrblue-600">成果物を投稿する</Link>
-              <button onClick={scrollToWorks} className="rounded-xl border-2 border-navy-700 px-6 py-3 text-sm font-bold text-navy-700 transition hover:bg-navy-700/5">成果物を見る ›</button>
+              <button onClick={scrollToWorks} className="rounded-xl border-2 border-wrblue-500 px-6 py-3 text-sm font-bold text-wrblue-500 transition hover:bg-wrblue-500/5">成果物を見る ›</button>
             </div>
           </div>
           <div className="space-y-4">


### PR DESCRIPTION
## 関連 Issue
Closes #222

## 変更の概要
ヒーロー・ヘッダー・CTA の主要アクションを WR Blue Pearl（スバルのラリーブルー系・濃いコバルト）に統一。「探す」等のスカイブルーや `mac-btn-brand` を使う他ボタンは**不変**。
（#221 とのコンフリクトで未マージだった #223 を本 PR に統合・作り直し）

- `index.css`：`wrblue-500 #0050b5 / wrblue-600 #003e8c` トークン追加（白文字 ≒7:1）
- 「＋ 投稿する」：Header・WORKS（`mac-btn-brand` を使わず個別の wrblue で他ボタンに波及させない）
- 「成果物を投稿する」：ヒーロー（塗り）・CTA帯（濃紺の上なので白の細リングで分離）
- 「成果物を見る ›」：ヒーロー二次ボタン＝アウトライン様式のまま配色を wrblue に

## 変更の種別
- [x] style（見た目のみ）

## 動作確認チェックリスト
- [x] build/lint green
- [x] 実機（ヒーロー/ヘッダー/CTA/WORKS・MCP）で「投稿する」「見る」系が WR ブルー、探す/募集中/見る›(カード) はスカイブルーのままを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)