### PR TITLE
feat: 週次ダイジェストメール＋通知のopt-out設定（#175 follow-up）

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/domain/digest/DigestScheduler.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/digest/DigestScheduler.java
@@ -1,0 +1,26 @@
+package com.reviewboard.domain.digest;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 週次ダイジェストの定期実行（Issue #233・C-5）。既定は毎週月曜 08:00。
+ * cron は {@code app.digest.cron} で上書き可。{@code app.digest.enabled=false} で無効化できる
+ * （テスト・一時停止用）。実処理は {@link DigestService} に委譲する。
+ */
+@Component
+@ConditionalOnProperty(value = "app.digest.enabled", matchIfMissing = true)
+public class DigestScheduler {
+
+    private final DigestService digestService;
+
+    public DigestScheduler(DigestService digestService) {
+        this.digestService = digestService;
+    }
+
+    @Scheduled(cron = "${app.digest.cron:0 0 8 * * MON}")
+    public void runScheduled() {
+        digestService.sendWeeklyDigests();
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/digest/DigestService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/digest/DigestService.java
@@ -1,0 +1,120 @@
+package com.reviewboard.domain.digest;
+
+import com.reviewboard.domain.cohort.Cohort;
+import com.reviewboard.domain.cohort.CohortRepository;
+import com.reviewboard.domain.notification.NotificationRepository;
+import com.reviewboard.domain.notificationpref.NotificationPrefService;
+import com.reviewboard.domain.notificationpref.dto.NotificationPrefResponse;
+import com.reviewboard.domain.post.PostRepository;
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRepository;
+import com.reviewboard.domain.user.UserStatus;
+import com.reviewboard.mail.MailService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 週次ダイジェスト（Issue #233・C-5）。過疎化対策の能動チャネル。
+ *
+ * <p>cohort ごとに「未レビュー成果物（review_count=0）」を集計し、opt-in（weekly_digest かつ
+ * email_enabled）かつ有効な受講生へ MailService で送る。cohort 境界を越えない。
+ * 送る中身（未レビュー or 未読）が無いユーザーには送らない（空メールを出さない）。
+ */
+@Service
+public class DigestService {
+
+    private static final Logger log = LoggerFactory.getLogger(DigestService.class);
+
+    private final CohortRepository cohortRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final NotificationRepository notificationRepository;
+    private final NotificationPrefService prefService;
+    private final MailService mailService;
+    private final String appName;
+
+    public DigestService(CohortRepository cohortRepository, UserRepository userRepository,
+                         PostRepository postRepository, NotificationRepository notificationRepository,
+                         NotificationPrefService prefService, MailService mailService,
+                         @Value("${app.name:レビューラボ}") String appName) {
+        this.cohortRepository = cohortRepository;
+        this.userRepository = userRepository;
+        this.postRepository = postRepository;
+        this.notificationRepository = notificationRepository;
+        this.prefService = prefService;
+        this.mailService = mailService;
+        this.appName = appName;
+    }
+
+    /**
+     * 全 cohort の週次ダイジェストを送る。メール無効時は何もしない。
+     *
+     * @return 送信したメール件数（テスト・運用ログ用）
+     */
+    @Transactional(readOnly = true)
+    public int sendWeeklyDigests() {
+        if (!mailService.enabled()) {
+            log.debug("mail disabled; skip weekly digest");
+            return 0;
+        }
+        int sent = 0;
+        for (Cohort cohort : cohortRepository.findAll()) {
+            int unreviewed = postRepository
+                    .countByCohortIdAndDeletedAtIsNullAndReviewCount(cohort.getId(), 0);
+            List<User> members = userRepository.findByCohortIdAndStatus(cohort.getId(), UserStatus.ACTIVE);
+            if (members.isEmpty()) {
+                continue;
+            }
+            Map<Long, NotificationPrefResponse> prefs =
+                    prefService.effectivePrefs(members.stream().map(User::getId).toList());
+            for (User m : members) {
+                if (!shouldSendDigest(prefs.get(m.getId()))) {
+                    continue;
+                }
+                int unread = notificationRepository.countByRecipientUserIdAndReadAtIsNull(m.getId());
+                if (unreviewed == 0 && unread == 0) {
+                    continue; // 知らせる中身が無ければ送らない
+                }
+                mailService.send(m.getEmail(), subject(), buildBody(appName, m.getDisplayName(),
+                        unreviewed, unread, mailService.baseUrl()));
+                sent++;
+            }
+        }
+        log.info("weekly digest sent count={}", sent);
+        return sent;
+    }
+
+    /** opt-in 判定（純粋関数）：メール ON かつ 週次ダイジェスト ON のときだけ送る。 */
+    static boolean shouldSendDigest(NotificationPrefResponse pref) {
+        return pref != null && pref.emailEnabled() && pref.weeklyDigest();
+    }
+
+    private String subject() {
+        return "【" + appName + "】今週のレビュー状況";
+    }
+
+    /** ダイジェスト本文（純粋関数・単体テスト対象）。 */
+    static String buildBody(String appName, String displayName, int unreviewed, int unread, String baseUrl) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(displayName).append(" さん\n\n");
+        sb.append("今週のレビュー状況をお届けします。\n\n");
+        if (unreviewed > 0) {
+            sb.append("・まだレビューが付いていない成果物が ").append(unreviewed).append(" 件あります。\n");
+            sb.append("  レビューを送って仲間の成長を後押ししましょう。\n");
+        }
+        if (unread > 0) {
+            sb.append("・未読の通知が ").append(unread).append(" 件あります。\n");
+        }
+        if (baseUrl != null && !baseUrl.isBlank()) {
+            sb.append("\n").append(baseUrl).append("\n");
+        }
+        sb.append("\n— ").append(appName);
+        return sb.toString();
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/notification/NotificationService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/notification/NotificationService.java
@@ -29,6 +29,7 @@ public class NotificationService {
     private final UserRepository userRepository;
     private final com.reviewboard.storage.StorageService storageService;
     private final MailService mailService;
+    private final com.reviewboard.domain.notificationpref.NotificationPrefService prefService;
     /** アプリの表示名（メール署名など外向き文面の単一ソース。完全リネームの仕込み）。 */
     private final String appName;
 
@@ -36,11 +37,13 @@ public class NotificationService {
                                UserRepository userRepository,
                                com.reviewboard.storage.StorageService storageService,
                                MailService mailService,
+                               com.reviewboard.domain.notificationpref.NotificationPrefService prefService,
                                @org.springframework.beans.factory.annotation.Value("${app.name:レビューラボ}") String appName) {
         this.notificationRepository = notificationRepository;
         this.userRepository = userRepository;
         this.storageService = storageService;
         this.mailService = mailService;
+        this.prefService = prefService;
         this.appName = appName;
     }
 
@@ -65,7 +68,9 @@ public class NotificationService {
 
         // #175 過疎化対策：核となるイベント（レビューを受け取った）だけ外向きにメールも送る。
         // 無効時（既定）は何もしない。送信は @Async＝この TX をブロックしない・失敗は握りつぶす。
-        if (mailService.enabled() && type == NotificationType.REVIEW_RECEIVED) {
+        // C-5（#233）：受信者が email をオフ（opt-out）にしていたら送らない。
+        if (mailService.enabled() && type == NotificationType.REVIEW_RECEIVED
+                && prefService.isEmailEnabled(recipientUserId)) {
             sendReviewReceivedEmail(recipientUserId, actorUserId, postId);
         }
     }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/notificationpref/NotificationPrefController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/notificationpref/NotificationPrefController.java
@@ -1,0 +1,39 @@
+package com.reviewboard.domain.notificationpref;
+
+import com.reviewboard.domain.auth.AuthPrincipal;
+import com.reviewboard.domain.notificationpref.dto.NotificationPrefResponse;
+import com.reviewboard.domain.notificationpref.dto.NotificationPrefUpdateRequest;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 通知設定 API（Issue #233・C-5）。★S軸：常に「自分の設定」だけを読み書きする（本人限定・他人の設定は触れない）。
+ */
+@RestController
+@RequestMapping("/api/notification-prefs")
+public class NotificationPrefController {
+
+    private final NotificationPrefService service;
+
+    public NotificationPrefController(NotificationPrefService service) {
+        this.service = service;
+    }
+
+    /** 自分の通知設定を取得（行が無ければ既定の全 ON）。 */
+    @GetMapping
+    public NotificationPrefResponse get(@AuthenticationPrincipal AuthPrincipal principal) {
+        return service.get(principal.userId());
+    }
+
+    /** 自分の通知設定を更新。 */
+    @PutMapping
+    public NotificationPrefResponse update(@AuthenticationPrincipal AuthPrincipal principal,
+                                           @Valid @RequestBody NotificationPrefUpdateRequest body) {
+        return service.update(principal.userId(), body.emailEnabled(), body.weeklyDigest());
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/notificationpref/NotificationPrefService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/notificationpref/NotificationPrefService.java
@@ -1,0 +1,71 @@
+package com.reviewboard.domain.notificationpref;
+
+import com.reviewboard.domain.notificationpref.dto.NotificationPrefResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 通知設定の取得・更新（Issue #233・C-5）。
+ *
+ * <p>★方針：行が無いユーザーは「既定（全 ON）」。opt-out したときだけ行を upsert する。
+ * これにより全ユーザーの backfill を避けつつ「未設定＝従来どおり受け取る」を保つ。
+ */
+@Service
+public class NotificationPrefService {
+
+    private final UserNotificationPrefRepository repository;
+
+    public NotificationPrefService(UserNotificationPrefRepository repository) {
+        this.repository = repository;
+    }
+
+    /** 自分の設定を返す（行が無ければ既定）。 */
+    @Transactional(readOnly = true)
+    public NotificationPrefResponse get(Long userId) {
+        return repository.findByUserId(userId)
+                .map(NotificationPrefResponse::from)
+                .orElseGet(NotificationPrefResponse::defaults);
+    }
+
+    /** 自分の設定を upsert する。 */
+    @Transactional
+    public NotificationPrefResponse update(Long userId, boolean emailEnabled, boolean weeklyDigest) {
+        UserNotificationPref pref = repository.findByUserId(userId).orElseGet(() -> {
+            UserNotificationPref p = new UserNotificationPref();
+            p.setUserId(userId);
+            return p;
+        });
+        pref.setEmailEnabled(emailEnabled);
+        pref.setWeeklyDigest(weeklyDigest);
+        pref.setUpdatedAt(OffsetDateTime.now());
+        repository.save(pref);
+        return NotificationPrefResponse.from(pref);
+    }
+
+    /** 個別の外向きメール（レビュー受領など）を送ってよいか。行が無ければ既定 ON。 */
+    @Transactional(readOnly = true)
+    public boolean isEmailEnabled(Long userId) {
+        return repository.findByUserId(userId).map(UserNotificationPref::isEmailEnabled).orElse(true);
+    }
+
+    /**
+     * バッチ用：対象ユーザー群について「(email_enabled, weekly_digest)」の実効値を返す。
+     * 行が無いユーザーは既定（true,true）で埋める。N+1 を避けてまとめ引きする。
+     */
+    @Transactional(readOnly = true)
+    public Map<Long, NotificationPrefResponse> effectivePrefs(Collection<Long> userIds) {
+        Map<Long, NotificationPrefResponse> result = new HashMap<>();
+        for (Long id : userIds) {
+            result.put(id, NotificationPrefResponse.defaults());
+        }
+        for (UserNotificationPref pref : repository.findByUserIdIn(userIds)) {
+            result.put(pref.getUserId(), NotificationPrefResponse.from(pref));
+        }
+        return result;
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/notificationpref/UserNotificationPref.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/notificationpref/UserNotificationPref.java
@@ -1,0 +1,38 @@
+package com.reviewboard.domain.notificationpref;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+
+/**
+ * ユーザーごとの通知設定（Issue #233・C-5）。
+ *
+ * <p>行が無いユーザーは「既定（全 ON）」として扱う（opt-out したときだけ行を作る）。
+ * したがって本エンティティが存在する＝何らかを明示設定した状態。
+ */
+@Entity
+@Table(name = "user_notification_prefs")
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserNotificationPref {
+
+    /** users.id と 1:1（PK 兼 FK）。 */
+    @Id
+    @Column(name = "user_id")
+    private Long userId;
+
+    /** 個別の外向きメール（レビュー受領など）の ON/OFF。 */
+    @Column(name = "email_enabled", nullable = false)
+    private boolean emailEnabled = true;
+
+    /** 週次ダイジェスト（未レビュー成果物の掘り起こし）の ON/OFF。 */
+    @Column(name = "weekly_digest", nullable = false)
+    private boolean weeklyDigest = true;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/notificationpref/UserNotificationPrefRepository.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/notificationpref/UserNotificationPrefRepository.java
@@ -1,0 +1,15 @@
+package com.reviewboard.domain.notificationpref;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface UserNotificationPrefRepository extends JpaRepository<UserNotificationPref, Long> {
+
+    Optional<UserNotificationPref> findByUserId(Long userId);
+
+    /** 週次ダイジェストのバッチ用：対象ユーザー群の設定をまとめ引き（行が無い＝既定 ON）。 */
+    List<UserNotificationPref> findByUserIdIn(Collection<Long> userIds);
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/notificationpref/dto/NotificationPrefResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/notificationpref/dto/NotificationPrefResponse.java
@@ -1,0 +1,15 @@
+package com.reviewboard.domain.notificationpref.dto;
+
+import com.reviewboard.domain.notificationpref.UserNotificationPref;
+
+/** 通知設定のレスポンス。行が無いユーザーは既定（全 ON）を返す。 */
+public record NotificationPrefResponse(boolean emailEnabled, boolean weeklyDigest) {
+
+    public static NotificationPrefResponse defaults() {
+        return new NotificationPrefResponse(true, true);
+    }
+
+    public static NotificationPrefResponse from(UserNotificationPref pref) {
+        return new NotificationPrefResponse(pref.isEmailEnabled(), pref.isWeeklyDigest());
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/notificationpref/dto/NotificationPrefUpdateRequest.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/notificationpref/dto/NotificationPrefUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.reviewboard.domain.notificationpref.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+/** 通知設定の更新リクエスト。両項目とも必須（UI のトグル現在値をそのまま送る）。 */
+public record NotificationPrefUpdateRequest(
+        @NotNull Boolean emailEnabled,
+        @NotNull Boolean weeklyDigest) {
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/PostRepository.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/PostRepository.java
@@ -21,6 +21,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     /** ランディング統計：cohort 内の未削除投稿（集計の母集合）。 */
     List<Post> findByCohortIdAndDeletedAtIsNull(Long cohortId);
 
+    /** 週次ダイジェスト（C-5・#233）：cohort 内の未レビュー（review_count=0）成果物の件数。 */
+    int countByCohortIdAndDeletedAtIsNullAndReviewCount(Long cohortId, int reviewCount);
+
     /**
      * 一覧・検索・絞り込み（F-POST-03 / F-SEARCH-01 / F-FILTER-01）。
      * ★cohort 境界（IDOR 遮断）は常に効かせたまま、任意条件を AND で重ねる。

--- a/review-board/backend/src/main/java/com/reviewboard/domain/user/UserRepository.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/user/UserRepository.java
@@ -20,4 +20,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     /** メンション解決用：同 cohort の全メンバー（越境メンションを防ぐ） */
     List<User> findByCohortId(Long cohortId);
+
+    /** 週次ダイジェスト（C-5・#233）：同 cohort の有効ユーザーのみ（無効化済みには送らない）。 */
+    List<User> findByCohortIdAndStatus(Long cohortId, UserStatus status);
 }

--- a/review-board/backend/src/main/resources/application.yml
+++ b/review-board/backend/src/main/resources/application.yml
@@ -127,6 +127,10 @@ app:
   # B-4 パスワードリセット（#231）。発行トークンは短命にして漏洩窓を狭める。
   password-reset:
     ttl-seconds: ${PASSWORD_RESET_TTL_SECONDS:3600}   # 既定 1 時間
+  # C-5 週次ダイジェスト（#233）。既定 月曜 08:00。メール無効時は no-op。
+  digest:
+    enabled: ${DIGEST_ENABLED:true}
+    cron: ${DIGEST_CRON:0 0 8 * * MON}
 
 ---
 # dev プロファイル：自動サムネを ON にし、mac の Chrome を既定パスで使う（env で上書き可）。

--- a/review-board/backend/src/main/resources/db/migration/V16__add_user_notification_prefs.sql
+++ b/review-board/backend/src/main/resources/db/migration/V16__add_user_notification_prefs.sql
@@ -1,0 +1,14 @@
+-- C-5 通知設定（opt-out）と週次ダイジェスト（Issue #233・#175 follow-up）。
+--
+-- 設計方針：
+--  - 行が無いユーザー＝既定（全 ON）として扱う。opt-out したときだけ行を作る（全ユーザー backfill 不要）。
+--  - email_enabled：レビュー受領など個別の外向きメール全般の ON/OFF。
+--  - weekly_digest：週次ダイジェスト（未レビュー成果物の掘り起こし）の ON/OFF。
+--  - user 削除時は CASCADE（孤児設定を残さない）。
+
+CREATE TABLE user_notification_prefs (
+    user_id       BIGINT      PRIMARY KEY REFERENCES users (id) ON DELETE CASCADE,
+    email_enabled BOOLEAN     NOT NULL DEFAULT true,
+    weekly_digest BOOLEAN     NOT NULL DEFAULT true,
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/review-board/backend/src/test/java/com/reviewboard/domain/digest/DigestBatchIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/digest/DigestBatchIntegrationTest.java
@@ -1,0 +1,151 @@
+package com.reviewboard.domain.digest;
+
+import com.reviewboard.domain.cohort.Cohort;
+import com.reviewboard.domain.post.Post;
+import com.reviewboard.domain.post.RecruitStatus;
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRole;
+import com.reviewboard.domain.user.UserStatus;
+import com.reviewboard.mail.MailService;
+import com.reviewboard.support.AbstractIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+/**
+ * C-5 週次ダイジェスト（#233）。集計の正しさ・opt-out 尊重・cohort 境界を検証する。
+ * メールは {@link MockitoSpyBean} で覗き、{@code enabled()} を true にスタブして送信判定を試す。
+ */
+class DigestBatchIntegrationTest extends AbstractIntegrationTest {
+
+    @MockitoSpyBean
+    MailService mailService;
+
+    @Autowired
+    DigestService digestService;
+
+    @Autowired
+    com.reviewboard.domain.notificationpref.NotificationPrefService prefService;
+
+    private Cohort cohortA;
+    private Cohort cohortB;
+    private User aliceA; // cohort A・既定（opt-in）
+    private User bobA;   // cohort A・opt-out 予定
+
+    @BeforeEach
+    void seed() {
+        doReturn(true).when(mailService).enabled(); // バッチを走らせるため有効化
+        cohortA = newCohort("A");
+        cohortB = newCohort("B");
+        aliceA = newUser("alice@a.example", UserRole.STUDENT, cohortA.getId());
+        bobA = newUser("bob@a.example", UserRole.STUDENT, cohortA.getId());
+    }
+
+    private void newUnreviewedPost(Long authorId, Long cohortId) {
+        OffsetDateTime now = OffsetDateTime.now();
+        Post p = new Post();
+        p.setAuthorUserId(authorId);
+        p.setCohortId(cohortId);
+        p.setTitle("作品");
+        p.setDescription("説明");
+        p.setRecruitStatus(RecruitStatus.OPEN);
+        p.setReviewCount(0); // 未レビュー
+        p.setCreatedAt(now);
+        p.setUpdatedAt(now);
+        postRepository.save(p);
+    }
+
+    /** opt-in ユーザーには、cohort 内の未レビュー件数を載せて送る。opt-out には送らない。 */
+    @Test
+    void sends_to_opted_in_only_with_correct_count() throws Exception {
+        newUnreviewedPost(aliceA.getId(), cohortA.getId());
+        newUnreviewedPost(aliceA.getId(), cohortA.getId()); // cohort A の未レビュー=2
+
+        // bob は週次ダイジェストを opt-out。
+        prefService.update(bobA.getId(), true, false);
+
+        int sent = digestService.sendWeeklyDigests();
+
+        // alice にだけ届く（bob は opt-out）。
+        ArgumentCaptor<String> body = ArgumentCaptor.forClass(String.class);
+        verify(mailService, timeout(3000)).send(eq("alice@a.example"), any(), body.capture());
+        verify(mailService, never()).send(eq("bob@a.example"), any(), any());
+        assertThat(body.getValue()).contains("2 件");
+        assertThat(sent).isEqualTo(1);
+    }
+
+    /** email 全体を opt-out したユーザーには（週次 ON でも）送らない。 */
+    @Test
+    void email_opt_out_suppresses_digest() throws Exception {
+        newUnreviewedPost(aliceA.getId(), cohortA.getId());
+        prefService.update(aliceA.getId(), false, true); // メール全体オフ
+        prefService.update(bobA.getId(), false, true);
+
+        int sent = digestService.sendWeeklyDigests();
+
+        verify(mailService, never()).send(any(), any(), any());
+        assertThat(sent).isZero();
+    }
+
+    /** 送る中身（未レビュー・未読）が無いユーザーには送らない（空メール抑止）。 */
+    @Test
+    void no_content_no_mail() {
+        // 未レビュー投稿なし・未読通知なし。
+        int sent = digestService.sendWeeklyDigests();
+        verify(mailService, never()).send(any(), any(), any());
+        assertThat(sent).isZero();
+    }
+
+    /** cohort 境界：B の未レビューは A のメンバーの集計に混ざらない。 */
+    @Test
+    void cohort_boundary_is_respected() throws Exception {
+        User carolB = newUser("carol@b.example", UserRole.STUDENT, cohortB.getId());
+        newUnreviewedPost(carolB.getId(), cohortB.getId()); // cohort B のみ未レビュー=1
+        // cohort A は未レビュー 0 → A のメンバーには送られない。
+
+        digestService.sendWeeklyDigests();
+
+        verify(mailService, never()).send(eq("alice@a.example"), any(), any());
+        verify(mailService, never()).send(eq("bob@a.example"), any(), any());
+        ArgumentCaptor<String> body = ArgumentCaptor.forClass(String.class);
+        verify(mailService, timeout(3000)).send(eq("carol@b.example"), any(), body.capture());
+        assertThat(body.getValue()).contains("1 件");
+    }
+
+    /** 無効化（kick）済みユーザーには送らない。 */
+    @Test
+    void disabled_user_excluded() {
+        newUnreviewedPost(aliceA.getId(), cohortA.getId());
+        aliceA.setStatus(UserStatus.DISABLED);
+        userRepository.save(aliceA);
+        bobA.setStatus(UserStatus.DISABLED);
+        userRepository.save(bobA);
+
+        int sent = digestService.sendWeeklyDigests();
+        verify(mailService, never()).send(eq("alice@a.example"), any(), any());
+        assertThat(sent).isZero();
+    }
+
+    /** メール無効（既定）なら何もしない。 */
+    @Test
+    void no_op_when_mail_disabled() {
+        doReturn(false).when(mailService).enabled();
+        newUnreviewedPost(aliceA.getId(), cohortA.getId());
+
+        int sent = digestService.sendWeeklyDigests();
+        assertThat(sent).isZero();
+        verify(mailService, never()).send(any(), any(), any());
+    }
+}

--- a/review-board/backend/src/test/java/com/reviewboard/domain/digest/DigestServiceTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/digest/DigestServiceTest.java
@@ -1,0 +1,38 @@
+package com.reviewboard.domain.digest;
+
+import com.reviewboard.domain.notificationpref.dto.NotificationPrefResponse;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * DigestService の純粋ロジック（Spring 不要）。opt-in 判定と本文生成を単体で固める。
+ */
+class DigestServiceTest {
+
+    @Test
+    void shouldSendDigest_requires_both_email_and_weekly_on() {
+        assertThat(DigestService.shouldSendDigest(new NotificationPrefResponse(true, true))).isTrue();
+        assertThat(DigestService.shouldSendDigest(new NotificationPrefResponse(true, false))).isFalse();
+        assertThat(DigestService.shouldSendDigest(new NotificationPrefResponse(false, true))).isFalse();
+        assertThat(DigestService.shouldSendDigest(new NotificationPrefResponse(false, false))).isFalse();
+        assertThat(DigestService.shouldSendDigest(null)).isFalse();
+    }
+
+    @Test
+    void buildBody_includes_counts_and_link() {
+        String body = DigestService.buildBody("レビューラボ", "山田", 3, 2, "https://app.example");
+        assertThat(body).contains("山田 さん");
+        assertThat(body).contains("3 件");      // 未レビュー
+        assertThat(body).contains("2 件");      // 未読通知
+        assertThat(body).contains("https://app.example");
+        assertThat(body).contains("— レビューラボ");
+    }
+
+    @Test
+    void buildBody_omits_unread_line_when_zero() {
+        String body = DigestService.buildBody("レビューラボ", "佐藤", 1, 0, "");
+        assertThat(body).contains("1 件");
+        assertThat(body).doesNotContain("未読の通知");
+    }
+}

--- a/review-board/backend/src/test/java/com/reviewboard/domain/notificationpref/NotificationPrefIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/notificationpref/NotificationPrefIntegrationTest.java
@@ -1,0 +1,84 @@
+package com.reviewboard.domain.notificationpref;
+
+import com.reviewboard.domain.cohort.Cohort;
+import com.reviewboard.domain.user.UserRole;
+import com.reviewboard.support.AbstractIntegrationTest;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * C-5 通知設定 API（#233）。既定（全 ON）・更新の往復・本人限定（独立性）・未認証 401 を検証する。
+ */
+class NotificationPrefIntegrationTest extends AbstractIntegrationTest {
+
+    @BeforeEach
+    void seed() {
+        Cohort a = newCohort("A");
+        newUser("alice@example.com", UserRole.STUDENT, a.getId());
+        newUser("bob@example.com", UserRole.STUDENT, a.getId());
+    }
+
+    /** 行が無いユーザーは既定で全 ON を返す。 */
+    @Test
+    void defaults_when_no_row() throws Exception {
+        Cookie c = login("alice@example.com");
+        mockMvc.perform(get("/api/notification-prefs").cookie(c))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.emailEnabled").value(true))
+                .andExpect(jsonPath("$.weeklyDigest").value(true));
+    }
+
+    /** 更新→取得で反映される。 */
+    @Test
+    void update_then_get_reflects() throws Exception {
+        Cookie c = login("alice@example.com");
+        mockMvc.perform(put("/api/notification-prefs").cookie(c)
+                        .contentType("application/json")
+                        .content("{\"emailEnabled\":false,\"weeklyDigest\":true}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.emailEnabled").value(false))
+                .andExpect(jsonPath("$.weeklyDigest").value(true));
+
+        mockMvc.perform(get("/api/notification-prefs").cookie(c))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.emailEnabled").value(false));
+    }
+
+    /** alice の更新は bob に影響しない（本人限定・設定は独立）。 */
+    @Test
+    void prefs_are_per_user() throws Exception {
+        Cookie alice = login("alice@example.com");
+        mockMvc.perform(put("/api/notification-prefs").cookie(alice)
+                        .contentType("application/json")
+                        .content("{\"emailEnabled\":false,\"weeklyDigest\":false}"))
+                .andExpect(status().isOk());
+
+        Cookie bob = login("bob@example.com");
+        mockMvc.perform(get("/api/notification-prefs").cookie(bob))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.emailEnabled").value(true))
+                .andExpect(jsonPath("$.weeklyDigest").value(true));
+    }
+
+    /** 未認証は 401。 */
+    @Test
+    void unauthenticated_is_401() throws Exception {
+        mockMvc.perform(get("/api/notification-prefs")).andExpect(status().isUnauthorized());
+    }
+
+    /** null フィールドは 400（@NotNull）。 */
+    @Test
+    void null_fields_rejected() throws Exception {
+        Cookie c = login("alice@example.com");
+        mockMvc.perform(put("/api/notification-prefs").cookie(c)
+                        .contentType("application/json")
+                        .content("{\"emailEnabled\":true}"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/review-board/backend/src/test/java/com/reviewboard/support/AbstractIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/support/AbstractIntegrationTest.java
@@ -90,6 +90,7 @@ public abstract class AbstractIntegrationTest {
     @Autowired protected AuditLogRepository auditLogRepository;
     @Autowired protected RefreshTokenRepository refreshTokenRepository;
     @Autowired protected com.reviewboard.domain.passwordreset.PasswordResetTokenRepository passwordResetTokenRepository;
+    @Autowired protected com.reviewboard.domain.notificationpref.UserNotificationPrefRepository notificationPrefRepository;
     @Autowired protected com.reviewboard.domain.invite.CohortInviteRepository inviteRepository;
     @Autowired protected org.springframework.security.crypto.password.PasswordEncoder passwordEncoder;
     @Autowired protected com.reviewboard.domain.auth.RateLimitFilter rateLimitFilter;
@@ -108,6 +109,7 @@ public abstract class AbstractIntegrationTest {
         postRepository.deleteAll();
         refreshTokenRepository.deleteAll();
         passwordResetTokenRepository.deleteAll();
+        notificationPrefRepository.deleteAll();
         inviteRepository.deleteAll();
         userRepository.deleteAll();
         cohortRepository.deleteAll();

--- a/review-board/frontend/src/api/notificationPrefs.js
+++ b/review-board/frontend/src/api/notificationPrefs.js
@@ -1,0 +1,8 @@
+import client from './client';
+
+// C-5（#233）通知設定。常に自分の設定だけを読み書きする（backend が principal で限定）。
+export const fetchNotificationPrefs = () =>
+  client.get('/notification-prefs').then((r) => r.data);
+
+export const updateNotificationPrefs = (prefs) =>
+  client.put('/notification-prefs', prefs).then((r) => r.data);

--- a/review-board/frontend/src/pages/ProfilePage.jsx
+++ b/review-board/frontend/src/pages/ProfilePage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { fetchProfile, updateMyProfile } from '../api/profile';
+import { fetchNotificationPrefs, updateNotificationPrefs } from '../api/notificationPrefs';
 import { ROLE_LABEL, EVAL_LABEL } from '../constants';
 import { useAuth } from '../context/AuthContext';
 import Avatar from '../components/Avatar';
@@ -62,6 +63,8 @@ export default function ProfilePage() {
       )}
 
       {streak && <StreakCard streak={streak} />}
+
+      {isOwn && <NotificationPrefsCard />}
 
       <section>
         <h3 className="mac-h mb-3 text-lg">投稿した成果物（{posts.length}）</h3>
@@ -197,6 +200,90 @@ function Stat({ label, value }) {
     <div className="rounded-xl bg-white/95 p-3 shadow-mac-sm">
       <div className="text-2xl font-extrabold text-navy-700">{value}</div>
       <div className="text-xs text-gray-500">{label}</div>
+    </div>
+  );
+}
+
+// C-5（#233）通知設定：本人のみ表示。メール通知のオフ（opt-out）と週次ダイジェストを切り替える。
+// 変更はトグル操作ごとに即保存し、失敗時は元に戻す（楽観的更新）。
+function NotificationPrefsCard() {
+  const [prefs, setPrefs] = useState(null);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    fetchNotificationPrefs()
+      .then(setPrefs)
+      .catch(() => setError('通知設定を取得できませんでした'))
+      .finally(() => setLoaded(true));
+  }, []);
+
+  const toggle = async (key) => {
+    const next = { ...prefs, [key]: !prefs[key] };
+    setPrefs(next); // 楽観的更新
+    setError('');
+    try {
+      const saved = await updateNotificationPrefs(next);
+      setPrefs(saved);
+    } catch {
+      setPrefs(prefs); // 失敗したら戻す
+      setError('保存に失敗しました');
+    }
+  };
+
+  if (!loaded) return null;
+
+  return (
+    <section className="mac-panel p-5">
+      <h3 className="mac-h mb-1 text-lg">通知設定</h3>
+      <p className="mb-4 text-xs text-gray-500">メールの受け取りを管理できます。</p>
+      {error && <p className="mb-3 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+      {prefs && (
+        <div className="space-y-1">
+          <Toggle
+            label="メール通知"
+            desc="あなたの成果物にレビューが届いたときにメールでお知らせします。"
+            checked={prefs.emailEnabled}
+            onChange={() => toggle('emailEnabled')}
+          />
+          <Toggle
+            label="週次ダイジェスト"
+            desc="レビュー待ちの成果物などを週に1回まとめてお届けします。"
+            checked={prefs.weeklyDigest}
+            disabled={!prefs.emailEnabled}
+            onChange={() => toggle('weeklyDigest')}
+          />
+        </div>
+      )}
+    </section>
+  );
+}
+
+// アクセシブルなトグルスイッチ（role=switch・aria-checked）。
+function Toggle({ label, desc, checked, onChange, disabled = false }) {
+  return (
+    <div className={`flex items-start justify-between gap-4 rounded-xl px-1 py-2.5 ${disabled ? 'opacity-50' : ''}`}>
+      <div className="flex-1">
+        <div className="text-sm font-semibold text-navy-700">{label}</div>
+        <p className="mt-0.5 text-xs text-gray-500">{desc}</p>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        aria-label={label}
+        disabled={disabled}
+        onClick={onChange}
+        className={`relative mt-0.5 inline-flex h-6 w-11 shrink-0 items-center rounded-full transition disabled:cursor-not-allowed ${
+          checked ? 'bg-brand-500' : 'bg-gray-300'
+        }`}
+      >
+        <span
+          className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition ${
+            checked ? 'translate-x-5' : 'translate-x-0.5'
+          }`}
+        />
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## 関連 Issue

Closes #233

---

## 変更の概要

無料ロードマップ **C-5**。#175（メール通知MVP）の follow-up。過疎化対策の外向きチャネルを「週次ダイジェスト」へ拡張し、ユーザーが通知を opt-out できるようにした。

- migration **V16** `user_notification_prefs`（user_id PK/FK・email_enabled・weekly_digest・updated_at）。**行が無い＝既定（全 ON）** として扱い、opt-out 時のみ upsert（全ユーザー backfill 不要・「未設定＝従来どおり受け取る」を維持）。
- `GET /PUT /api/notification-prefs`（**本人限定**・認証必須）。
- `@Scheduled` 週次バッチ `DigestScheduler`（既定 **月曜 08:00**・`app.digest.cron` で上書き・`app.digest.enabled=false` で無効化）。`DigestService` が cohort ごとに未レビュー成果物（review_count=0）を集計し、`email_enabled` かつ `weekly_digest` ON の**有効**ユーザーへ `MailService` 送信。
  - **cohort 境界を越えない** / **無効化（kick）ユーザーは除外** / 知らせる中身（未レビュー・未読）が無ければ送らない（空メール抑止）。
- `NotificationService` の REVIEW_RECEIVED メール送出を `email_enabled` で分岐（**opt-out 尊重**）。
- フロント：プロフィール（本人）に**通知設定UI**（`role=switch`・`aria-checked` 対応トグル・楽観的更新・失敗時ロールバック）。

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] backend 全テスト green（`DOCKER_API_VERSION=1.44 ./gradlew test` BUILD SUCCESSFUL）
- [x] frontend `npm run build` 成功 / `npm run lint` エラー0（既存 warning 1 件のみ）
- [x] 集計の正しさ / cohort 境界 / opt-out（週次・メール全体）/ 無効化ユーザー除外 / 空メール抑止 / メール無効時 no-op / prefs 本人限定・既定ON・401 を統合テストで担保
- [x] opt-in 判定・本文生成は純粋関数化して単体テスト
- [x] `.env` ファイルやパスワードをコミットしていない（staged 機密スキャン済み）

---

## 補足

- 週次ダイジェスト・REVIEW_RECEIVED メールとも、本番で `MAIL_ENABLED=true` ＋ `spring.mail.*`／`PUBLIC_ORIGIN`（リンク用）が無ければ no-op（ログのみ）。既定はこれまで通り送信されない。
- バッチは単一インスタンス前提の単純走査（cohort × メンバー）。規模拡大時はページング/キュー化が将来課題。