### PR TITLE
feat: 二要素認証（TOTP・任意）— MFA

### DIFF
--- a/review-board/backend/build.gradle
+++ b/review-board/backend/build.gradle
@@ -45,6 +45,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+	// C-6 TOTP 二要素認証（#235・任意の MFA）。Apache-2.0・無料。シークレット生成/コード検証/QR を提供。
+	implementation 'dev.samstevens.totp:totp:1.7.1'
 	runtimeOnly 'org.postgresql:postgresql'
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-database-postgresql'

--- a/review-board/backend/src/main/java/com/reviewboard/config/SecurityConfig.java
+++ b/review-board/backend/src/main/java/com/reviewboard/config/SecurityConfig.java
@@ -73,7 +73,9 @@ public class SecurityConfig {
                         "/api/auth/login", "/api/auth/refresh", "/api/auth/logout",
                         "/api/auth/register",
                         // B-4 パスワードリセット（#231）。自己回復のため未認証で叩く。
-                        "/api/auth/password-reset/request", "/api/auth/password-reset/confirm").permitAll()
+                        "/api/auth/password-reset/request", "/api/auth/password-reset/confirm",
+                        // C-6 MFA 2段目（#235）。チャレンジ Cookie ＋ TOTP で認証を完了させる。
+                        "/api/auth/login/mfa").permitAll()
                 // 運用メトリクスは情報漏えいを避けるため運用ロール（講師）限定（SEC-2/SEC-11）。
                 // 誰でも JVM ヒープ・Hikari プール・流量を覗ける状態にしない。
                 .requestMatchers("/actuator/**").hasRole("TEACHER")

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/AuthController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/AuthController.java
@@ -1,8 +1,10 @@
 package com.reviewboard.domain.auth;
 
 import com.reviewboard.domain.auth.dto.LoginRequest;
+import com.reviewboard.domain.auth.dto.MfaRequiredResponse;
 import com.reviewboard.domain.auth.dto.RegisterRequest;
 import com.reviewboard.domain.auth.dto.UserResponse;
+import com.reviewboard.domain.mfa.dto.MfaCodeRequest;
 import com.reviewboard.domain.user.User;
 import com.reviewboard.domain.user.UserRepository;
 import com.reviewboard.storage.StorageService;
@@ -24,20 +26,60 @@ public class AuthController {
     private final AuthCookies cookies;
     private final UserRepository userRepository;
     private final StorageService storageService;
+    private final JwtService jwtService;
 
     public AuthController(AuthService authService, AuthCookies cookies, UserRepository userRepository,
-                          StorageService storageService) {
+                          StorageService storageService, JwtService jwtService) {
         this.authService = authService;
         this.cookies = cookies;
         this.userRepository = userRepository;
         this.storageService = storageService;
+        this.jwtService = jwtService;
     }
 
-    /** F-AUTH-01 ログイン */
+    /**
+     * F-AUTH-01 ログイン（1段目）。MFA（#235）有効ユーザーは access/refresh を出さず、
+     * 短命チャレンジ Cookie を立てて {@code {mfaRequired:true}} を返す（続けて /login/mfa を叩く）。
+     */
     @PostMapping("/login")
-    public ResponseEntity<UserResponse> login(@Valid @RequestBody LoginRequest request) {
+    public ResponseEntity<?> login(@Valid @RequestBody LoginRequest request) {
         AuthService.LoginResult result = authService.login(request.email(), request.password());
+        if (result.mfaRequired()) {
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.SET_COOKIE, cookies.mfa(result.mfaChallengeToken()).toString())
+                    .body(MfaRequiredResponse.required());
+        }
+        return sessionResponse(result, 200);
+    }
+
+    /**
+     * F-AUTH-01 ログイン（2段目・MFA）。チャレンジ Cookie ＋ TOTP コードを検証してセッションを発行する。
+     * チャレンジ欠落・不正・期限切れ・コード不一致はいずれも 401（存在を漏らさない）。
+     */
+    @PostMapping("/login/mfa")
+    public ResponseEntity<?> loginMfa(
+            @CookieValue(name = AuthCookies.MFA, required = false) String mfaToken,
+            @Valid @RequestBody MfaCodeRequest body) {
+        if (mfaToken == null || mfaToken.isBlank()) {
+            throw new BadCredentialsException();
+        }
+        Long userId;
+        try {
+            userId = jwtService.parseMfaChallenge(mfaToken);
+        } catch (io.jsonwebtoken.JwtException e) {
+            throw new BadCredentialsException();
+        }
+        AuthService.LoginResult result = authService.verifyMfaAndLogin(userId, body.code());
         return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookies.access(result.accessToken()).toString())
+                .header(HttpHeaders.SET_COOKIE, cookies.refresh(result.refreshToken()).toString())
+                .header(HttpHeaders.SET_COOKIE, cookies.clearMfa().toString())
+                .body(UserResponse.from(result.user(),
+                        storageService.presignedGetUrl(result.user().getAvatarKey())));
+    }
+
+    private ResponseEntity<UserResponse> sessionResponse(AuthService.LoginResult result, int status) {
+        return ResponseEntity.status(status)
                 .header(HttpHeaders.SET_COOKIE, cookies.access(result.accessToken()).toString())
                 .header(HttpHeaders.SET_COOKIE, cookies.refresh(result.refreshToken()).toString())
                 .body(UserResponse.from(result.user(), storageService.presignedGetUrl(result.user().getAvatarKey())));

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/AuthCookies.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/AuthCookies.java
@@ -13,8 +13,12 @@ public class AuthCookies {
 
     public static final String ACCESS = "access_token";
     public static final String REFRESH = "refresh_token";
-    /** refresh は認証エンドポイントにのみ送られれば十分（露出面を狭める） */
+    /** MFA チャレンジ（パスワード検証済み・TOTP 待ち）の短命 Cookie（#235）。 */
+    public static final String MFA = "mfa_token";
+    /** refresh / mfa は認証エンドポイントにのみ送られれば十分（露出面を狭める） */
     private static final String REFRESH_PATH = "/api/auth";
+    /** MFA チャレンジ Cookie の寿命（秒）。JwtService のチャレンジ寿命と揃える。 */
+    private static final long MFA_MAX_AGE = 300;
 
     private final JwtProperties props;
 
@@ -30,12 +34,21 @@ public class AuthCookies {
         return base(REFRESH, token, REFRESH_PATH, props.refreshTtlSeconds());
     }
 
+    /** MFA チャレンジ Cookie（短命・/api/auth に限定）。 */
+    public ResponseCookie mfa(String token) {
+        return base(MFA, token, REFRESH_PATH, MFA_MAX_AGE);
+    }
+
     public ResponseCookie clearAccess() {
         return base(ACCESS, "", "/", 0);
     }
 
     public ResponseCookie clearRefresh() {
         return base(REFRESH, "", REFRESH_PATH, 0);
+    }
+
+    public ResponseCookie clearMfa() {
+        return base(MFA, "", REFRESH_PATH, 0);
     }
 
     private ResponseCookie base(String name, String value, String path, long maxAgeSeconds) {

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/AuthService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/AuthService.java
@@ -21,15 +21,17 @@ public class AuthService {
     private final JwtService jwtService;
     private final RefreshTokenService refreshTokenService;
     private final InviteService inviteService;
+    private final com.reviewboard.domain.mfa.TotpService totpService;
 
     public AuthService(UserRepository userRepository, PasswordEncoder passwordEncoder,
                        JwtService jwtService, RefreshTokenService refreshTokenService,
-                       InviteService inviteService) {
+                       InviteService inviteService, com.reviewboard.domain.mfa.TotpService totpService) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.jwtService = jwtService;
         this.refreshTokenService = refreshTokenService;
         this.inviteService = inviteService;
+        this.totpService = totpService;
     }
 
     /**
@@ -55,12 +57,13 @@ public class AuthService {
         user.setUpdatedAt(now);
         userRepository.save(user);
 
-        String access = jwtService.issueAccessToken(user.getId(), user.getRole(), user.getCohortId());
-        String refresh = refreshTokenService.issue(user.getId());
-        return new LoginResult(user, access, refresh);
+        return issueSession(user);
     }
 
-    /** F-AUTH-01 ログイン。失敗は存在を漏らさない汎用エラー（BadCredentials）。 */
+    /**
+     * F-AUTH-01 ログイン。失敗は存在を漏らさない汎用エラー（BadCredentials）。
+     * MFA（#235）有効ユーザーはここでは access/refresh を出さず、TOTP 待ちの「チャレンジ」を返す。
+     */
     @Transactional
     public LoginResult login(String email, String rawPassword) {
         User user = userRepository.findByEmail(email).orElseThrow(BadCredentialsException::new);
@@ -71,9 +74,34 @@ public class AuthService {
         if (user.getStatus() == com.reviewboard.domain.user.UserStatus.DISABLED) {
             throw new org.springframework.security.access.AccessDeniedException("このアカウントは無効化されています");
         }
+        // #235 MFA 有効：パスワードは正しいが、まだログインさせない。TOTP 確認のチャレンジを発行する。
+        if (user.isMfaEnabled()) {
+            return LoginResult.mfaRequired(jwtService.issueMfaChallengeToken(user.getId()));
+        }
+        return issueSession(user);
+    }
+
+    /**
+     * F-AUTH-01(2段目) MFA コード検証＋ログイン確定（#235）。
+     * チャレンジから解決した userId と TOTP コードを検証し、成功時に access/refresh を発行する。
+     * 失敗（MFA 無効化済み・コード不一致）は存在を漏らさない汎用エラー（BadCredentials）。
+     */
+    @Transactional
+    public LoginResult verifyMfaAndLogin(Long userId, String code) {
+        User user = userRepository.findById(userId).orElseThrow(BadCredentialsException::new);
+        if (!user.isMfaEnabled() || !totpService.verify(user.getTotpSecret(), code)) {
+            throw new BadCredentialsException();
+        }
+        if (user.getStatus() == com.reviewboard.domain.user.UserStatus.DISABLED) {
+            throw new org.springframework.security.access.AccessDeniedException("このアカウントは無効化されています");
+        }
+        return issueSession(user);
+    }
+
+    private LoginResult issueSession(User user) {
         String access = jwtService.issueAccessToken(user.getId(), user.getRole(), user.getCohortId());
         String refresh = refreshTokenService.issue(user.getId());
-        return new LoginResult(user, access, refresh);
+        return LoginResult.authenticated(user, access, refresh);
     }
 
     /** F-AUTH-(extra) リフレッシュ。rotation + reuse 検知は RefreshTokenService が担う。 */
@@ -94,7 +122,20 @@ public class AuthService {
         }
     }
 
-    public record LoginResult(User user, String accessToken, String refreshToken) {
+    /**
+     * ログイン結果。通常は認証完了（user＋tokens）。MFA 有効時は {@code mfaRequired=true} で
+     * tokens は無く、代わりに {@code mfaChallengeToken}（短命）を持つ。
+     */
+    public record LoginResult(User user, String accessToken, String refreshToken,
+                              boolean mfaRequired, String mfaChallengeToken) {
+
+        static LoginResult authenticated(User user, String access, String refresh) {
+            return new LoginResult(user, access, refresh, false, null);
+        }
+
+        static LoginResult mfaRequired(String challengeToken) {
+            return new LoginResult(null, null, null, true, challengeToken);
+        }
     }
 
     public record RefreshResult(String accessToken, String refreshToken) {

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/JwtService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/JwtService.java
@@ -22,6 +22,9 @@ public class JwtService {
 
     private final SecretKey key;
     private final long accessTtlSeconds;
+    /** MFA チャレンジ（パスワード検証済み・TOTP 待ち）の寿命。短命にして窓を狭める（#235）。 */
+    private static final long MFA_CHALLENGE_TTL_SECONDS = 300; // 5 分
+    private static final String MFA_PURPOSE = "mfa";
 
     public JwtService(JwtProperties props) {
         byte[] secretBytes = props.secret().getBytes(StandardCharsets.UTF_8);
@@ -44,6 +47,37 @@ public class JwtService {
                 .expiration(Date.from(now.plusSeconds(accessTtlSeconds)))
                 .signWith(key)
                 .compact();
+    }
+
+    /**
+     * MFA チャレンジトークンを発行する（#235）。パスワード検証済みだが TOTP 未確認の中間状態を表す。
+     * purpose=mfa の claim を持ち、access/refresh とは用途を分離する（access として使えない）。
+     */
+    public String issueMfaChallengeToken(Long userId) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim("purpose", MFA_PURPOSE)
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plusSeconds(MFA_CHALLENGE_TTL_SECONDS)))
+                .signWith(key)
+                .compact();
+    }
+
+    /**
+     * MFA チャレンジトークンを検証して userId を返す。purpose=mfa でなければ不正。
+     * 署名不正・期限切れ・purpose 不一致は {@link JwtException} で失敗（呼び出し側で 401）。
+     */
+    public Long parseMfaChallenge(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+        if (!MFA_PURPOSE.equals(claims.get("purpose", String.class))) {
+            throw new JwtException("not an mfa challenge token");
+        }
+        return Long.valueOf(claims.getSubject());
     }
 
     /**

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/RateLimitFilter.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/RateLimitFilter.java
@@ -79,6 +79,8 @@ public class RateLimitFilter extends OncePerRequestFilter {
             case "/api/auth/register" -> props.registerMax();
             case "/api/auth/refresh" -> props.refreshMax();
             case "/api/auth/password-reset/request" -> props.passwordResetMax();
+            // C-6（#235）：MFA コードの総当たり対策。login と同じ上限を課す。
+            case "/api/auth/login/mfa" -> props.loginMax();
             default -> 0;
         };
     }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/dto/MfaRequiredResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/dto/MfaRequiredResponse.java
@@ -1,0 +1,9 @@
+package com.reviewboard.domain.auth.dto;
+
+/** ログイン1段目の応答：MFA が必要でまだセッションを発行していないことを示す。 */
+public record MfaRequiredResponse(boolean mfaRequired) {
+
+    public static MfaRequiredResponse required() {
+        return new MfaRequiredResponse(true);
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/dto/UserResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/dto/UserResponse.java
@@ -4,9 +4,11 @@ import com.reviewboard.domain.user.User;
 import com.reviewboard.domain.user.UserRole;
 
 /** 認証後にフロントへ返す最小ユーザー情報（パスワード等は含めない）。avatarUrl は短命署名URL（null可）。 */
-public record UserResponse(Long id, String displayName, UserRole role, Long cohortId, String avatarUrl) {
+public record UserResponse(Long id, String displayName, UserRole role, Long cohortId, String avatarUrl,
+                           boolean mfaEnabled) {
 
     public static UserResponse from(User user, String avatarUrl) {
-        return new UserResponse(user.getId(), user.getDisplayName(), user.getRole(), user.getCohortId(), avatarUrl);
+        return new UserResponse(user.getId(), user.getDisplayName(), user.getRole(), user.getCohortId(), avatarUrl,
+                user.isMfaEnabled());
     }
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/mfa/MfaController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/mfa/MfaController.java
@@ -1,0 +1,49 @@
+package com.reviewboard.domain.mfa;
+
+import com.reviewboard.domain.auth.AuthPrincipal;
+import com.reviewboard.domain.mfa.dto.MfaCodeRequest;
+import com.reviewboard.domain.mfa.dto.MfaSetupResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 二要素認証（TOTP）の設定 API（Issue #235・C-6）。★認証必須＝常に自分のアカウントの MFA を操作する。
+ */
+@RestController
+@RequestMapping("/api/auth/mfa")
+public class MfaController {
+
+    private final MfaService mfaService;
+
+    public MfaController(MfaService mfaService) {
+        this.mfaService = mfaService;
+    }
+
+    /** セットアップ開始：シークレット発行（pending）＋ QR を返す。 */
+    @PostMapping("/setup")
+    public MfaSetupResponse setup(@AuthenticationPrincipal AuthPrincipal principal) {
+        MfaService.SetupResult result = mfaService.setup(principal.userId());
+        return new MfaSetupResponse(result.secret(), result.qrDataUri());
+    }
+
+    /** 有効化：認証アプリのコードで pending シークレットを検証する。 */
+    @PostMapping("/enable")
+    public ResponseEntity<Void> enable(@AuthenticationPrincipal AuthPrincipal principal,
+                                       @Valid @RequestBody MfaCodeRequest body) {
+        mfaService.enable(principal.userId(), body.code());
+        return ResponseEntity.noContent().build();
+    }
+
+    /** 無効化：現在のコードで本人確認してから無効化する。 */
+    @PostMapping("/disable")
+    public ResponseEntity<Void> disable(@AuthenticationPrincipal AuthPrincipal principal,
+                                        @Valid @RequestBody MfaCodeRequest body) {
+        mfaService.disable(principal.userId(), body.code());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/mfa/MfaService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/mfa/MfaService.java
@@ -1,0 +1,86 @@
+package com.reviewboard.domain.mfa;
+
+import com.reviewboard.common.InvalidRequestException;
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 二要素認証（TOTP）の登録・有効化・無効化（Issue #235・C-6）。
+ *
+ * <p>フロー：
+ *  <ol>
+ *    <li>{@link #setup}：シークレットを発行して保存（pending・mfa_enabled=false）。QR を返す。</li>
+ *    <li>{@link #enable}：認証アプリのコードで pending シークレットを検証し、有効化する。</li>
+ *    <li>{@link #disable}：コード検証のうえ無効化し、シークレットを破棄する。</li>
+ *  </ol>
+ */
+@Service
+public class MfaService {
+
+    private final UserRepository userRepository;
+    private final TotpService totpService;
+
+    public MfaService(UserRepository userRepository, TotpService totpService) {
+        this.userRepository = userRepository;
+        this.totpService = totpService;
+    }
+
+    /** TOTP セットアップ開始。新しいシークレットを保存（pending）し、認証アプリ取り込み用の情報を返す。 */
+    @Transactional
+    public SetupResult setup(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalStateException("authenticated user not found"));
+        if (user.isMfaEnabled()) {
+            // 既に有効。二重 setup は禁止（まず disable させる）。
+            throw new InvalidRequestException("二要素認証は既に有効です");
+        }
+        String secret = totpService.generateSecret();
+        user.setTotpSecret(secret);
+        user.setMfaEnabled(false);
+        user.setUpdatedAt(OffsetDateTime.now());
+        String qr = totpService.qrDataUri(secret, user.getEmail());
+        return new SetupResult(secret, qr);
+    }
+
+    /** pending シークレットをコードで検証し、有効化する。コード不一致は 400。 */
+    @Transactional
+    public void enable(Long userId, String code) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalStateException("authenticated user not found"));
+        if (user.isMfaEnabled()) {
+            throw new InvalidRequestException("二要素認証は既に有効です");
+        }
+        if (user.getTotpSecret() == null) {
+            throw new InvalidRequestException("先に二要素認証のセットアップを開始してください");
+        }
+        if (!totpService.verify(user.getTotpSecret(), code)) {
+            throw new InvalidRequestException("コードが正しくありません");
+        }
+        user.setMfaEnabled(true);
+        user.setUpdatedAt(OffsetDateTime.now());
+    }
+
+    /** 無効化。現在のコードで本人確認してから secret を破棄する。コード不一致は 400。 */
+    @Transactional
+    public void disable(Long userId, String code) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalStateException("authenticated user not found"));
+        if (!user.isMfaEnabled()) {
+            throw new InvalidRequestException("二要素認証は有効になっていません");
+        }
+        if (!totpService.verify(user.getTotpSecret(), code)) {
+            throw new InvalidRequestException("コードが正しくありません");
+        }
+        user.setMfaEnabled(false);
+        user.setTotpSecret(null);
+        user.setUpdatedAt(OffsetDateTime.now());
+    }
+
+    /** setup の戻り（生シークレットと QR data URI は setup 応答時にしか返さない）。 */
+    public record SetupResult(String secret, String qrDataUri) {
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/mfa/TotpService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/mfa/TotpService.java
@@ -1,0 +1,68 @@
+package com.reviewboard.domain.mfa;
+
+import dev.samstevens.totp.code.CodeVerifier;
+import dev.samstevens.totp.code.DefaultCodeGenerator;
+import dev.samstevens.totp.code.DefaultCodeVerifier;
+import dev.samstevens.totp.exceptions.QrGenerationException;
+import dev.samstevens.totp.qr.QrData;
+import dev.samstevens.totp.qr.QrGenerator;
+import dev.samstevens.totp.qr.ZxingPngQrGenerator;
+import dev.samstevens.totp.secret.DefaultSecretGenerator;
+import dev.samstevens.totp.secret.SecretGenerator;
+import dev.samstevens.totp.time.SystemTimeProvider;
+import dev.samstevens.totp.util.Utils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * TOTP（RFC 6238）の生成・QR・検証（Issue #235・C-6）。ライブラリ {@code dev.samstevens.totp} の薄いラッパ。
+ *
+ * <p>シークレットは Base32。検証は前後 1 ステップ（±30 秒）の時刻ずれを許容する。
+ */
+@Service
+public class TotpService {
+
+    private final SecretGenerator secretGenerator = new DefaultSecretGenerator();
+    private final QrGenerator qrGenerator = new ZxingPngQrGenerator();
+    private final CodeVerifier codeVerifier;
+    /** otpauth ラベルの issuer（認証アプリ上の表示名）。アプリ名に追従。 */
+    private final String issuer;
+
+    public TotpService(@Value("${app.name:レビューラボ}") String issuer) {
+        this.issuer = issuer;
+        DefaultCodeVerifier verifier = new DefaultCodeVerifier(new DefaultCodeGenerator(), new SystemTimeProvider());
+        verifier.setAllowedTimePeriodDiscrepancy(1); // ±1 ステップ（時刻ずれ許容）
+        this.codeVerifier = verifier;
+    }
+
+    /** 新しい Base32 シークレットを生成する（setup 時に1度だけ）。 */
+    public String generateSecret() {
+        return secretGenerator.generate();
+    }
+
+    /** 認証アプリ取り込み用の QR を data URI（PNG）で返す。 */
+    public String qrDataUri(String secret, String accountLabel) {
+        QrData data = new QrData.Builder()
+                .label(accountLabel)
+                .secret(secret)
+                .issuer(issuer)
+                .algorithm(dev.samstevens.totp.code.HashingAlgorithm.SHA1)
+                .digits(6)
+                .period(30)
+                .build();
+        try {
+            byte[] png = qrGenerator.generate(data);
+            return Utils.getDataUriForImage(png, qrGenerator.getImageMimeType());
+        } catch (QrGenerationException e) {
+            throw new IllegalStateException("QR 生成に失敗しました", e);
+        }
+    }
+
+    /** コードがシークレットに対して有効か（時刻ずれを許容）。secret/ code が null/空なら false。 */
+    public boolean verify(String secret, String code) {
+        if (secret == null || secret.isBlank() || code == null || code.isBlank()) {
+            return false;
+        }
+        return codeVerifier.isValidCode(secret, code.trim());
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/mfa/dto/MfaCodeRequest.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/mfa/dto/MfaCodeRequest.java
@@ -1,0 +1,8 @@
+package com.reviewboard.domain.mfa.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/** TOTP コードの検証リクエスト（enable / disable / login/mfa 共通）。 */
+public record MfaCodeRequest(
+        @NotBlank String code) {
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/mfa/dto/MfaSetupResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/mfa/dto/MfaSetupResponse.java
@@ -1,0 +1,5 @@
+package com.reviewboard.domain.mfa.dto;
+
+/** TOTP セットアップ応答。QR（data URI）と、手入力用のシークレット。setup 応答でのみ返す。 */
+public record MfaSetupResponse(String secret, String qrDataUri) {
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/user/User.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/user/User.java
@@ -51,6 +51,14 @@ public class User {
     @Column(name = "avatar_key", length = 512)
     private String avatarKey;
 
+    /** TOTP シークレット（Base32・#235）。setup 中は値を持つが mfaEnabled=false（pending）。未設定は null。 */
+    @Column(name = "totp_secret", length = 64)
+    private String totpSecret;
+
+    /** 二要素認証（TOTP）が有効か（#235）。true のときだけログインで TOTP を要求する。 */
+    @Column(name = "mfa_enabled", nullable = false)
+    private boolean mfaEnabled = false;
+
     // --- 非正規化カウンタ（書き込みと同一Txで増減 + 定期再計算で補正。母 S-3） ---
     @Column(name = "received_reviews_count", nullable = false)
     private int receivedReviewsCount = 0;

--- a/review-board/backend/src/main/resources/db/migration/V17__add_user_mfa.sql
+++ b/review-board/backend/src/main/resources/db/migration/V17__add_user_mfa.sql
@@ -1,0 +1,10 @@
+-- C-6 二要素認証（TOTP・Issue #235）。任意の MFA。
+--
+-- セキュリティ：
+--  - totp_secret は TOTP 検証のため復号可能な形（Base32）で保持する必要がある（パスワードと異なり一方向化できない）。
+--    現状は MVP として平文保持。将来の本実装では KMS/アプリ層暗号化での at-rest 暗号化を検討（ADR 候補）。
+--  - mfa_enabled=true のときだけログインで TOTP を要求する。setup 中（pending）は secret を持つが enabled=false。
+
+ALTER TABLE users
+    ADD COLUMN totp_secret VARCHAR(64),
+    ADD COLUMN mfa_enabled BOOLEAN NOT NULL DEFAULT false;

--- a/review-board/backend/src/test/java/com/reviewboard/domain/mfa/MfaIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/mfa/MfaIntegrationTest.java
@@ -1,0 +1,170 @@
+package com.reviewboard.domain.mfa;
+
+import com.reviewboard.domain.cohort.Cohort;
+import com.reviewboard.domain.user.UserRole;
+import com.reviewboard.support.AbstractIntegrationTest;
+import com.jayway.jsonpath.JsonPath;
+import dev.samstevens.totp.code.DefaultCodeGenerator;
+import dev.samstevens.totp.time.SystemTimeProvider;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * C-6 二要素認証（TOTP・#235）。setup→enable→2段階ログインの正常系と、拒否系（誤コード・チャレンジ欠落・
+ * 無効ユーザー）を検証する。TOTP コードはライブラリの CodeGenerator で算出する。
+ */
+class MfaIntegrationTest extends AbstractIntegrationTest {
+
+    private static final String EMAIL = "mfa@example.com";
+    private final DefaultCodeGenerator codeGenerator = new DefaultCodeGenerator();
+    private final SystemTimeProvider timeProvider = new SystemTimeProvider();
+
+    @BeforeEach
+    void seed() {
+        Cohort a = newCohort("A");
+        newUser(EMAIL, UserRole.STUDENT, a.getId());
+    }
+
+    private String currentCode(String secret) throws Exception {
+        return codeGenerator.generate(secret, timeProvider.getTime() / 30);
+    }
+
+    /** setup→enable で TOTP を有効化し、生成した secret を返す（access cookie で認証）。 */
+    private String setupAndEnable(Cookie access) throws Exception {
+        MvcResult setup = mockMvc.perform(post("/api/auth/mfa/setup").cookie(access))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.qrDataUri").exists())
+                .andReturn();
+        String secret = JsonPath.read(setup.getResponse().getContentAsString(), "$.secret");
+        assertThat(JsonPath.<String>read(setup.getResponse().getContentAsString(), "$.qrDataUri"))
+                .startsWith("data:image");
+
+        mockMvc.perform(post("/api/auth/mfa/enable").cookie(access)
+                        .contentType("application/json")
+                        .content("{\"code\":\"" + currentCode(secret) + "\"}"))
+                .andExpect(status().isNoContent());
+        return secret;
+    }
+
+    private MvcResult passwordLogin(String email) throws Exception {
+        return mockMvc.perform(post("/api/auth/login")
+                        .contentType("application/json")
+                        .content("{\"email\":\"" + email + "\",\"password\":\"" + PASSWORD + "\"}"))
+                .andReturn();
+    }
+
+    /** 有効化前は従来どおり1段階でログインできる（mfaEnabled=false が応答に出る）。 */
+    @Test
+    void login_is_single_step_when_mfa_disabled() throws Exception {
+        MvcResult res = passwordLogin(EMAIL);
+        assertThat(res.getResponse().getStatus()).isEqualTo(200);
+        assertThat(res.getResponse().getCookie("access_token")).isNotNull();
+        assertThat(JsonPath.<Boolean>read(res.getResponse().getContentAsString(), "$.mfaEnabled")).isFalse();
+    }
+
+    /** 有効化後：password ログインは access を出さず mfaRequired＋チャレンジ Cookie を返す。 */
+    @Test
+    void login_requires_second_factor_after_enable() throws Exception {
+        Cookie access = login(EMAIL);
+        setupAndEnable(access);
+
+        MvcResult res = passwordLogin(EMAIL);
+        assertThat(res.getResponse().getStatus()).isEqualTo(200);
+        assertThat(res.getResponse().getCookie("access_token")).isNull();
+        assertThat(res.getResponse().getCookie("mfa_token")).isNotNull();
+        assertThat(JsonPath.<Boolean>read(res.getResponse().getContentAsString(), "$.mfaRequired")).isTrue();
+    }
+
+    /** 2段階フル：password→正しい TOTP で access が発行される。 */
+    @Test
+    void full_two_step_login_succeeds_with_correct_code() throws Exception {
+        Cookie access = login(EMAIL);
+        String secret = setupAndEnable(access);
+
+        Cookie mfa = passwordLogin(EMAIL).getResponse().getCookie("mfa_token");
+        assertThat(mfa).isNotNull();
+
+        MvcResult res = mockMvc.perform(post("/api/auth/login/mfa").cookie(mfa)
+                        .contentType("application/json")
+                        .content("{\"code\":\"" + currentCode(secret) + "\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mfaEnabled").value(true))
+                .andReturn();
+        assertThat(res.getResponse().getCookie("access_token")).isNotNull();
+    }
+
+    /** 誤った TOTP コードでは 2段目が 401。 */
+    @Test
+    void wrong_code_at_second_step_is_401() throws Exception {
+        Cookie access = login(EMAIL);
+        setupAndEnable(access);
+        Cookie mfa = passwordLogin(EMAIL).getResponse().getCookie("mfa_token");
+
+        mockMvc.perform(post("/api/auth/login/mfa").cookie(mfa)
+                        .contentType("application/json")
+                        .content("{\"code\":\"000000\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    /** チャレンジ Cookie が無いと 2段目は 401。 */
+    @Test
+    void missing_challenge_cookie_is_401() throws Exception {
+        mockMvc.perform(post("/api/auth/login/mfa")
+                        .contentType("application/json")
+                        .content("{\"code\":\"123456\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    /** enable に誤コードを出すと 400（有効化されない）。 */
+    @Test
+    void enable_with_wrong_code_is_400() throws Exception {
+        Cookie access = login(EMAIL);
+        mockMvc.perform(post("/api/auth/mfa/setup").cookie(access)).andExpect(status().isOk());
+        mockMvc.perform(post("/api/auth/mfa/enable").cookie(access)
+                        .contentType("application/json")
+                        .content("{\"code\":\"000000\"}"))
+                .andExpect(status().isBadRequest());
+
+        // 有効化されていないので password ログインは1段階のまま。
+        assertThat(passwordLogin(EMAIL).getResponse().getCookie("access_token")).isNotNull();
+    }
+
+    /** disable 後は1段階ログインに戻る。 */
+    @Test
+    void disable_returns_to_single_step() throws Exception {
+        Cookie access = login(EMAIL);
+        String secret = setupAndEnable(access);
+
+        mockMvc.perform(post("/api/auth/mfa/disable").cookie(access)
+                        .contentType("application/json")
+                        .content("{\"code\":\"" + currentCode(secret) + "\"}"))
+                .andExpect(status().isNoContent());
+
+        MvcResult res = passwordLogin(EMAIL);
+        assertThat(res.getResponse().getStatus()).isEqualTo(200);
+        assertThat(res.getResponse().getCookie("access_token")).isNotNull();
+    }
+
+    /** setup は認証必須（未認証は 401）。 */
+    @Test
+    void setup_requires_auth() throws Exception {
+        mockMvc.perform(post("/api/auth/mfa/setup")).andExpect(status().isUnauthorized());
+    }
+
+    /** /me に mfaEnabled が含まれる。 */
+    @Test
+    void me_exposes_mfa_status() throws Exception {
+        Cookie access = login(EMAIL);
+        mockMvc.perform(get("/api/auth/me").cookie(access))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mfaEnabled").value(false));
+    }
+}

--- a/review-board/frontend/src/api/auth.js
+++ b/review-board/frontend/src/api/auth.js
@@ -12,6 +12,10 @@ export const logout = () => client.post('/auth/logout');
 
 export const fetchMe = () => client.get('/auth/me').then((r) => r.data);
 
+// C-6 MFA（#235）ログイン2段目。チャレンジ Cookie ＋ TOTP コードで認証を完了する。
+export const loginMfa = (code) =>
+  client.post('/auth/login/mfa', { code }).then((r) => r.data);
+
 // B-4 パスワードリセット（#231・公開）。request は列挙防止のため常に 204（成功）扱い。
 export const requestPasswordReset = (email) =>
   client.post('/auth/password-reset/request', { email });

--- a/review-board/frontend/src/api/mfa.js
+++ b/review-board/frontend/src/api/mfa.js
@@ -1,0 +1,8 @@
+import client from './client';
+
+// C-6 二要素認証（TOTP・#235）。常に自分のアカウントの MFA を操作する（認証必須）。
+export const setupMfa = () => client.post('/auth/mfa/setup').then((r) => r.data); // {secret, qrDataUri}
+
+export const enableMfa = (code) => client.post('/auth/mfa/enable', { code });
+
+export const disableMfa = (code) => client.post('/auth/mfa/disable', { code });

--- a/review-board/frontend/src/context/AuthContext.jsx
+++ b/review-board/frontend/src/context/AuthContext.jsx
@@ -18,6 +18,15 @@ export function AuthProvider({ children }) {
 
   const login = useCallback(async (email, password) => {
     const u = await authApi.login(email, password);
+    // C-6（#235）MFA 有効ユーザーはまだログイン未完了（access 無し）。呼び出し側で TOTP を求める。
+    if (u?.mfaRequired) return u;
+    setUser(u);
+    return u;
+  }, []);
+
+  // C-6 MFA ログイン2段目：TOTP コードで確定し、ログイン状態にする。
+  const completeMfaLogin = useCallback(async (code) => {
+    const u = await authApi.loginMfa(code);
     setUser(u);
     return u;
   }, []);
@@ -45,7 +54,7 @@ export function AuthProvider({ children }) {
   }, []);
 
   return (
-    <AuthContext.Provider value={{ user, loading, login, register, logout, refreshUser }}>
+    <AuthContext.Provider value={{ user, loading, login, completeMfaLogin, register, logout, refreshUser }}>
       {children}
     </AuthContext.Provider>
   );

--- a/review-board/frontend/src/pages/LoginPage.jsx
+++ b/review-board/frontend/src/pages/LoginPage.jsx
@@ -5,20 +5,27 @@ import DolphinIcon from '../components/DolphinIcon';
 import { APP_NAME, APP_TAGLINE } from '../constants';
 
 export default function LoginPage() {
-  const { login } = useAuth();
+  const { login, completeMfaLogin } = useAuth();
   const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  // C-6（#235）MFA 2段目：パスワード成功後に TOTP を要求する状態。
+  const [mfaStep, setMfaStep] = useState(false);
+  const [code, setCode] = useState('');
 
   const onSubmit = async (e) => {
     e.preventDefault();
     setError('');
     setSubmitting(true);
     try {
-      await login(email, password);
+      const result = await login(email, password);
+      if (result?.mfaRequired) {
+        setMfaStep(true); // TOTP 入力へ
+        return;
+      }
       navigate('/', { replace: true });
     } catch (err) {
       // 認証失敗は存在を漏らさない汎用メッセージ（backend が 401 を返す）
@@ -27,6 +34,59 @@ export default function LoginPage() {
       setSubmitting(false);
     }
   };
+
+  const onSubmitMfa = async (e) => {
+    e.preventDefault();
+    setError('');
+    setSubmitting(true);
+    try {
+      await completeMfaLogin(code);
+      navigate('/', { replace: true });
+    } catch (err) {
+      setError(err.response?.status === 401 ? '認証コードが正しくありません' : '通信に失敗しました');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (mfaStep) {
+    return (
+      <main className="flex min-h-screen items-center justify-center px-4">
+        <div className="w-full max-w-sm">
+          <div className="mb-7 flex flex-col items-center text-center">
+            <div className="mb-3 flex h-16 w-16 items-center justify-center rounded-[20px] bg-[#e8f3ff] shadow-mac ring-1 ring-black/5">
+              <DolphinIcon className="h-12 w-12" />
+            </div>
+            <h1 className="text-2xl font-extrabold tracking-tight text-navy-700">{APP_NAME}</h1>
+            <p className="mt-1 text-sm text-gray-500">二要素認証</p>
+          </div>
+          <form onSubmit={onSubmitMfa} className="mac-card p-7">
+            {error && (
+              <p className="mb-4 rounded-xl border border-red-100 bg-red-50/80 px-3.5 py-2.5 text-sm text-red-600">
+                {error}
+              </p>
+            )}
+            <label className="mac-label" htmlFor="code">認証アプリの6桁コード</label>
+            <input
+              id="code"
+              type="text"
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              required
+              autoFocus
+              placeholder="123456"
+              value={code}
+              onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+              className="mac-input mb-6 text-center text-lg tracking-[0.4em]"
+            />
+            <button type="submit" disabled={submitting} className="mac-btn-navy w-full py-2.5">
+              {submitting ? '確認中…' : 'ログイン'}
+            </button>
+          </form>
+        </div>
+      </main>
+    );
+  }
 
   return (
     <main className="flex min-h-screen items-center justify-center px-4">

--- a/review-board/frontend/src/pages/ProfilePage.jsx
+++ b/review-board/frontend/src/pages/ProfilePage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { fetchProfile, updateMyProfile } from '../api/profile';
 import { fetchNotificationPrefs, updateNotificationPrefs } from '../api/notificationPrefs';
+import { setupMfa, enableMfa, disableMfa } from '../api/mfa';
 import { ROLE_LABEL, EVAL_LABEL } from '../constants';
 import { useAuth } from '../context/AuthContext';
 import Avatar from '../components/Avatar';
@@ -65,6 +66,8 @@ export default function ProfilePage() {
       {streak && <StreakCard streak={streak} />}
 
       {isOwn && <NotificationPrefsCard />}
+
+      {isOwn && <MfaCard />}
 
       <section>
         <h3 className="mac-h mb-3 text-lg">投稿した成果物（{posts.length}）</h3>
@@ -285,6 +288,125 @@ function Toggle({ label, desc, checked, onChange, disabled = false }) {
         />
       </button>
     </div>
+  );
+}
+
+// C-6（#235）二要素認証（TOTP）設定：本人のみ。setup→QR表示→コードで有効化／コードで無効化。
+function MfaCard() {
+  const { user, refreshUser } = useAuth();
+  const enabled = !!user?.mfaEnabled;
+  const [setup, setSetup] = useState(null); // {secret, qrDataUri}（setup 中のみ）
+  const [code, setCode] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  const startSetup = async () => {
+    setError('');
+    setBusy(true);
+    try {
+      setSetup(await setupMfa());
+    } catch {
+      setError('セットアップを開始できませんでした');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const confirmEnable = async (e) => {
+    e.preventDefault();
+    setError('');
+    setBusy(true);
+    try {
+      await enableMfa(code);
+      await refreshUser();
+      setSetup(null);
+      setCode('');
+    } catch (err) {
+      setError(err.response?.status === 400 ? 'コードが正しくありません' : '有効化に失敗しました');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const confirmDisable = async (e) => {
+    e.preventDefault();
+    setError('');
+    setBusy(true);
+    try {
+      await disableMfa(code);
+      await refreshUser();
+      setCode('');
+    } catch (err) {
+      setError(err.response?.status === 400 ? 'コードが正しくありません' : '無効化に失敗しました');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section className="mac-panel p-5">
+      <div className="mb-1 flex items-center justify-between">
+        <h3 className="mac-h text-lg">二要素認証（2FA）</h3>
+        <span className={`rounded-full px-2.5 py-0.5 text-xs font-semibold ${enabled ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'}`}>
+          {enabled ? '有効' : '無効'}
+        </span>
+      </div>
+      <p className="mb-4 text-xs text-gray-500">
+        認証アプリ（Google Authenticator 等）のワンタイムコードでログインを保護します。
+      </p>
+      {error && <p className="mb-3 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+
+      {/* 無効 & setup 未開始：開始ボタン */}
+      {!enabled && !setup && (
+        <button onClick={startSetup} disabled={busy} className="mac-btn-brand">
+          {busy ? '準備中…' : '二要素認証を設定する'}
+        </button>
+      )}
+
+      {/* setup 中：QR ＋ コード入力で有効化 */}
+      {!enabled && setup && (
+        <form onSubmit={confirmEnable} className="space-y-3">
+          <p className="text-sm text-gray-600">認証アプリで以下の QR コードを読み取ってください。</p>
+          <img src={setup.qrDataUri} alt="TOTP QR コード" className="h-44 w-44 rounded-lg ring-1 ring-black/5" />
+          <p className="break-all text-xs text-gray-400">
+            手入力用キー：<span className="font-mono text-gray-600">{setup.secret}</span>
+          </p>
+          <label className="mac-label" htmlFor="mfa-enable-code">アプリに表示された6桁コード</label>
+          <input
+            id="mfa-enable-code"
+            type="text"
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            placeholder="123456"
+            value={code}
+            onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+            className="mac-input"
+          />
+          <div className="flex gap-2">
+            <button type="button" onClick={() => { setSetup(null); setCode(''); setError(''); }} className="mac-btn-ghost">キャンセル</button>
+            <button type="submit" disabled={busy} className="mac-btn-brand">{busy ? '確認中…' : '有効化する'}</button>
+          </div>
+        </form>
+      )}
+
+      {/* 有効：コード入力で無効化 */}
+      {enabled && (
+        <form onSubmit={confirmDisable} className="space-y-3">
+          <label className="mac-label" htmlFor="mfa-disable-code">無効化するには現在の6桁コードを入力</label>
+          <input
+            id="mfa-disable-code"
+            type="text"
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            placeholder="123456"
+            value={code}
+            onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+            className="mac-input"
+          />
+          <button type="submit" disabled={busy} className="mac-btn-ghost text-red-600">{busy ? '確認中…' : '二要素認証を無効にする'}</button>
+        </form>
+      )}
+    </section>
   );
 }
 


### PR DESCRIPTION
## 関連 Issue

Closes #235

---

## 変更の概要

無料ロードマップ **C-6**（最後・唯一の新規依存）。任意の二要素認証（TOTP）を実装。

- **新規依存**：`dev.samstevens.totp:totp:1.7.1`（Apache-2.0・無料）。`TotpService`（シークレット生成・QR data URI・コード検証 ±1ステップの時刻ずれ許容）。
- migration **V17**：`users.totp_secret`（VARCHAR・null可）/ `users.mfa_enabled`（BOOLEAN・既定 false）。
- **設定API**（認証必須）：`POST /api/auth/mfa/{setup,enable,disable}`。setup＝シークレット発行(pending)＋QR、enable＝コード検証で有効化、disable＝コード検証で無効化＋secret 破棄。
- **2段階ログイン（ステートレス）**：`/api/auth/login` はパスワード検証後、MFA 有効なら access/refresh を出さず**短命チャレンジ JWT（purpose=mfa・5分）**を HttpOnly Cookie で発行し `{mfaRequired:true}` を返す。`/api/auth/login/mfa`（permitAll）でチャレンジ Cookie＋TOTP を検証して access/refresh 発行。失敗は 401・**総当たり対策でレートリミット対象**。
- `UserResponse`・`/me` に `mfaEnabled` を追加。
- フロント：プロフィールに**MFA設定UI**（QR表示→コードで有効化／コードで無効化・状態バッジ）、ログインに**TOTP入力ステップ**（パスワード成功後に2段目へ）。

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] backend 全テスト green（`DOCKER_API_VERSION=1.44 ./gradlew test` BUILD SUCCESSFUL・MFA 11ケース含む）
- [x] frontend `npm run build` 成功 / `npm run lint` エラー0（既存 warning 1 件のみ）
- [x] setup→enable→2段階ログイン正常系／誤コード401・チャレンジ欠落401・enable誤コード400・無効化済み・認証必須401・disable後1段階 を統合テストで担保
- [x] `.env` ・機密をコミットしていない（totp_secret はDB保持・コードには実値なし）

---

## 補足・レビュー観点

- **依存スキャン（Trivy）要確認**：TOTP ライブラリは QR 生成のため `com.google.zxing:core/javase 3.4.0`・`jai-imageio-core 1.4.0` を推移的に持つ（`commons-codec` は Spring 管理で 1.18.0 に解決）。dependency-scan CI で 0 件を確認してください。**もし zxing 系が指摘された場合の代替**：サーバは `otpauth://` URI のみ返し QR をクライアント描画に切替（zxing 依存を除去）できる設計です。
- **totp_secret の at-rest**：TOTP 検証のため復号可能形（Base32）で保持。MVP は平文・将来は KMS/アプリ層暗号化を検討（migration V17 にコメント明記）。
- チャレンジトークンは access/refresh と用途分離（purpose=mfa・access として使えない）。Cookie は HttpOnly+SameSite=Strict・path=/api/auth・5分。