### PR TITLE
feat: パスワードリセット機能（自己回復・メール経由）

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/config/SecurityConfig.java
+++ b/review-board/backend/src/main/java/com/reviewboard/config/SecurityConfig.java
@@ -71,7 +71,9 @@ public class SecurityConfig {
                 // health は監視プローブ用に開放（liveness/readiness）。
                 .requestMatchers("/actuator/health",
                         "/api/auth/login", "/api/auth/refresh", "/api/auth/logout",
-                        "/api/auth/register").permitAll()
+                        "/api/auth/register",
+                        // B-4 パスワードリセット（#231）。自己回復のため未認証で叩く。
+                        "/api/auth/password-reset/request", "/api/auth/password-reset/confirm").permitAll()
                 // 運用メトリクスは情報漏えいを避けるため運用ロール（講師）限定（SEC-2/SEC-11）。
                 // 誰でも JVM ヒープ・Hikari プール・流量を覗ける状態にしない。
                 .requestMatchers("/actuator/**").hasRole("TEACHER")

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/RateLimitFilter.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/RateLimitFilter.java
@@ -78,6 +78,7 @@ public class RateLimitFilter extends OncePerRequestFilter {
             case "/api/auth/login" -> props.loginMax();
             case "/api/auth/register" -> props.registerMax();
             case "/api/auth/refresh" -> props.refreshMax();
+            case "/api/auth/password-reset/request" -> props.passwordResetMax();
             default -> 0;
         };
     }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/RateLimitProperties.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/RateLimitProperties.java
@@ -10,6 +10,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @param loginMax      窓あたりの /api/auth/login 上限（IP 単位）
  * @param registerMax   窓あたりの /api/auth/register 上限（IP 単位）
  * @param refreshMax    窓あたりの /api/auth/refresh 上限（IP 単位）
+ * @param passwordResetMax 窓あたりの /api/auth/password-reset/request 上限（IP 単位・列挙/送信乱用対策）
  */
 @ConfigurationProperties(prefix = "app.ratelimit")
 public record RateLimitProperties(
@@ -17,5 +18,6 @@ public record RateLimitProperties(
         int windowSeconds,
         int loginMax,
         int registerMax,
-        int refreshMax) {
+        int refreshMax,
+        int passwordResetMax) {
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/passwordreset/PasswordResetController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/passwordreset/PasswordResetController.java
@@ -1,0 +1,41 @@
+package com.reviewboard.domain.passwordreset;
+
+import com.reviewboard.domain.passwordreset.dto.PasswordResetConfirmRequest;
+import com.reviewboard.domain.passwordreset.dto.PasswordResetRequestRequest;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * パスワードリセット API（Issue #231・B-4・公開エンドポイント）。
+ *
+ * <p>request は email 列挙を防ぐため、ユーザーの有無にかかわらず常に 204 を返す。
+ * confirm はトークン検証に失敗すると 400（{@code InvalidRequestException}）。
+ */
+@RestController
+@RequestMapping("/api/auth/password-reset")
+public class PasswordResetController {
+
+    private final PasswordResetService service;
+
+    public PasswordResetController(PasswordResetService service) {
+        this.service = service;
+    }
+
+    /** リセット要求。存在を漏らさないため常に 204（メール送信の有無で挙動を変えない）。 */
+    @PostMapping("/request")
+    public ResponseEntity<Void> request(@Valid @RequestBody PasswordResetRequestRequest body) {
+        service.request(body.email());
+        return ResponseEntity.noContent().build();
+    }
+
+    /** リセット確定。成功で 204、無効/期限切れ/使用済みトークンは 400。 */
+    @PostMapping("/confirm")
+    public ResponseEntity<Void> confirm(@Valid @RequestBody PasswordResetConfirmRequest body) {
+        service.confirm(body.token(), body.password());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/passwordreset/PasswordResetProperties.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/passwordreset/PasswordResetProperties.java
@@ -1,0 +1,13 @@
+package com.reviewboard.domain.passwordreset;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * パスワードリセット設定（application.yml の app.password-reset.*。Issue #231）。
+ *
+ * @param ttlSeconds 発行トークンの有効期間（秒）。短命にして漏洩窓を狭める（既定 1 時間）。
+ */
+@ConfigurationProperties(prefix = "app.password-reset")
+public record PasswordResetProperties(
+        long ttlSeconds) {
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/passwordreset/PasswordResetService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/passwordreset/PasswordResetService.java
@@ -1,0 +1,140 @@
+package com.reviewboard.domain.passwordreset;
+
+import com.reviewboard.common.InvalidRequestException;
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRepository;
+import com.reviewboard.domain.user.UserStatus;
+import com.reviewboard.mail.MailService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.time.OffsetDateTime;
+import java.util.Base64;
+import java.util.HexFormat;
+
+/**
+ * パスワードリセット（Issue #231・B-4）。自己回復フローのオーケストレーション。
+ *
+ * <p>セキュリティ（S軸）：
+ *  <ul>
+ *    <li>生トークンはメールにのみ載せ、DB は SHA-256 ハッシュのみ保持（refresh / invite と同方針）。</li>
+ *    <li>request は <b>存在を漏らさず常に成功扱い</b>（email 列挙を防ぐ）。送信有無で挙動を変えない。</li>
+ *    <li>confirm は 1 度きり：期限切れ・使用済み・未知トークンはすべて 400（区別しない）。</li>
+ *    <li>新パスワード設定時、当該ユーザーの未使用トークンを一括無効化（旧リンク失効）。</li>
+ *  </ul>
+ */
+@Service
+public class PasswordResetService {
+
+    private static final Logger log = LoggerFactory.getLogger(PasswordResetService.class);
+
+    private final PasswordResetTokenRepository repository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final MailService mailService;
+    private final long ttlSeconds;
+    private final SecureRandom random = new SecureRandom();
+
+    public PasswordResetService(PasswordResetTokenRepository repository, UserRepository userRepository,
+                                PasswordEncoder passwordEncoder, MailService mailService,
+                                PasswordResetProperties props) {
+        this.repository = repository;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.mailService = mailService;
+        this.ttlSeconds = props.ttlSeconds();
+    }
+
+    /**
+     * リセット要求。email に紐づくユーザーがいればトークンを発行してメール送信する。
+     * 存在しない／無効化済みでも黙って何もしない（列挙防止のため呼び出し側は常に 200 を返す）。
+     */
+    @Transactional
+    public void request(String email) {
+        String normalizedEmail = email == null ? "" : email.trim().toLowerCase();
+        userRepository.findByEmail(normalizedEmail).ifPresent(user -> {
+            // 無効化（kick・#229）済みアカウントには発行しない（復活経路にしない）。
+            if (user.getStatus() == UserStatus.DISABLED) {
+                return;
+            }
+            // 旧リンクは無効化してから新規発行（同時に複数の有効リンクを残さない）。
+            OffsetDateTime now = OffsetDateTime.now();
+            repository.invalidateActiveByUserId(user.getId(), now);
+
+            String raw = randomToken();
+            PasswordResetToken token = new PasswordResetToken();
+            token.setUserId(user.getId());
+            token.setTokenHash(sha256(raw));
+            token.setCreatedAt(now);
+            token.setExpiresAt(now.plusSeconds(ttlSeconds));
+            repository.save(token);
+
+            sendMail(user, raw);
+        });
+    }
+
+    /**
+     * リセット確定。トークンを検証し、有効なら bcrypt で更新してトークンを消費する。
+     *
+     * @throws InvalidRequestException 未知／期限切れ／使用済みトークン（区別せず 400）
+     */
+    @Transactional
+    public void confirm(String rawToken, String newRawPassword) {
+        PasswordResetToken token = repository.findByTokenHash(sha256(rawToken))
+                .orElseThrow(() -> new InvalidRequestException("リンクが無効か、有効期限が切れています"));
+
+        OffsetDateTime now = OffsetDateTime.now();
+        if (token.getUsedAt() != null || token.getExpiresAt().isBefore(now)) {
+            throw new InvalidRequestException("リンクが無効か、有効期限が切れています");
+        }
+
+        User user = userRepository.findById(token.getUserId())
+                .orElseThrow(() -> new InvalidRequestException("リンクが無効か、有効期限が切れています"));
+
+        user.setPasswordHash(passwordEncoder.encode(newRawPassword));
+        user.setUpdatedAt(now);
+        token.setUsedAt(now);
+    }
+
+    private void sendMail(User user, String rawToken) {
+        String base = mailService.baseUrl();
+        String link = (base == null || base.isBlank())
+                ? "/password-reset?token=" + rawToken
+                : base + "/password-reset?token=" + rawToken;
+        String body = """
+                %s 様
+
+                パスワード再設定のリクエストを受け付けました。
+                以下のリンクから新しいパスワードを設定してください（有効期限: 約%d分）。
+
+                %s
+
+                心当たりがない場合は、このメールを破棄してください。
+                """.formatted(user.getDisplayName(), ttlSeconds / 60, link);
+        // MailService は app.mail.enabled=false なら no-op（ログのみ）。失敗は内部で握りつぶす。
+        mailService.send(user.getEmail(), "【レビューラボ】パスワード再設定のご案内", body);
+        log.debug("password reset token issued userId={}", user.getId());
+    }
+
+    private String randomToken() {
+        byte[] bytes = new byte[32];
+        random.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private String sha256(String value) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] hash = md.digest(value.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash); // 64 文字 hex（password_reset_tokens.token_hash CHAR(64)）
+        } catch (Exception e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/passwordreset/PasswordResetToken.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/passwordreset/PasswordResetToken.java
@@ -1,0 +1,40 @@
+package com.reviewboard.domain.passwordreset;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+
+/**
+ * パスワードリセットトークン（Issue #231・B-4）。
+ * 平文は保存せず SHA-256 ハッシュを保持し、1 度きりで使い捨て（used_at で消費・expires_at で失効）。
+ */
+@Entity
+@Table(name = "password_reset_tokens")
+@Getter
+@Setter
+@NoArgsConstructor
+public class PasswordResetToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "token_hash", nullable = false, unique = true, length = 64)
+    private String tokenHash;
+
+    @Column(name = "expires_at", nullable = false)
+    private OffsetDateTime expiresAt;
+
+    /** 消費済みの時刻。null＝未使用。1 度きりのため confirm 成功時に立てる。 */
+    @Column(name = "used_at")
+    private OffsetDateTime usedAt;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/passwordreset/PasswordResetTokenRepository.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/passwordreset/PasswordResetTokenRepository.java
@@ -1,0 +1,19 @@
+package com.reviewboard.domain.passwordreset;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
+
+    Optional<PasswordResetToken> findByTokenHash(String tokenHash);
+
+    /** 新規発行前に、当該ユーザーの未使用トークンをまとめて消費扱いにする（旧リンクの無効化）。 */
+    @Modifying
+    @Query("UPDATE PasswordResetToken t SET t.usedAt = :now WHERE t.userId = :userId AND t.usedAt IS NULL")
+    int invalidateActiveByUserId(@Param("userId") Long userId, @Param("now") OffsetDateTime now);
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/passwordreset/dto/PasswordResetConfirmRequest.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/passwordreset/dto/PasswordResetConfirmRequest.java
@@ -1,0 +1,10 @@
+package com.reviewboard.domain.passwordreset.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/** パスワードリセット確定（メールで受け取ったトークン + 新パスワード）。 */
+public record PasswordResetConfirmRequest(
+        @NotBlank String token,
+        @NotBlank @Size(min = 8, max = 72) String password) {
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/passwordreset/dto/PasswordResetRequestRequest.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/passwordreset/dto/PasswordResetRequestRequest.java
@@ -1,0 +1,9 @@
+package com.reviewboard.domain.passwordreset.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+/** パスワードリセット要求（email を受け取り、存在を漏らさず常に 200 を返す）。 */
+public record PasswordResetRequestRequest(
+        @NotBlank @Email String email) {
+}

--- a/review-board/backend/src/main/resources/application.yml
+++ b/review-board/backend/src/main/resources/application.yml
@@ -123,6 +123,10 @@ app:
     login-max: 20                     # 20 回/分/IP（誤入力の余地は残しつつ総当たりは抑止）
     register-max: 10
     refresh-max: 60
+    password-reset-max: 5             # 5 回/分/IP（メール送信乱用・email 列挙の抑止。B-4 #231）
+  # B-4 パスワードリセット（#231）。発行トークンは短命にして漏洩窓を狭める。
+  password-reset:
+    ttl-seconds: ${PASSWORD_RESET_TTL_SECONDS:3600}   # 既定 1 時間
 
 ---
 # dev プロファイル：自動サムネを ON にし、mac の Chrome を既定パスで使う（env で上書き可）。

--- a/review-board/backend/src/main/resources/db/migration/V15__add_password_reset_tokens.sql
+++ b/review-board/backend/src/main/resources/db/migration/V15__add_password_reset_tokens.sql
@@ -1,0 +1,18 @@
+-- B-4 パスワードリセット（Issue #231）。ユーザーが自分でパスワードを再設定する自己回復フロー。
+--
+-- セキュリティ（S軸）：
+--  - 生トークンはメールリンクにのみ載せ、DB には SHA-256 hex（CHAR 64）で保存（URL/ログ漏洩耐性・refresh / invite と同方針）。
+--  - 検証は raw 比較ではなく token_hash の UNIQUE lookup で行う（timing 比較なし）。
+--  - 1 度きりの使い捨て：消費時に used_at を立て、再利用は拒否（400）。期限切れ（expires_at）も拒否。
+--  - user 削除時は CASCADE（孤児トークンを残さない）。
+
+CREATE TABLE password_reset_tokens (
+    id         BIGSERIAL   PRIMARY KEY,
+    user_id    BIGINT      NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    token_hash CHAR(64)    NOT NULL UNIQUE,
+    expires_at TIMESTAMPTZ NOT NULL,
+    used_at    TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_password_reset_tokens_user ON password_reset_tokens (user_id);

--- a/review-board/backend/src/test/java/com/reviewboard/domain/passwordreset/PasswordResetIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/passwordreset/PasswordResetIntegrationTest.java
@@ -1,0 +1,145 @@
+package com.reviewboard.domain.passwordreset;
+
+import com.reviewboard.domain.cohort.Cohort;
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRole;
+import com.reviewboard.domain.user.UserStatus;
+import com.reviewboard.mail.MailService;
+import com.reviewboard.support.AbstractIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import java.time.OffsetDateTime;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * B-4 パスワードリセット（#231）。S軸の拒否系（列挙防止・1度きり・期限切れ）を担保する。
+ *
+ * <p>生トークンはメールにのみ載るため、{@link MockitoSpyBean} で {@link MailService} を覗き、
+ * 送信本文のリンクから raw token を取り出して confirm を検証する。
+ */
+class PasswordResetIntegrationTest extends AbstractIntegrationTest {
+
+    @MockitoSpyBean
+    MailService mailService;
+
+    private static final String EMAIL = "reset@example.com";
+    private Long cohortId;
+
+    @BeforeEach
+    void seed() {
+        Cohort a = newCohort("A");
+        cohortId = a.getId();
+        newUser(EMAIL, UserRole.STUDENT, cohortId);
+    }
+
+    /** request 成功 → メール本文のリンクから raw token を取り出す。 */
+    private String requestAndCaptureToken(String email) throws Exception {
+        mockMvc.perform(post("/api/auth/password-reset/request")
+                        .contentType("application/json")
+                        .content("{\"email\":\"" + email + "\"}"))
+                .andExpect(status().isNoContent());
+        ArgumentCaptor<String> body = ArgumentCaptor.forClass(String.class);
+        // @Async なため timeout 付き verify（同期実行されても即マッチ）。
+        verify(mailService, timeout(3000)).send(eq(email), any(), body.capture());
+        Matcher m = Pattern.compile("token=([A-Za-z0-9_-]+)").matcher(body.getValue());
+        assertThat(m.find()).as("メール本文にリセットリンクが含まれる").isTrue();
+        return m.group(1);
+    }
+
+    private void confirm(String token, String newPassword, int expectedStatus) throws Exception {
+        mockMvc.perform(post("/api/auth/password-reset/confirm")
+                        .contentType("application/json")
+                        .content("{\"token\":\"" + token + "\",\"password\":\"" + newPassword + "\"}"))
+                .andExpect(status().is(expectedStatus));
+    }
+
+    private void login(String email, String password, int expectedStatus) throws Exception {
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType("application/json")
+                        .content("{\"email\":\"" + email + "\",\"password\":\"" + password + "\"}"))
+                .andExpect(status().is(expectedStatus));
+    }
+
+    /** 発行 → 確定 → 新パスワードでログイン成功・旧パスワードは失敗（401）。 */
+    @Test
+    void full_flow_resets_password() throws Exception {
+        String token = requestAndCaptureToken(EMAIL);
+        String newPassword = "brand-new-passw0rd";
+
+        confirm(token, newPassword, 204);
+
+        login(EMAIL, newPassword, 200);
+        login(EMAIL, PASSWORD, 401); // 旧パスワードはもう使えない
+    }
+
+    /** 同じトークンは 1 度きり：2 回目の confirm は 400。 */
+    @Test
+    void token_is_single_use() throws Exception {
+        String token = requestAndCaptureToken(EMAIL);
+        confirm(token, "first-new-passw0rd", 204);
+        confirm(token, "second-new-passw0rd", 400);
+    }
+
+    /** 未知のトークンは 400（存在を区別しない）。 */
+    @Test
+    void unknown_token_is_rejected() throws Exception {
+        confirm("totally-unknown-token", "whatever-passw0rd", 400);
+    }
+
+    /** 期限切れトークンは 400。 */
+    @Test
+    void expired_token_is_rejected() throws Exception {
+        String token = requestAndCaptureToken(EMAIL);
+        // DB 上の唯一のトークンを過去に失効させる。
+        PasswordResetToken stored = passwordResetTokenRepository.findAll().get(0);
+        stored.setExpiresAt(OffsetDateTime.now().minusMinutes(1));
+        passwordResetTokenRepository.save(stored);
+
+        confirm(token, "new-after-expiry-pw", 400);
+    }
+
+    /** 存在しない email でも 204（列挙防止）。メールは送らない。 */
+    @Test
+    void unknown_email_still_returns_204_and_sends_no_mail() throws Exception {
+        mockMvc.perform(post("/api/auth/password-reset/request")
+                        .contentType("application/json")
+                        .content("{\"email\":\"nobody@example.com\"}"))
+                .andExpect(status().isNoContent());
+        verify(mailService, never()).send(any(), any(), any());
+    }
+
+    /** 無効化（kick・#229）済みユーザーには発行しない（204 だが復活経路にしない）。 */
+    @Test
+    void disabled_user_gets_no_token() throws Exception {
+        User u = userRepository.findByEmail(EMAIL).orElseThrow();
+        u.setStatus(UserStatus.DISABLED);
+        userRepository.save(u);
+
+        mockMvc.perform(post("/api/auth/password-reset/request")
+                        .contentType("application/json")
+                        .content("{\"email\":\"" + EMAIL + "\"}"))
+                .andExpect(status().isNoContent());
+        verify(mailService, never()).send(any(), any(), any());
+        assertThat(passwordResetTokenRepository.findAll()).isEmpty();
+    }
+
+    /** confirm の新パスワードが短すぎると 400（@Valid・min=8）。 */
+    @Test
+    void too_short_password_is_rejected() throws Exception {
+        String token = requestAndCaptureToken(EMAIL);
+        confirm(token, "short", 400);
+    }
+}

--- a/review-board/backend/src/test/java/com/reviewboard/support/AbstractIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/support/AbstractIntegrationTest.java
@@ -89,6 +89,7 @@ public abstract class AbstractIntegrationTest {
     @Autowired protected NotificationRepository notificationRepository;
     @Autowired protected AuditLogRepository auditLogRepository;
     @Autowired protected RefreshTokenRepository refreshTokenRepository;
+    @Autowired protected com.reviewboard.domain.passwordreset.PasswordResetTokenRepository passwordResetTokenRepository;
     @Autowired protected com.reviewboard.domain.invite.CohortInviteRepository inviteRepository;
     @Autowired protected org.springframework.security.crypto.password.PasswordEncoder passwordEncoder;
     @Autowired protected com.reviewboard.domain.auth.RateLimitFilter rateLimitFilter;
@@ -106,6 +107,7 @@ public abstract class AbstractIntegrationTest {
         reviewRepository.deleteAll();
         postRepository.deleteAll();
         refreshTokenRepository.deleteAll();
+        passwordResetTokenRepository.deleteAll();
         inviteRepository.deleteAll();
         userRepository.deleteAll();
         cohortRepository.deleteAll();

--- a/review-board/frontend/src/App.jsx
+++ b/review-board/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import Header from './components/Header';
 import { APP_NAME } from './constants';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
+import PasswordResetPage from './pages/PasswordResetPage';
 import InvitesPage from './pages/InvitesPage';
 import PostsPage from './pages/PostsPage';
 import NewPostPage from './pages/NewPostPage';
@@ -47,6 +48,7 @@ export default function App() {
       <Routes>
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
+        <Route path="/password-reset" element={<PasswordResetPage />} />
         <Route path="/" element={<Shell><PostsPage /></Shell>} />
         <Route path="/invites" element={<Shell><InvitesPage /></Shell>} />
         <Route path="/posts/new" element={<Shell><NewPostPage /></Shell>} />

--- a/review-board/frontend/src/api/auth.js
+++ b/review-board/frontend/src/api/auth.js
@@ -11,3 +11,10 @@ export const register = (payload) =>
 export const logout = () => client.post('/auth/logout');
 
 export const fetchMe = () => client.get('/auth/me').then((r) => r.data);
+
+// B-4 パスワードリセット（#231・公開）。request は列挙防止のため常に 204（成功）扱い。
+export const requestPasswordReset = (email) =>
+  client.post('/auth/password-reset/request', { email });
+
+export const confirmPasswordReset = (token, password) =>
+  client.post('/auth/password-reset/confirm', { token, password });

--- a/review-board/frontend/src/pages/LoginPage.jsx
+++ b/review-board/frontend/src/pages/LoginPage.jsx
@@ -86,6 +86,12 @@ export default function LoginPage() {
           <button type="submit" disabled={submitting} className="mac-btn-navy w-full py-2.5">
             {submitting ? 'ログイン中…' : 'ログイン'}
           </button>
+
+          <p className="mt-4 text-center text-xs text-gray-400">
+            <Link to="/password-reset" className="font-semibold text-navy-700 hover:underline">
+              パスワードをお忘れですか？
+            </Link>
+          </p>
         </form>
 
         <p className="mt-6 text-center text-xs text-gray-400">

--- a/review-board/frontend/src/pages/PasswordResetPage.jsx
+++ b/review-board/frontend/src/pages/PasswordResetPage.jsx
@@ -1,0 +1,177 @@
+import { useState } from 'react';
+import { Link, useSearchParams, useNavigate } from 'react-router-dom';
+import DolphinIcon from '../components/DolphinIcon';
+import { APP_NAME } from '../constants';
+import { requestPasswordReset, confirmPasswordReset } from '../api/auth';
+
+/**
+ * B-4 パスワードリセット（#231）。
+ * - token クエリなし＝リクエスト画面（email を送る）。列挙防止のため常に「送信しました」を表示。
+ * - token クエリあり＝確定画面（新パスワードを設定）。成功でログインへ誘導。
+ */
+export default function PasswordResetPage() {
+  const [params] = useSearchParams();
+  const token = params.get('token');
+  return (
+    <main className="flex min-h-screen items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        <div className="mb-7 flex flex-col items-center text-center">
+          <div className="mb-3 flex h-16 w-16 items-center justify-center rounded-[20px] bg-[#e8f3ff] shadow-mac ring-1 ring-black/5">
+            <DolphinIcon className="h-12 w-12" />
+          </div>
+          <h1 className="text-2xl font-extrabold tracking-tight text-navy-700">{APP_NAME}</h1>
+          <p className="mt-1 text-sm text-gray-500">パスワードの再設定</p>
+        </div>
+        {token ? <ConfirmForm token={token} /> : <RequestForm />}
+        <p className="mt-6 text-center text-xs text-gray-400">
+          <Link to="/login" className="font-semibold text-navy-700 hover:underline">ログインに戻る</Link>
+        </p>
+      </div>
+    </main>
+  );
+}
+
+/** リクエスト：email を送信。存在を漏らさないため、結果に関わらず同じ確認文を出す。 */
+function RequestForm() {
+  const [email, setEmail] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState(false);
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      await requestPasswordReset(email);
+    } catch {
+      // 列挙防止：失敗（4xx 含む）でも同じ確認文を出す。
+    } finally {
+      setSubmitting(false);
+      setDone(true);
+    }
+  };
+
+  if (done) {
+    return (
+      <div className="mac-card p-7 text-sm text-gray-600">
+        ご登録のメールアドレス宛に、パスワード再設定の手順をお送りしました。
+        メールが届かない場合は、アドレスの誤りや迷惑メールフォルダをご確認ください。
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="mac-card p-7">
+      <p className="mb-4 text-sm text-gray-500">
+        登録済みのメールアドレスを入力してください。再設定用のリンクをお送りします。
+      </p>
+      <label className="mac-label" htmlFor="email">メールアドレス</label>
+      <input
+        id="email"
+        type="email"
+        required
+        autoComplete="email"
+        placeholder="you@example.com"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        className="mac-input mb-6"
+      />
+      <button type="submit" disabled={submitting} className="mac-btn-navy w-full py-2.5">
+        {submitting ? '送信中…' : '再設定リンクを送る'}
+      </button>
+    </form>
+  );
+}
+
+/** 確定：token + 新パスワード。成功でログインへ誘導。期限切れ/使用済みは 400 → 汎用エラー。 */
+function ConfirmForm({ token }) {
+  const navigate = useNavigate();
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState(false);
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    if (password.length < 8) {
+      setError('パスワードは8文字以上で入力してください');
+      return;
+    }
+    if (password !== confirm) {
+      setError('確認用パスワードが一致しません');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await confirmPasswordReset(token, password);
+      setDone(true);
+      setTimeout(() => navigate('/login', { replace: true }), 1800);
+    } catch (err) {
+      setError(
+        err.response?.status === 400
+          ? 'リンクが無効か、有効期限が切れています。お手数ですが再度リクエストしてください。'
+          : '通信に失敗しました',
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (done) {
+    return (
+      <div className="mac-card p-7 text-sm text-gray-600">
+        パスワードを再設定しました。ログイン画面に移動します…
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="mac-card p-7">
+      {error && (
+        <p className="mb-4 rounded-xl border border-red-100 bg-red-50/80 px-3.5 py-2.5 text-sm text-red-600">
+          {error}
+        </p>
+      )}
+      <label className="mac-label" htmlFor="password">新しいパスワード</label>
+      <div className="relative mb-4">
+        <input
+          id="password"
+          type={showPassword ? 'text' : 'password'}
+          required
+          autoComplete="new-password"
+          placeholder="8文字以上"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="mac-input pr-12"
+        />
+        <button
+          type="button"
+          onClick={() => setShowPassword((v) => !v)}
+          aria-label={showPassword ? 'パスワードを隠す' : 'パスワードを表示'}
+          aria-pressed={showPassword}
+          className="absolute right-2 top-1/2 -translate-y-1/2 rounded-lg px-2.5 py-1 text-xs font-semibold text-gray-500 transition hover:bg-black/[0.05] hover:text-navy-700"
+        >
+          {showPassword ? '非表示' : '表示'}
+        </button>
+      </div>
+
+      <label className="mac-label" htmlFor="confirm">新しいパスワード（確認）</label>
+      <input
+        id="confirm"
+        type={showPassword ? 'text' : 'password'}
+        required
+        autoComplete="new-password"
+        placeholder="もう一度入力"
+        value={confirm}
+        onChange={(e) => setConfirm(e.target.value)}
+        className="mac-input mb-6"
+      />
+
+      <button type="submit" disabled={submitting} className="mac-btn-navy w-full py-2.5">
+        {submitting ? '更新中…' : 'パスワードを更新'}
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
## 関連 Issue

Closes #231

---

## 変更の概要

無料ロードマップ **B-4**。ユーザーが自分でパスワードを再設定できる自己回復フローを実装。

- migration **V15** `password_reset_tokens`（token_hash CHAR(64) UNIQUE / user_id / expires_at / used_at）。
- `POST /api/auth/password-reset/request`：email を受け取り、**存在を漏らさず常に 204**（列挙防止）。ユーザーが居ればトークンを発行し `MailService` でメール送信（`app.mail.enabled=false` なら no-op）。
- `POST /api/auth/password-reset/confirm`：token + 新パスワード → 検証 → bcrypt 更新 → トークン消費。未知 / 期限切れ / 使用済みは**区別せず 400**。
- トークンは refresh / invite と同方針で **SHA-256 ハッシュ保存**・1 度きり使い捨て。新発行時に旧トークンを無効化。
- 両エンドポイントを `SecurityConfig` の `permitAll` に追加。`request` を SEC-12 レートリミット対象（5回/分/IP）に。
- 無効化（kick・#229）済みユーザーには発行しない（復活経路にしない）。
- フロント `/password-reset` 画面（token クエリの有無でリクエスト/確定を切替）＋ログイン画面に「パスワードをお忘れですか？」導線。
- TTL は env 駆動（`PASSWORD_RESET_TTL_SECONDS`・既定 1 時間）。

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] backend 全テスト green（`DOCKER_API_VERSION=1.44 ./gradlew test` BUILD SUCCESSFUL）
- [x] frontend `npm run build` 成功 / `npm run lint` エラー0（既存 warning 1 件のみ）
- [x] 拒否系を統合テストで担保：列挙防止(存在しないemail→204・メール無送信) / 1度きり / 期限切れ→400 / 無効化ユーザー無発行 / 短いPW→400 / 発行→確定→新PWログイン成功・旧PW→401
- [x] `.env` ファイルやパスワードをコミットしていない（staged 機密スキャン済み）

---

## 補足

- メール送信は既定 OFF（no-op・ログのみ）。本番で有効化する場合は `MAIL_ENABLED=true` ＋ `spring.mail.*` と `PUBLIC_ORIGIN`（リンクの絶対URL用）が必要。
- 単一インスタンス前提のメモリ・レートリミット方針は既存（SEC-12）どおり。