### PR TITLE
feat: 2FA設定にコピーボタン（手入力キー/otpauthリンク）を追加

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/domain/mfa/MfaController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/mfa/MfaController.java
@@ -28,7 +28,7 @@ public class MfaController {
     @PostMapping("/setup")
     public MfaSetupResponse setup(@AuthenticationPrincipal AuthPrincipal principal) {
         MfaService.SetupResult result = mfaService.setup(principal.userId());
-        return new MfaSetupResponse(result.secret(), result.qrDataUri());
+        return new MfaSetupResponse(result.secret(), result.qrDataUri(), result.otpauthUri());
     }
 
     /** 有効化：認証アプリのコードで pending シークレットを検証する。 */

--- a/review-board/backend/src/main/java/com/reviewboard/domain/mfa/MfaService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/mfa/MfaService.java
@@ -43,7 +43,8 @@ public class MfaService {
         user.setMfaEnabled(false);
         user.setUpdatedAt(OffsetDateTime.now());
         String qr = totpService.qrDataUri(secret, user.getEmail());
-        return new SetupResult(secret, qr);
+        String otpauthUri = totpService.otpauthUri(secret, user.getEmail());
+        return new SetupResult(secret, qr, otpauthUri);
     }
 
     /** pending シークレットをコードで検証し、有効化する。コード不一致は 400。 */
@@ -80,7 +81,7 @@ public class MfaService {
         user.setUpdatedAt(OffsetDateTime.now());
     }
 
-    /** setup の戻り（生シークレットと QR data URI は setup 応答時にしか返さない）。 */
-    public record SetupResult(String secret, String qrDataUri) {
+    /** setup の戻り（生シークレット・QR data URI・otpauth URI は setup 応答時にしか返さない）。 */
+    public record SetupResult(String secret, String qrDataUri, String otpauthUri) {
     }
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/mfa/TotpService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/mfa/TotpService.java
@@ -42,7 +42,24 @@ public class TotpService {
 
     /** 認証アプリ取り込み用の QR を data URI（PNG）で返す。 */
     public String qrDataUri(String secret, String accountLabel) {
-        QrData data = new QrData.Builder()
+        try {
+            byte[] png = qrGenerator.generate(qrData(secret, accountLabel));
+            return Utils.getDataUriForImage(png, qrGenerator.getImageMimeType());
+        } catch (QrGenerationException e) {
+            throw new IllegalStateException("QR 生成に失敗しました", e);
+        }
+    }
+
+    /**
+     * QR と同じ内容の otpauth:// URI を返す（#237）。カメラの無いユーザーが、対応する認証アプリ
+     * （デスクトップ版 1Password / Bitwarden 等）へ手入力でなく貼り付けで取り込めるようにする。
+     */
+    public String otpauthUri(String secret, String accountLabel) {
+        return qrData(secret, accountLabel).getUri();
+    }
+
+    private QrData qrData(String secret, String accountLabel) {
+        return new QrData.Builder()
                 .label(accountLabel)
                 .secret(secret)
                 .issuer(issuer)
@@ -50,12 +67,6 @@ public class TotpService {
                 .digits(6)
                 .period(30)
                 .build();
-        try {
-            byte[] png = qrGenerator.generate(data);
-            return Utils.getDataUriForImage(png, qrGenerator.getImageMimeType());
-        } catch (QrGenerationException e) {
-            throw new IllegalStateException("QR 生成に失敗しました", e);
-        }
     }
 
     /** コードがシークレットに対して有効か（時刻ずれを許容）。secret/ code が null/空なら false。 */

--- a/review-board/backend/src/main/java/com/reviewboard/domain/mfa/dto/MfaSetupResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/mfa/dto/MfaSetupResponse.java
@@ -1,5 +1,8 @@
 package com.reviewboard.domain.mfa.dto;
 
-/** TOTP セットアップ応答。QR（data URI）と、手入力用のシークレット。setup 応答でのみ返す。 */
-public record MfaSetupResponse(String secret, String qrDataUri) {
+/**
+ * TOTP セットアップ応答。QR（data URI）・手入力用シークレット・otpauth URI を返す（setup 応答でのみ）。
+ * otpauthUri はカメラの無いユーザーが対応アプリへ貼り付けで取り込むための導線（#237）。
+ */
+public record MfaSetupResponse(String secret, String qrDataUri, String otpauthUri) {
 }

--- a/review-board/backend/src/test/java/com/reviewboard/domain/mfa/MfaIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/mfa/MfaIntegrationTest.java
@@ -43,9 +43,13 @@ class MfaIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.qrDataUri").exists())
                 .andReturn();
-        String secret = JsonPath.read(setup.getResponse().getContentAsString(), "$.secret");
-        assertThat(JsonPath.<String>read(setup.getResponse().getContentAsString(), "$.qrDataUri"))
-                .startsWith("data:image");
+        String body = setup.getResponse().getContentAsString();
+        String secret = JsonPath.read(body, "$.secret");
+        assertThat(JsonPath.<String>read(body, "$.qrDataUri")).startsWith("data:image");
+        // #237 カメラ無しユーザー向け：otpauth URI を返し、貼り付けで取り込めるようにする。
+        assertThat(JsonPath.<String>read(body, "$.otpauthUri"))
+                .startsWith("otpauth://totp/")
+                .contains(secret);
 
         mockMvc.perform(post("/api/auth/mfa/enable").cookie(access)
                         .contentType("application/json")

--- a/review-board/frontend/src/pages/ProfilePage.jsx
+++ b/review-board/frontend/src/pages/ProfilePage.jsx
@@ -295,10 +295,22 @@ function Toggle({ label, desc, checked, onChange, disabled = false }) {
 function MfaCard() {
   const { user, refreshUser } = useAuth();
   const enabled = !!user?.mfaEnabled;
-  const [setup, setSetup] = useState(null); // {secret, qrDataUri}（setup 中のみ）
+  const [setup, setSetup] = useState(null); // {secret, qrDataUri, otpauthUri}（setup 中のみ）
   const [code, setCode] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
+  const [copied, setCopied] = useState(''); // 直近にコピーした項目のラベル（フィードバック用）
+
+  // #237 カメラ無しユーザー向け：手入力の打ち間違い（O/0 等）を避けるためクリップボードへコピー。
+  const copy = async (text, label) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(label);
+      setTimeout(() => setCopied(''), 1500);
+    } catch {
+      setError('コピーできませんでした。手動で選択してコピーしてください。');
+    }
+  };
 
   const startSetup = async () => {
     setError('');
@@ -368,9 +380,33 @@ function MfaCard() {
         <form onSubmit={confirmEnable} className="space-y-3">
           <p className="text-sm text-gray-600">認証アプリで以下の QR コードを読み取ってください。</p>
           <img src={setup.qrDataUri} alt="TOTP QR コード" className="h-44 w-44 rounded-lg ring-1 ring-black/5" />
-          <p className="break-all text-xs text-gray-400">
-            手入力用キー：<span className="font-mono text-gray-600">{setup.secret}</span>
-          </p>
+
+          {/* #237 カメラが無い場合：QR を読まず、キーまたはリンクを貼り付けで取り込む */}
+          <div className="rounded-xl bg-gray-50 p-3 ring-1 ring-black/5">
+            <p className="mb-2 text-xs font-semibold text-gray-600">カメラが無い場合（手入力アプリ向け）</p>
+
+            <div className="mb-2 flex items-center gap-2">
+              <code className="flex-1 break-all rounded-lg bg-white px-2 py-1.5 font-mono text-xs text-gray-700 ring-1 ring-black/5">
+                {setup.secret}
+              </code>
+              <button type="button" onClick={() => copy(setup.secret, 'key')} className="mac-btn-ghost shrink-0 text-xs">
+                {copied === 'key' ? '✓ コピー済' : 'キーをコピー'}
+              </button>
+            </div>
+
+            <button
+              type="button"
+              onClick={() => copy(setup.otpauthUri, 'uri')}
+              className="mac-btn-ghost text-xs"
+            >
+              {copied === 'uri' ? '✓ コピー済' : 'otpauth リンクをコピー'}
+            </button>
+
+            <p className="mt-2 text-[11px] leading-relaxed text-gray-400">
+              キーは大文字の A–Z と 2–7 のみ（数字の 0・1・8・9 は含まれません）。
+              「O」はアルファベットのオーです。手入力より<strong>コピー＆貼り付け</strong>を推奨します。
+            </p>
+          </div>
           <label className="mac-label" htmlFor="mfa-enable-code">アプリに表示された6桁コード</label>
           <input
             id="mfa-enable-code"


### PR DESCRIPTION
## 関連 Issue

Closes #237

---

## 変更の概要

C-6 MFA（#235）follow-up。**QR スキャン用のカメラを持たないユーザー**が、手入力時の **O（オー）/0（ゼロ）取り違え**なく 2FA を登録できるよう、設定画面にコピー機能を追加。

- **backend**: `TotpService.otpauthUri()` を追加（`QrData.getUri()` を再利用・QR と同一内容）。`MfaSetupResponse` / `MfaService.SetupResult` に `otpauthUri` を追加し setup 応答で返す。
- **frontend**: 設定画面（setup 中）に
  - 「**キーをコピー**」ボタン（手入力用キーをクリップボードへ）
  - 「**otpauth リンクをコピー**」ボタン（対応アプリへ貼り付け）
  - 注記：「Base32 は A–Z と 2–7 のみ。0・1・8・9 は無い。O はアルファベット。手入力よりコピー＆貼り付け推奨」
- 既存の QR 表示・有効化・無効化フローは**不変**（貼り付け経路を追加するだけ）。

## 背景

手入力用キーを目視で打つと O/0 を取り違えてコードが一致せず有効化に失敗する事象があった。カメラ無しのデスクトップ認証アプリ（1Password / Bitwarden / Authy desktop 等）はキー/URI の貼り付けで登録できるため、コピー導線で打ち間違いを根本的に無くす。

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] backend MFA テスト green（otpauthUri が `otpauth://totp/` で始まり secret を含むことを追加検証）
- [x] frontend `npm run build` 成功 / `npm run lint` エラー0（既存 warning 1 件のみ）
- [x] 既存の有効化／2段階ログイン／無効化フローは不変
- [x] `.env`・機密をコミットしていない

## スコープ外

- リカバリコード（端末紛失時のバックアップ）は別 Issue。