### PR TITLE
chore: 2FAをQRスキャン一本化（手入力キー/コピー/otpauthリンクを削除）

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/domain/mfa/MfaController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/mfa/MfaController.java
@@ -28,7 +28,7 @@ public class MfaController {
     @PostMapping("/setup")
     public MfaSetupResponse setup(@AuthenticationPrincipal AuthPrincipal principal) {
         MfaService.SetupResult result = mfaService.setup(principal.userId());
-        return new MfaSetupResponse(result.secret(), result.qrDataUri(), result.otpauthUri());
+        return new MfaSetupResponse(result.qrDataUri());
     }
 
     /** 有効化：認証アプリのコードで pending シークレットを検証する。 */

--- a/review-board/backend/src/main/java/com/reviewboard/domain/mfa/MfaService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/mfa/MfaService.java
@@ -42,9 +42,8 @@ public class MfaService {
         user.setTotpSecret(secret);
         user.setMfaEnabled(false);
         user.setUpdatedAt(OffsetDateTime.now());
-        String qr = totpService.qrDataUri(secret, user.getEmail());
-        String otpauthUri = totpService.otpauthUri(secret, user.getEmail());
-        return new SetupResult(secret, qr, otpauthUri);
+        // 生シークレットは返さず QR にのみ内包する（取り込みは QR スキャン一本化・#239）。
+        return new SetupResult(totpService.qrDataUri(secret, user.getEmail()));
     }
 
     /** pending シークレットをコードで検証し、有効化する。コード不一致は 400。 */
@@ -81,7 +80,7 @@ public class MfaService {
         user.setUpdatedAt(OffsetDateTime.now());
     }
 
-    /** setup の戻り（生シークレット・QR data URI・otpauth URI は setup 応答時にしか返さない）。 */
-    public record SetupResult(String secret, String qrDataUri, String otpauthUri) {
+    /** setup の戻り（QR data URI のみ。生シークレットは外に出さない）。 */
+    public record SetupResult(String qrDataUri) {
     }
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/mfa/TotpService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/mfa/TotpService.java
@@ -50,14 +50,6 @@ public class TotpService {
         }
     }
 
-    /**
-     * QR と同じ内容の otpauth:// URI を返す（#237）。カメラの無いユーザーが、対応する認証アプリ
-     * （デスクトップ版 1Password / Bitwarden 等）へ手入力でなく貼り付けで取り込めるようにする。
-     */
-    public String otpauthUri(String secret, String accountLabel) {
-        return qrData(secret, accountLabel).getUri();
-    }
-
     private QrData qrData(String secret, String accountLabel) {
         return new QrData.Builder()
                 .label(accountLabel)

--- a/review-board/backend/src/main/java/com/reviewboard/domain/mfa/dto/MfaSetupResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/mfa/dto/MfaSetupResponse.java
@@ -1,8 +1,8 @@
 package com.reviewboard.domain.mfa.dto;
 
 /**
- * TOTP セットアップ応答。QR（data URI）・手入力用シークレット・otpauth URI を返す（setup 応答でのみ）。
- * otpauthUri はカメラの無いユーザーが対応アプリへ貼り付けで取り込むための導線（#237）。
+ * TOTP セットアップ応答。QR（data URI）のみを返す。
+ * 生シークレットは API では返さない（QR に内包・取り込みは QR スキャン一本化。#239）。
  */
-public record MfaSetupResponse(String secret, String qrDataUri, String otpauthUri) {
+public record MfaSetupResponse(String qrDataUri) {
 }

--- a/review-board/backend/src/test/java/com/reviewboard/domain/mfa/MfaIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/mfa/MfaIntegrationTest.java
@@ -42,14 +42,14 @@ class MfaIntegrationTest extends AbstractIntegrationTest {
         MvcResult setup = mockMvc.perform(post("/api/auth/mfa/setup").cookie(access))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.qrDataUri").exists())
+                // #239 QR 一本化：生シークレット・otpauth URI は API で返さない。
+                .andExpect(jsonPath("$.secret").doesNotExist())
+                .andExpect(jsonPath("$.otpauthUri").doesNotExist())
                 .andReturn();
-        String body = setup.getResponse().getContentAsString();
-        String secret = JsonPath.read(body, "$.secret");
-        assertThat(JsonPath.<String>read(body, "$.qrDataUri")).startsWith("data:image");
-        // #237 カメラ無しユーザー向け：otpauth URI を返し、貼り付けで取り込めるようにする。
-        assertThat(JsonPath.<String>read(body, "$.otpauthUri"))
-                .startsWith("otpauth://totp/")
-                .contains(secret);
+        assertThat(JsonPath.<String>read(setup.getResponse().getContentAsString(), "$.qrDataUri"))
+                .startsWith("data:image");
+        // コード生成用のシークレットは QR に内包される。テストは DB から取得して算出する。
+        String secret = userRepository.findByEmail(EMAIL).orElseThrow().getTotpSecret();
 
         mockMvc.perform(post("/api/auth/mfa/enable").cookie(access)
                         .contentType("application/json")

--- a/review-board/frontend/src/pages/ProfilePage.jsx
+++ b/review-board/frontend/src/pages/ProfilePage.jsx
@@ -295,22 +295,10 @@ function Toggle({ label, desc, checked, onChange, disabled = false }) {
 function MfaCard() {
   const { user, refreshUser } = useAuth();
   const enabled = !!user?.mfaEnabled;
-  const [setup, setSetup] = useState(null); // {secret, qrDataUri, otpauthUri}（setup 中のみ）
+  const [setup, setSetup] = useState(null); // { qrDataUri }（setup 中のみ）
   const [code, setCode] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
-  const [copied, setCopied] = useState(''); // 直近にコピーした項目のラベル（フィードバック用）
-
-  // #237 カメラ無しユーザー向け：手入力の打ち間違い（O/0 等）を避けるためクリップボードへコピー。
-  const copy = async (text, label) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopied(label);
-      setTimeout(() => setCopied(''), 1500);
-    } catch {
-      setError('コピーできませんでした。手動で選択してコピーしてください。');
-    }
-  };
 
   const startSetup = async () => {
     setError('');
@@ -378,35 +366,8 @@ function MfaCard() {
       {/* setup 中：QR ＋ コード入力で有効化 */}
       {!enabled && setup && (
         <form onSubmit={confirmEnable} className="space-y-3">
-          <p className="text-sm text-gray-600">認証アプリで以下の QR コードを読み取ってください。</p>
+          <p className="text-sm text-gray-600">認証アプリ（Google Authenticator 等）で以下の QR コードを読み取ってください。</p>
           <img src={setup.qrDataUri} alt="TOTP QR コード" className="h-44 w-44 rounded-lg ring-1 ring-black/5" />
-
-          {/* #237 カメラが無い場合：QR を読まず、キーまたはリンクを貼り付けで取り込む */}
-          <div className="rounded-xl bg-gray-50 p-3 ring-1 ring-black/5">
-            <p className="mb-2 text-xs font-semibold text-gray-600">カメラが無い場合（手入力アプリ向け）</p>
-
-            <div className="mb-2 flex items-center gap-2">
-              <code className="flex-1 break-all rounded-lg bg-white px-2 py-1.5 font-mono text-xs text-gray-700 ring-1 ring-black/5">
-                {setup.secret}
-              </code>
-              <button type="button" onClick={() => copy(setup.secret, 'key')} className="mac-btn-ghost shrink-0 text-xs">
-                {copied === 'key' ? '✓ コピー済' : 'キーをコピー'}
-              </button>
-            </div>
-
-            <button
-              type="button"
-              onClick={() => copy(setup.otpauthUri, 'uri')}
-              className="mac-btn-ghost text-xs"
-            >
-              {copied === 'uri' ? '✓ コピー済' : 'otpauth リンクをコピー'}
-            </button>
-
-            <p className="mt-2 text-[11px] leading-relaxed text-gray-400">
-              キーは大文字の A–Z と 2–7 のみ（数字の 0・1・8・9 は含まれません）。
-              「O」はアルファベットのオーです。手入力より<strong>コピー＆貼り付け</strong>を推奨します。
-            </p>
-          </div>
           <label className="mac-label" htmlFor="mfa-enable-code">アプリに表示された6桁コード</label>
           <input
             id="mfa-enable-code"


### PR DESCRIPTION
## 関連 Issue

Closes #239

---

## 変更の概要

2FA を認証アプリ（TOTP）に一本化し、取り込み導線を **QR スキャンのみ**に統一。手入力導線（#237/#238 で追加）は誤用されやすく混乱の元だったため削除する。

- **frontend**: 設定画面から削除
  - 「手入力用キー」表示＋「キーをコピー」ボタン
  - 「otpauth リンクをコピー」ボタン
  - O/0 等の注記・「カメラが無い場合」ブロック全体
  - 未使用になる `copy` / `copied` 状態
  - → QR 表示＋6桁コード入力＋有効化/無効化は**不変**
- **backend**（上記でしか使っていないデッドコード除去）
  - `TotpService.otpauthUri()` を削除
  - `MfaSetupResponse` / `MfaService.SetupResult` から `otpauthUri`・`secret` を除去 → **API は生シークレットを返さず QR に内包**（セキュリティ面でも改善）
- **test**: setup 応答に `secret`/`otpauthUri` が**含まれない**ことを検証。TOTP コードは DB の `totp_secret` から生成する方式に変更。

## 変更の種別

- [x] chore（設定・整理）

---

## 動作確認チェックリスト

- [x] backend MFA テスト green（setup→enable→2段階ログイン正常系＋拒否系・secret/otpauthUri 非返却を検証）
- [x] frontend `npm run build` 成功 / `npm run lint` エラー0（既存 warning 1 件のみ・未使用変数の除去確認）
- [x] QR 表示・有効化・無効化・2段階ログインは不変
- [x] `.env`・機密をコミットしていない

## 補足

- 取り込みは QR スキャン一本。カメラの無いデスクトップ認証アプリ利用者は、各アプリの QR 取り込み（画面の QR を読む／スクショ取り込み）で対応可能。