### PR TITLE
feat: セキュリティヘッダ付与（HSTS/Referrer-Policy/Permissions-Policy＋nginx CSP）SEC-13

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/config/SecurityConfig.java
+++ b/review-board/backend/src/main/java/com/reviewboard/config/SecurityConfig.java
@@ -16,6 +16,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
 
 /**
  * ★S軸の中核。RBAC + ステートレス認可。
@@ -51,6 +52,14 @@ public class SecurityConfig {
             // app.embedding.frame-ancestors に顧客オリジンを設定したときだけ、X-Frame-Options を外し
             // CSP frame-ancestors で許可オリジンに限定して iframe 埋め込みを解放する。
             .headers(h -> {
+                // SEC-13 防御ヘッダ（無条件付与）。X-Content-Type-Options: nosniff は Spring 既定で付与。
+                // HSTS は HTTPS 応答にのみ付与される（dev の HTTP では出ないが無害）。
+                h.httpStrictTransportSecurity(hsts -> hsts
+                        .includeSubDomains(true).maxAgeInSeconds(31536000)) // 1 年
+                 .referrerPolicy(rp -> rp.policy(
+                        ReferrerPolicyHeaderWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN))
+                 .permissionsPolicyHeader(pp -> pp.policy(
+                        "camera=(), microphone=(), geolocation=(), payment=()"));
                 if (!isFramingLocked(frameAncestors)) {
                     h.frameOptions(fo -> fo.disable())
                      .contentSecurityPolicy(csp -> csp.policyDirectives("frame-ancestors " + frameAncestors));

--- a/review-board/backend/src/test/java/com/reviewboard/config/SecurityHeadersIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/config/SecurityHeadersIntegrationTest.java
@@ -1,0 +1,26 @@
+package com.reviewboard.config;
+
+import com.reviewboard.support.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * SEC-13：防御セキュリティヘッダが応答に付与されることを検証する。
+ * （HSTS は HTTPS 応答にのみ付くため MockMvc では検証しない。nginx 側でも別途付与。）
+ */
+class SecurityHeadersIntegrationTest extends AbstractIntegrationTest {
+
+    @Test
+    void security_headers_are_present() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("X-Content-Type-Options", "nosniff"))
+                .andExpect(header().string("Referrer-Policy", "strict-origin-when-cross-origin"))
+                .andExpect(header().string("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=()"))
+                // 既定（埋め込みロック）では X-Frame-Options: DENY を維持する。
+                .andExpect(header().string("X-Frame-Options", "DENY"));
+    }
+}

--- a/review-board/infra/deploy/nginx-review-board-tls.conf
+++ b/review-board/infra/deploy/nginx-review-board-tls.conf
@@ -26,6 +26,16 @@ server {
     # アップロード上限（バックエンドの max-upload-bytes=5MB と整合・余裕を持たせる）。
     client_max_body_size 8m;
 
+    # SEC-13 セキュリティヘッダ（SPA 配信 vhost に付与・全レスポンスに always）。
+    # CSP：自己完結 SPA 想定。style はインライン許容（style 属性を一部使用）、script は同一オリジンのみ。
+    # 画像は署名付き S3(https) と data: を許可。frame-ancestors none で埋め込み拒否（X-Frame-Options と二重）。
+    add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'; font-src 'self' data:" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+
     # React 静的（SPA）。current/dist を指すシンボリックリンク。
     root /var/www/review-board;
     index index.html;

--- a/review-board/infra/deploy/nginx-review-board.conf
+++ b/review-board/infra/deploy/nginx-review-board.conf
@@ -9,6 +9,14 @@ server {
     # アップロード上限（バックエンドの max-upload-bytes=5MB と整合・余裕を持たせる）。
     client_max_body_size 8m;
 
+    # SEC-13 セキュリティヘッダ（SPA 配信 vhost に付与）。HSTS は HTTPS 化（certbot）後に有効。
+    add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'; font-src 'self' data:" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+
     # React 静的（SPA）。current/dist を指すシンボリックリンク。
     root /var/www/review-board;
     index index.html;


### PR DESCRIPTION
## 関連 Issue
Closes #225

## 変更の概要
判定表 **SEC-13**（CSP/HSTS等が N/A）を解消。無料（コードのみ）の堅牢化。

- **backend** `SecurityConfig.headers`：HSTS（1年・includeSubDomains）・Referrer-Policy（strict-origin-when-cross-origin）・Permissions-Policy を無条件付与。X-Content-Type-Options: nosniff は Spring 既定。**埋め込み継ぎ目（frame-ancestors）の条件分岐は維持**。
- **nginx**（TLS版/通常版 vhost）：CSP・HSTS・X-Frame-Options・nosniff・Referrer-Policy・Permissions-Policy を付与。SPA を壊さない CSP（style はインライン許容・script は同一オリジン）。
- `SecurityHeadersIntegrationTest` でヘッダ存在を検証。

## 変更の種別
- [x] feat（SEC-13）

## 動作確認チェックリスト
- [x] backend テスト green（ヘッダ検証・auth・observability 回帰なし）
- [x] 埋め込み継ぎ目（frame-ancestors）の既存挙動を壊していない
- [x] nginx 変更は次回デプロイで反映（CSP は SPA を壊さない範囲）

## レビュー時に特に確認してほしい点
- nginx CSP が本番 SPA を壊さないか（次回デプロイ後に実機確認推奨。HSTS は HTTPS 応答のみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)