### PR TITLE
feat: 認証エンドポイントのレートリミット（総当たり対策）SEC-12

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/RateLimitFilter.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/RateLimitFilter.java
@@ -1,0 +1,121 @@
+package com.reviewboard.domain.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.reviewboard.common.ApiError;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * ★SEC-12：認証エンドポイントの総当たり・列挙対策（軽量な in-memory 固定窓レートリミット）。
+ *
+ * <p>POST /api/auth/{login,register,refresh} に IP 単位で上限を課す。超過は 429（JSON）。
+ * 新規依存を避け、{@link ConcurrentHashMap} の固定窓で実装する。
+ *
+ * <p>制約：単一インスタンス前提（メモリ保持）。多インスタンス化時は共有ストア（Redis 等）が要る。
+ * 本番は nginx の {@code limit_req} と併用して多層化することも可能。
+ *
+ * <p>{@code @Component} の {@link OncePerRequestFilter} は Spring Boot がサーブレットチェーンへ自動登録する。
+ * {@code @Order(HIGHEST_PRECEDENCE)} で Security チェーンより前段に置き、認証処理前に総当たりを弾く。
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class RateLimitFilter extends OncePerRequestFilter {
+
+    private final RateLimitProperties props;
+    private final ObjectMapper objectMapper;
+    private final Map<String, Window> windows = new ConcurrentHashMap<>();
+
+    public RateLimitFilter(RateLimitProperties props, ObjectMapper objectMapper) {
+        this.props = props;
+        this.objectMapper = objectMapper;
+    }
+
+    /** 対象は POST の login/register/refresh のみ。それ以外と無効時は素通し。 */
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        if (!props.enabled() || !"POST".equalsIgnoreCase(request.getMethod())) {
+            return true;
+        }
+        return limitFor(request.getRequestURI()) <= 0;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain chain) throws ServletException, IOException {
+        int limit = limitFor(request.getRequestURI());
+        String key = clientIp(request) + "|" + request.getRequestURI();
+        if (overLimit(key, limit)) {
+            response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+            response.setHeader("Retry-After", String.valueOf(props.windowSeconds()));
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+            objectMapper.writeValue(response.getWriter(),
+                    ApiError.of("RATE_LIMITED", "試行が多すぎます。しばらくしてから再度お試しください。"));
+            return;
+        }
+        chain.doFilter(request, response);
+    }
+
+    /** パスごとの上限（0 以下＝対象外）。 */
+    private int limitFor(String uri) {
+        if (uri == null) {
+            return 0;
+        }
+        return switch (uri) {
+            case "/api/auth/login" -> props.loginMax();
+            case "/api/auth/register" -> props.registerMax();
+            case "/api/auth/refresh" -> props.refreshMax();
+            default -> 0;
+        };
+    }
+
+    /** 固定窓カウント。窓を跨いだらリセット。上限超過なら true。 */
+    private boolean overLimit(String key, int limit) {
+        long now = System.currentTimeMillis();
+        long windowMs = props.windowSeconds() * 1000L;
+        Window w = windows.compute(key, (k, cur) -> {
+            if (cur == null || now - cur.startMs >= windowMs) {
+                return new Window(now);
+            }
+            return cur;
+        });
+        return w.count.incrementAndGet() > limit;
+    }
+
+    /** X-Forwarded-For（nginx 経由）の先頭ホップを優先。無ければ remoteAddr。 */
+    private String clientIp(HttpServletRequest request) {
+        String xff = request.getHeader("X-Forwarded-For");
+        if (xff != null && !xff.isBlank()) {
+            int comma = xff.indexOf(',');
+            return (comma > 0 ? xff.substring(0, comma) : xff).trim();
+        }
+        return request.getRemoteAddr();
+    }
+
+    /** テスト用：窓カウントを全消去（テスト間で状態を持ち越さないため）。 */
+    public void clear() {
+        windows.clear();
+    }
+
+    private static final class Window {
+        final long startMs;
+        final AtomicInteger count = new AtomicInteger(0);
+
+        Window(long startMs) {
+            this.startMs = startMs;
+        }
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/RateLimitProperties.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/RateLimitProperties.java
@@ -1,0 +1,21 @@
+package com.reviewboard.domain.auth;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * 認証エンドポイントのレートリミット設定（application.yml の app.ratelimit.*。SEC-12）。
+ *
+ * @param enabled       有効化（既定 true）。テストでは状態クリアで対応するため無効化はしない。
+ * @param windowSeconds 集計窓（秒）。固定窓。
+ * @param loginMax      窓あたりの /api/auth/login 上限（IP 単位）
+ * @param registerMax   窓あたりの /api/auth/register 上限（IP 単位）
+ * @param refreshMax    窓あたりの /api/auth/refresh 上限（IP 単位）
+ */
+@ConfigurationProperties(prefix = "app.ratelimit")
+public record RateLimitProperties(
+        boolean enabled,
+        int windowSeconds,
+        int loginMax,
+        int registerMax,
+        int refreshMax) {
+}

--- a/review-board/backend/src/main/resources/application.yml
+++ b/review-board/backend/src/main/resources/application.yml
@@ -116,6 +116,13 @@ app:
     viewport-width: 1200
     viewport-height: 750
     timeout-ms: 20000                 # Chrome コールドスタート＋ネットワーク取得の余裕（撮影は非同期）
+  # SEC-12 認証エンドポイントのレートリミット（IP 単位・固定窓・単一インスタンス前提）。
+  ratelimit:
+    enabled: ${RATE_LIMIT_ENABLED:true}
+    window-seconds: 60
+    login-max: 20                     # 20 回/分/IP（誤入力の余地は残しつつ総当たりは抑止）
+    register-max: 10
+    refresh-max: 60
 
 ---
 # dev プロファイル：自動サムネを ON にし、mac の Chrome を既定パスで使う（env で上書き可）。

--- a/review-board/backend/src/test/java/com/reviewboard/domain/auth/RateLimitIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/auth/RateLimitIntegrationTest.java
@@ -1,0 +1,51 @@
+package com.reviewboard.domain.auth;
+
+import com.reviewboard.domain.cohort.Cohort;
+import com.reviewboard.domain.user.UserRole;
+import com.reviewboard.support.AbstractIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * SEC-12：ログイン試行レートリミット。窓内で上限を超えると 429 を返すことを検証する。
+ * （他テストへ影響しないよう、フィルタ状態は AbstractIntegrationTest の @BeforeEach で都度クリア）
+ */
+class RateLimitIntegrationTest extends AbstractIntegrationTest {
+
+    @BeforeEach
+    void seed() {
+        Cohort a = newCohort("A");
+        newUser("rl@example.com", UserRole.STUDENT, a.getId());
+    }
+
+    /** login-max=20。誤パスワードでも試行はカウントされ、上限超過で 429。 */
+    @Test
+    void login_is_rate_limited_after_threshold() throws Exception {
+        String badLogin = "{\"email\":\"rl@example.com\",\"password\":\"wrong-password\"}";
+        // 上限（20）までは 401（認証失敗）。
+        for (int i = 0; i < 20; i++) {
+            mockMvc.perform(post("/api/auth/login").contentType("application/json").content(badLogin))
+                    .andExpect(status().isUnauthorized());
+        }
+        // 21 回目は 429（レートリミット）。
+        mockMvc.perform(post("/api/auth/login").contentType("application/json").content(badLogin))
+                .andExpect(status().isTooManyRequests())
+                .andExpect(header().exists("Retry-After"));
+    }
+
+    /** 正しい資格情報でも、窓内の試行回数として上限を超えれば 429（総当たり後の正答も弾く）。 */
+    @Test
+    void over_limit_blocks_even_valid_credentials() throws Exception {
+        String good = "{\"email\":\"rl@example.com\",\"password\":\"" + PASSWORD + "\"}";
+        for (int i = 0; i < 20; i++) {
+            mockMvc.perform(post("/api/auth/login").contentType("application/json").content(good))
+                    .andExpect(status().isOk());
+        }
+        mockMvc.perform(post("/api/auth/login").contentType("application/json").content(good))
+                .andExpect(status().isTooManyRequests());
+    }
+}

--- a/review-board/backend/src/test/java/com/reviewboard/support/AbstractIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/support/AbstractIntegrationTest.java
@@ -91,10 +91,12 @@ public abstract class AbstractIntegrationTest {
     @Autowired protected RefreshTokenRepository refreshTokenRepository;
     @Autowired protected com.reviewboard.domain.invite.CohortInviteRepository inviteRepository;
     @Autowired protected org.springframework.security.crypto.password.PasswordEncoder passwordEncoder;
+    @Autowired protected com.reviewboard.domain.auth.RateLimitFilter rateLimitFilter;
 
     /** FK 依存順（子 → 親）に全テーブルを掃除する。サブクラスで追加掃除が要れば override 可。 */
     @BeforeEach
     void cleanDatabase() {
+        rateLimitFilter.clear(); // SEC-12 レートリミットの窓をテスト間で持ち越さない
         auditLogRepository.deleteAll();
         notificationRepository.deleteAll();
         replyRepository.deleteAll();


### PR DESCRIPTION
## 関連 Issue
Closes #227

## 変更の概要
判定表 **SEC-12** を解消。新規依存なしの軽量 in-memory 固定窓レートリミット。

- `RateLimitFilter`（`OncePerRequestFilter`・`@Order(HIGHEST_PRECEDENCE)`・`@Component` で Boot 自動登録）が POST `/api/auth/{login,register,refresh}` に **IP 単位**の上限を課す。超過は **429**（JSON・`ApiError` 流用・`Retry-After` 付き）。
- `RateLimitProperties`（`app.ratelimit.*`・既定 enabled=true・window 60s・login 20 / register 10 / refresh 60）。
- **テスト分離**：`AbstractIntegrationTest` の `@BeforeEach` で窓をクリアし全スイートに影響させない。

## 変更の種別
- [x] feat（SEC-12）

## 動作確認チェックリスト
- [x] 全 backend テスト green（`RateLimitIntegrationTest` 含む・回帰なし）
- [x] 上限超過で 429（誤パス/正パスとも）・Retry-After 付与

## レビュー時に特に確認してほしい点
- 単一インスタンス前提のメモリ実装（多インスタンス化時は共有ストア要＝将来）。本番 nginx `limit_req` 併用で多層化可。
- Security チェーンには追加せず Boot 自動登録＋`@Order` 最前段（HttpSecurity のフィルタ順序例外を回避）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)