### PR TITLE
feat: MFAリカバリコード（端末紛失時の自己復旧手段）

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/AuthService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/AuthService.java
@@ -22,16 +22,19 @@ public class AuthService {
     private final RefreshTokenService refreshTokenService;
     private final InviteService inviteService;
     private final com.reviewboard.domain.mfa.TotpService totpService;
+    private final com.reviewboard.domain.mfa.RecoveryCodeService recoveryCodeService;
 
     public AuthService(UserRepository userRepository, PasswordEncoder passwordEncoder,
                        JwtService jwtService, RefreshTokenService refreshTokenService,
-                       InviteService inviteService, com.reviewboard.domain.mfa.TotpService totpService) {
+                       InviteService inviteService, com.reviewboard.domain.mfa.TotpService totpService,
+                       com.reviewboard.domain.mfa.RecoveryCodeService recoveryCodeService) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.jwtService = jwtService;
         this.refreshTokenService = refreshTokenService;
         this.inviteService = inviteService;
         this.totpService = totpService;
+        this.recoveryCodeService = recoveryCodeService;
     }
 
     /**
@@ -82,14 +85,20 @@ public class AuthService {
     }
 
     /**
-     * F-AUTH-01(2段目) MFA コード検証＋ログイン確定（#235）。
-     * チャレンジから解決した userId と TOTP コードを検証し、成功時に access/refresh を発行する。
-     * 失敗（MFA 無効化済み・コード不一致）は存在を漏らさない汎用エラー（BadCredentials）。
+     * F-AUTH-01(2段目) MFA コード検証＋ログイン確定（#235・#241）。
+     * チャレンジから解決した userId に対し、まず TOTP を検証し、ダメなら未使用リカバリコードと照合する
+     * （端末紛失時の自己復旧。一致したコードは消費される）。成功時に access/refresh を発行する。
+     * 失敗（MFA 無効化済み・どちらの検証も不一致）は存在を漏らさない汎用エラー（BadCredentials）。
      */
     @Transactional
     public LoginResult verifyMfaAndLogin(Long userId, String code) {
         User user = userRepository.findById(userId).orElseThrow(BadCredentialsException::new);
-        if (!user.isMfaEnabled() || !totpService.verify(user.getTotpSecret(), code)) {
+        if (!user.isMfaEnabled()) {
+            throw new BadCredentialsException();
+        }
+        boolean ok = totpService.verify(user.getTotpSecret(), code)
+                || recoveryCodeService.consume(userId, code);
+        if (!ok) {
             throw new BadCredentialsException();
         }
         if (user.getStatus() == com.reviewboard.domain.user.UserStatus.DISABLED) {

--- a/review-board/backend/src/main/java/com/reviewboard/domain/mfa/MfaController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/mfa/MfaController.java
@@ -2,10 +2,13 @@ package com.reviewboard.domain.mfa;
 
 import com.reviewboard.domain.auth.AuthPrincipal;
 import com.reviewboard.domain.mfa.dto.MfaCodeRequest;
+import com.reviewboard.domain.mfa.dto.MfaRecoveryCodesResponse;
+import com.reviewboard.domain.mfa.dto.MfaRecoveryStatusResponse;
 import com.reviewboard.domain.mfa.dto.MfaSetupResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,19 +34,40 @@ public class MfaController {
         return new MfaSetupResponse(result.qrDataUri());
     }
 
-    /** 有効化：認証アプリのコードで pending シークレットを検証する。 */
+    /**
+     * 有効化：認証アプリのコードで pending シークレットを検証する。
+     * 成功時、リカバリコード（生）を1度だけ返す（#241・端末紛失時の自己復旧手段）。
+     */
     @PostMapping("/enable")
-    public ResponseEntity<Void> enable(@AuthenticationPrincipal AuthPrincipal principal,
-                                       @Valid @RequestBody MfaCodeRequest body) {
-        mfaService.enable(principal.userId(), body.code());
-        return ResponseEntity.noContent().build();
+    public MfaRecoveryCodesResponse enable(@AuthenticationPrincipal AuthPrincipal principal,
+                                           @Valid @RequestBody MfaCodeRequest body) {
+        return new MfaRecoveryCodesResponse(mfaService.enable(principal.userId(), body.code()));
     }
 
-    /** 無効化：現在のコードで本人確認してから無効化する。 */
+    /** 無効化：現在のコードで本人確認してから無効化する（リカバリコードも全削除）。 */
     @PostMapping("/disable")
     public ResponseEntity<Void> disable(@AuthenticationPrincipal AuthPrincipal principal,
                                         @Valid @RequestBody MfaCodeRequest body) {
         mfaService.disable(principal.userId(), body.code());
         return ResponseEntity.noContent().build();
+    }
+
+    /** リカバリコードの残数（#241）。MFA 有効時のみ意味を持つ。 */
+    @GetMapping("/recovery-codes")
+    public MfaRecoveryStatusResponse recoveryStatus(@AuthenticationPrincipal AuthPrincipal principal) {
+        return new MfaRecoveryStatusResponse(
+                mfaService.remainingRecoveryCodes(principal.userId()),
+                RecoveryCodeService.LOW_REMAINING_THRESHOLD);
+    }
+
+    /**
+     * リカバリコードの再生成（#241）。現在の TOTP コードで本人確認し、旧コードを全破棄して新規発行する。
+     * 新しい生コードを1度だけ返す。
+     */
+    @PostMapping("/recovery-codes/regenerate")
+    public MfaRecoveryCodesResponse regenerateRecoveryCodes(@AuthenticationPrincipal AuthPrincipal principal,
+                                                            @Valid @RequestBody MfaCodeRequest body) {
+        return new MfaRecoveryCodesResponse(
+                mfaService.regenerateRecoveryCodes(principal.userId(), body.code()));
     }
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/mfa/MfaRecoveryCode.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/mfa/MfaRecoveryCode.java
@@ -1,0 +1,38 @@
+package com.reviewboard.domain.mfa;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+
+/**
+ * MFA リカバリコード（Issue #241）。認証アプリ／端末紛失時の自己復旧手段。
+ *
+ * <p>生コードは保存せず SHA-256 ハッシュのみ保持（refresh / invite / password-reset と同方針）。
+ * 1 度きりの使い捨て：ログイン2段目で一致したら {@code usedAt} を立てて以後拒否する。
+ */
+@Entity
+@Table(name = "mfa_recovery_codes")
+@Getter
+@Setter
+@NoArgsConstructor
+public class MfaRecoveryCode {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "code_hash", nullable = false, unique = true, length = 64)
+    private String codeHash;
+
+    @Column(name = "used_at")
+    private OffsetDateTime usedAt;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/mfa/MfaRecoveryCodeRepository.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/mfa/MfaRecoveryCodeRepository.java
@@ -1,0 +1,20 @@
+package com.reviewboard.domain.mfa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MfaRecoveryCodeRepository extends JpaRepository<MfaRecoveryCode, Long> {
+
+    /** ハッシュで1件引く（ログイン2段目の照合）。 */
+    Optional<MfaRecoveryCode> findByCodeHash(String codeHash);
+
+    /** 当該ユーザーの未使用コード数（残数表示・警告判定）。 */
+    long countByUserIdAndUsedAtIsNull(Long userId);
+
+    /** 当該ユーザーの全コード（regenerate / disable で破棄）。 */
+    List<MfaRecoveryCode> findAllByUserId(Long userId);
+
+    void deleteAllByUserId(Long userId);
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/mfa/MfaService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/mfa/MfaService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 
 /**
  * 二要素認証（TOTP）の登録・有効化・無効化（Issue #235・C-6）。
@@ -23,10 +24,13 @@ public class MfaService {
 
     private final UserRepository userRepository;
     private final TotpService totpService;
+    private final RecoveryCodeService recoveryCodeService;
 
-    public MfaService(UserRepository userRepository, TotpService totpService) {
+    public MfaService(UserRepository userRepository, TotpService totpService,
+                      RecoveryCodeService recoveryCodeService) {
         this.userRepository = userRepository;
         this.totpService = totpService;
+        this.recoveryCodeService = recoveryCodeService;
     }
 
     /** TOTP セットアップ開始。新しいシークレットを保存（pending）し、認証アプリ取り込み用の情報を返す。 */
@@ -46,9 +50,12 @@ public class MfaService {
         return new SetupResult(totpService.qrDataUri(secret, user.getEmail()));
     }
 
-    /** pending シークレットをコードで検証し、有効化する。コード不一致は 400。 */
+    /**
+     * pending シークレットをコードで検証し、有効化する。コード不一致は 400。
+     * 有効化と同時にリカバリコードを発行し、生コードを1度だけ返す（端末紛失時の自己復旧手段・#241）。
+     */
     @Transactional
-    public void enable(Long userId, String code) {
+    public List<String> enable(Long userId, String code) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalStateException("authenticated user not found"));
         if (user.isMfaEnabled()) {
@@ -62,9 +69,13 @@ public class MfaService {
         }
         user.setMfaEnabled(true);
         user.setUpdatedAt(OffsetDateTime.now());
+        return recoveryCodeService.regenerate(userId);
     }
 
-    /** 無効化。現在のコードで本人確認してから secret を破棄する。コード不一致は 400。 */
+    /**
+     * 無効化。現在のコードで本人確認してから secret を破棄する。コード不一致は 400。
+     * リカバリコードも全削除する（孤児を残さない・#241）。
+     */
     @Transactional
     public void disable(Long userId, String code) {
         User user = userRepository.findById(userId)
@@ -78,6 +89,31 @@ public class MfaService {
         user.setMfaEnabled(false);
         user.setTotpSecret(null);
         user.setUpdatedAt(OffsetDateTime.now());
+        recoveryCodeService.deleteAll(userId);
+    }
+
+    /**
+     * リカバリコードの再生成（#241）。現在の TOTP コードで本人確認してから旧コードを全破棄し、新規発行する。
+     * MFA 無効時・コード不一致は 400。
+     *
+     * @return 新しい生コード（1度だけ返す）
+     */
+    @Transactional
+    public List<String> regenerateRecoveryCodes(Long userId, String code) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalStateException("authenticated user not found"));
+        if (!user.isMfaEnabled()) {
+            throw new InvalidRequestException("二要素認証は有効になっていません");
+        }
+        if (!totpService.verify(user.getTotpSecret(), code)) {
+            throw new InvalidRequestException("コードが正しくありません");
+        }
+        return recoveryCodeService.regenerate(userId);
+    }
+
+    /** 未使用リカバリコードの残数（MFA 有効時のみ意味を持つ）。 */
+    public long remainingRecoveryCodes(Long userId) {
+        return recoveryCodeService.remaining(userId);
     }
 
     /** setup の戻り（QR data URI のみ。生シークレットは外に出さない）。 */

--- a/review-board/backend/src/main/java/com/reviewboard/domain/mfa/RecoveryCodeService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/mfa/RecoveryCodeService.java
@@ -1,0 +1,122 @@
+package com.reviewboard.domain.mfa;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * MFA リカバリコードの生成・保存・消費・再生成（Issue #241）。
+ *
+ * <p>生コードは {@code xxxx-xxxx} 形式（Crockford Base32・紛らわしい文字を除外）。
+ * 保存は SHA-256 hex のみ（refresh / invite / password-reset と同方針）。
+ * 1 度きりの使い捨て：{@link #consume} で一致したら used_at を立て、再利用は弾く。
+ */
+@Service
+public class RecoveryCodeService {
+
+    /** 1 ユーザーあたりの発行数。 */
+    static final int CODE_COUNT = 10;
+    /** 残数がこれ以下なら UI で警告（フロントが remaining と合わせて判断）。 */
+    public static final int LOW_REMAINING_THRESHOLD = 3;
+
+    /** 紛らわしい文字（0/O/1/I/L）を除いた英数字（Crockford Base32 系）。 */
+    private static final char[] ALPHABET = "23456789ABCDEFGHJKMNPQRSTUVWXYZ".toCharArray();
+    private static final int GROUP_LEN = 4; // xxxx-xxxx
+
+    private final MfaRecoveryCodeRepository repository;
+    private final SecureRandom random = new SecureRandom();
+
+    public RecoveryCodeService(MfaRecoveryCodeRepository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * 当該ユーザーのリカバリコードを作り直す（既存は全削除→新規 {@value #CODE_COUNT} 個）。
+     * MFA 有効化時・再生成時の両方から呼ぶ。
+     *
+     * @return 生コード（呼び出し元が1度だけユーザーに見せる。DB にはハッシュのみ残る）
+     */
+    @Transactional
+    public List<String> regenerate(Long userId) {
+        repository.deleteAllByUserId(userId);
+        OffsetDateTime now = OffsetDateTime.now();
+        List<String> rawCodes = new ArrayList<>(CODE_COUNT);
+        for (int i = 0; i < CODE_COUNT; i++) {
+            String raw = randomCode();
+            rawCodes.add(raw);
+            MfaRecoveryCode entity = new MfaRecoveryCode();
+            entity.setUserId(userId);
+            entity.setCodeHash(sha256(normalize(raw)));
+            entity.setCreatedAt(now);
+            repository.save(entity);
+        }
+        return rawCodes;
+    }
+
+    /**
+     * 入力コードが当該ユーザーの未使用リカバリコードと一致すれば消費して true。
+     * 不一致・使用済み・他人のコードは false（ログイン2段目で TOTP 失敗後に呼ぶ）。
+     */
+    @Transactional
+    public boolean consume(Long userId, String rawCode) {
+        if (rawCode == null || rawCode.isBlank()) {
+            return false;
+        }
+        Optional<MfaRecoveryCode> found = repository.findByCodeHash(sha256(normalize(rawCode)));
+        if (found.isEmpty()) {
+            return false;
+        }
+        MfaRecoveryCode code = found.get();
+        // 他人のコードのハッシュ衝突（事実上ありえないが）・使用済みは拒否。
+        if (!code.getUserId().equals(userId) || code.getUsedAt() != null) {
+            return false;
+        }
+        code.setUsedAt(OffsetDateTime.now());
+        return true;
+    }
+
+    /** 残りの未使用コード数。 */
+    public long remaining(Long userId) {
+        return repository.countByUserIdAndUsedAtIsNull(userId);
+    }
+
+    /** 当該ユーザーの全リカバリコードを削除（MFA 無効化時）。 */
+    @Transactional
+    public void deleteAll(Long userId) {
+        repository.deleteAllByUserId(userId);
+    }
+
+    /** {@code xxxx-xxxx} 形式の生コードを1つ作る。 */
+    private String randomCode() {
+        StringBuilder sb = new StringBuilder(GROUP_LEN * 2 + 1);
+        for (int i = 0; i < GROUP_LEN * 2; i++) {
+            if (i == GROUP_LEN) {
+                sb.append('-');
+            }
+            sb.append(ALPHABET[random.nextInt(ALPHABET.length)]);
+        }
+        return sb.toString();
+    }
+
+    /** 照合の正規化：大文字化＋区切り/空白除去（ユーザーの入力ゆらぎを吸収）。 */
+    private String normalize(String raw) {
+        return raw.trim().toUpperCase().replace("-", "").replaceAll("\\s", "");
+    }
+
+    private String sha256(String value) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] hash = md.digest(value.getBytes(StandardCharsets.UTF_8));
+            return java.util.HexFormat.of().formatHex(hash); // 64 文字 hex（mfa_recovery_codes.code_hash CHAR(64)）
+        } catch (Exception e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/mfa/dto/MfaRecoveryCodesResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/mfa/dto/MfaRecoveryCodesResponse.java
@@ -1,0 +1,10 @@
+package com.reviewboard.domain.mfa.dto;
+
+import java.util.List;
+
+/**
+ * リカバリコード発行応答（#241）。MFA 有効化時・再生成時に生コードを1度だけ返す。
+ * 生コードはこのレスポンス以降は二度と取得できない（DB はハッシュのみ）。
+ */
+public record MfaRecoveryCodesResponse(List<String> recoveryCodes) {
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/mfa/dto/MfaRecoveryStatusResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/mfa/dto/MfaRecoveryStatusResponse.java
@@ -1,0 +1,7 @@
+package com.reviewboard.domain.mfa.dto;
+
+/**
+ * リカバリコードの残数（#241）。{@code remaining} が {@code lowThreshold} 以下ならフロントで警告する。
+ */
+public record MfaRecoveryStatusResponse(long remaining, int lowThreshold) {
+}

--- a/review-board/backend/src/main/resources/db/migration/V18__add_mfa_recovery_codes.sql
+++ b/review-board/backend/src/main/resources/db/migration/V18__add_mfa_recovery_codes.sql
@@ -1,0 +1,17 @@
+-- MFA リカバリコード（Issue #241）。端末/認証アプリ紛失時の自己復旧手段。
+--
+-- セキュリティ（S軸）：
+--  - 生コードは MFA 有効化応答で1度だけ返し、DB には SHA-256 hex（CHAR 64）で保存
+--    （refresh / invite / password-reset と同方針。漏洩耐性・timing 比較なしの UNIQUE lookup）。
+--  - 1 度きりの使い捨て：消費時に used_at を立て、再利用は拒否（401）。
+--  - user 削除時は CASCADE（孤児コードを残さない）。disable 時はアプリ層で全削除。
+
+CREATE TABLE mfa_recovery_codes (
+    id         BIGSERIAL   PRIMARY KEY,
+    user_id    BIGINT      NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    code_hash  CHAR(64)    NOT NULL UNIQUE,
+    used_at    TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_mfa_recovery_codes_user ON mfa_recovery_codes (user_id);

--- a/review-board/backend/src/test/java/com/reviewboard/domain/mfa/MfaIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/mfa/MfaIntegrationTest.java
@@ -51,11 +51,26 @@ class MfaIntegrationTest extends AbstractIntegrationTest {
         // コード生成用のシークレットは QR に内包される。テストは DB から取得して算出する。
         String secret = userRepository.findByEmail(EMAIL).orElseThrow().getTotpSecret();
 
+        // #241 有効化はリカバリコード 10 個を1度だけ返す（200）。
         mockMvc.perform(post("/api/auth/mfa/enable").cookie(access)
                         .contentType("application/json")
                         .content("{\"code\":\"" + currentCode(secret) + "\"}"))
-                .andExpect(status().isNoContent());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.recoveryCodes", org.hamcrest.Matchers.hasSize(10)));
         return secret;
+    }
+
+    /** setup→enable し、発行されたリカバリコード（生）を返す。 */
+    @SuppressWarnings("unchecked")
+    private java.util.List<String> setupAndEnableCapturingCodes(Cookie access) throws Exception {
+        mockMvc.perform(post("/api/auth/mfa/setup").cookie(access)).andExpect(status().isOk());
+        String secret = userRepository.findByEmail(EMAIL).orElseThrow().getTotpSecret();
+        MvcResult res = mockMvc.perform(post("/api/auth/mfa/enable").cookie(access)
+                        .contentType("application/json")
+                        .content("{\"code\":\"" + currentCode(secret) + "\"}"))
+                .andExpect(status().isOk())
+                .andReturn();
+        return JsonPath.read(res.getResponse().getContentAsString(), "$.recoveryCodes");
     }
 
     private MvcResult passwordLogin(String email) throws Exception {
@@ -170,5 +185,163 @@ class MfaIntegrationTest extends AbstractIntegrationTest {
         mockMvc.perform(get("/api/auth/me").cookie(access))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.mfaEnabled").value(false));
+    }
+
+    // ---- #241 リカバリコード ----
+
+    /** リカバリコードでログイン2段目を突破できる（端末紛失時の自己復旧）。 */
+    @Test
+    void recovery_code_passes_second_step() throws Exception {
+        Cookie access = login(EMAIL);
+        java.util.List<String> codes = setupAndEnableCapturingCodes(access);
+
+        Cookie mfa = passwordLogin(EMAIL).getResponse().getCookie("mfa_token");
+        MvcResult res = mockMvc.perform(post("/api/auth/login/mfa").cookie(mfa)
+                        .contentType("application/json")
+                        .content("{\"code\":\"" + codes.get(0) + "\"}"))
+                .andExpect(status().isOk())
+                .andReturn();
+        assertThat(res.getResponse().getCookie("access_token")).isNotNull();
+    }
+
+    /** 使用済みリカバリコードは再利用できない（401）。 */
+    @Test
+    void used_recovery_code_is_rejected() throws Exception {
+        Cookie access = login(EMAIL);
+        java.util.List<String> codes = setupAndEnableCapturingCodes(access);
+        String code = codes.get(0);
+
+        // 1回目：成功して消費される。
+        Cookie mfa1 = passwordLogin(EMAIL).getResponse().getCookie("mfa_token");
+        mockMvc.perform(post("/api/auth/login/mfa").cookie(mfa1)
+                        .contentType("application/json")
+                        .content("{\"code\":\"" + code + "\"}"))
+                .andExpect(status().isOk());
+
+        // 2回目：同じコードは 401。
+        Cookie mfa2 = passwordLogin(EMAIL).getResponse().getCookie("mfa_token");
+        mockMvc.perform(post("/api/auth/login/mfa").cookie(mfa2)
+                        .contentType("application/json")
+                        .content("{\"code\":\"" + code + "\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    /** リカバリコードを使っても TOTP は引き続き有効。 */
+    @Test
+    void totp_still_works_after_recovery_exists() throws Exception {
+        Cookie access = login(EMAIL);
+        java.util.List<String> codes = setupAndEnableCapturingCodes(access);
+        String secret = userRepository.findByEmail(EMAIL).orElseThrow().getTotpSecret();
+
+        // リカバリコードで1回ログイン。
+        Cookie mfa1 = passwordLogin(EMAIL).getResponse().getCookie("mfa_token");
+        mockMvc.perform(post("/api/auth/login/mfa").cookie(mfa1)
+                        .contentType("application/json")
+                        .content("{\"code\":\"" + codes.get(0) + "\"}"))
+                .andExpect(status().isOk());
+
+        // TOTP も引き続き通る。
+        Cookie mfa2 = passwordLogin(EMAIL).getResponse().getCookie("mfa_token");
+        mockMvc.perform(post("/api/auth/login/mfa").cookie(mfa2)
+                        .contentType("application/json")
+                        .content("{\"code\":\"" + currentCode(secret) + "\"}"))
+                .andExpect(status().isOk());
+    }
+
+    /** 未知のリカバリコードは 401（総当たり対策の検証）。 */
+    @Test
+    void unknown_recovery_code_is_rejected() throws Exception {
+        Cookie access = login(EMAIL);
+        setupAndEnableCapturingCodes(access);
+        Cookie mfa = passwordLogin(EMAIL).getResponse().getCookie("mfa_token");
+
+        mockMvc.perform(post("/api/auth/login/mfa").cookie(mfa)
+                        .contentType("application/json")
+                        .content("{\"code\":\"ZZZZ-ZZZZ\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    /** 残数エンドポイントが消費に応じて減る。 */
+    @Test
+    void recovery_status_decreases_after_use() throws Exception {
+        Cookie access = login(EMAIL);
+        java.util.List<String> codes = setupAndEnableCapturingCodes(access);
+
+        mockMvc.perform(get("/api/auth/mfa/recovery-codes").cookie(access))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.remaining").value(10))
+                .andExpect(jsonPath("$.lowThreshold").value(3));
+
+        Cookie mfa = passwordLogin(EMAIL).getResponse().getCookie("mfa_token");
+        mockMvc.perform(post("/api/auth/login/mfa").cookie(mfa)
+                        .contentType("application/json")
+                        .content("{\"code\":\"" + codes.get(0) + "\"}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/auth/mfa/recovery-codes").cookie(access))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.remaining").value(9));
+    }
+
+    /** regenerate で新規10個を発行し、旧コードは無効化される。 */
+    @Test
+    void regenerate_invalidates_old_codes() throws Exception {
+        Cookie access = login(EMAIL);
+        java.util.List<String> oldCodes = setupAndEnableCapturingCodes(access);
+        String secret = userRepository.findByEmail(EMAIL).orElseThrow().getTotpSecret();
+
+        MvcResult res = mockMvc.perform(post("/api/auth/mfa/recovery-codes/regenerate").cookie(access)
+                        .contentType("application/json")
+                        .content("{\"code\":\"" + currentCode(secret) + "\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.recoveryCodes", org.hamcrest.Matchers.hasSize(10)))
+                .andReturn();
+        java.util.List<String> newCodes = JsonPath.read(res.getResponse().getContentAsString(), "$.recoveryCodes");
+
+        // 旧コードは 401。
+        Cookie mfaOld = passwordLogin(EMAIL).getResponse().getCookie("mfa_token");
+        mockMvc.perform(post("/api/auth/login/mfa").cookie(mfaOld)
+                        .contentType("application/json")
+                        .content("{\"code\":\"" + oldCodes.get(0) + "\"}"))
+                .andExpect(status().isUnauthorized());
+
+        // 新コードは通る。
+        Cookie mfaNew = passwordLogin(EMAIL).getResponse().getCookie("mfa_token");
+        mockMvc.perform(post("/api/auth/login/mfa").cookie(mfaNew)
+                        .contentType("application/json")
+                        .content("{\"code\":\"" + newCodes.get(0) + "\"}"))
+                .andExpect(status().isOk());
+    }
+
+    /** regenerate は誤った TOTP では 400（再生成されない）。 */
+    @Test
+    void regenerate_with_wrong_code_is_400() throws Exception {
+        Cookie access = login(EMAIL);
+        setupAndEnableCapturingCodes(access);
+        mockMvc.perform(post("/api/auth/mfa/recovery-codes/regenerate").cookie(access)
+                        .contentType("application/json")
+                        .content("{\"code\":\"000000\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    /** disable でリカバリコードも全削除される（残数0）。 */
+    @Test
+    void disable_clears_recovery_codes() throws Exception {
+        Cookie access = login(EMAIL);
+        setupAndEnableCapturingCodes(access);
+        String secret = userRepository.findByEmail(EMAIL).orElseThrow().getTotpSecret();
+
+        mockMvc.perform(post("/api/auth/mfa/disable").cookie(access)
+                        .contentType("application/json")
+                        .content("{\"code\":\"" + currentCode(secret) + "\"}"))
+                .andExpect(status().isNoContent());
+
+        assertThat(mfaRecoveryCodeRepository.count()).isZero();
+    }
+
+    /** recovery-codes 残数取得は認証必須（未認証は 401）。 */
+    @Test
+    void recovery_status_requires_auth() throws Exception {
+        mockMvc.perform(get("/api/auth/mfa/recovery-codes")).andExpect(status().isUnauthorized());
     }
 }

--- a/review-board/backend/src/test/java/com/reviewboard/support/AbstractIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/support/AbstractIntegrationTest.java
@@ -92,6 +92,7 @@ public abstract class AbstractIntegrationTest {
     @Autowired protected com.reviewboard.domain.passwordreset.PasswordResetTokenRepository passwordResetTokenRepository;
     @Autowired protected com.reviewboard.domain.notificationpref.UserNotificationPrefRepository notificationPrefRepository;
     @Autowired protected com.reviewboard.domain.invite.CohortInviteRepository inviteRepository;
+    @Autowired protected com.reviewboard.domain.mfa.MfaRecoveryCodeRepository mfaRecoveryCodeRepository;
     @Autowired protected org.springframework.security.crypto.password.PasswordEncoder passwordEncoder;
     @Autowired protected com.reviewboard.domain.auth.RateLimitFilter rateLimitFilter;
 
@@ -108,6 +109,7 @@ public abstract class AbstractIntegrationTest {
         reviewRepository.deleteAll();
         postRepository.deleteAll();
         refreshTokenRepository.deleteAll();
+        mfaRecoveryCodeRepository.deleteAll();
         passwordResetTokenRepository.deleteAll();
         notificationPrefRepository.deleteAll();
         inviteRepository.deleteAll();

--- a/review-board/frontend/src/api/mfa.js
+++ b/review-board/frontend/src/api/mfa.js
@@ -1,8 +1,17 @@
 import client from './client';
 
 // C-6 二要素認証（TOTP・#235）。常に自分のアカウントの MFA を操作する（認証必須）。
-export const setupMfa = () => client.post('/auth/mfa/setup').then((r) => r.data); // {secret, qrDataUri}
+export const setupMfa = () => client.post('/auth/mfa/setup').then((r) => r.data); // {qrDataUri}
 
-export const enableMfa = (code) => client.post('/auth/mfa/enable', { code });
+// #241 有効化はリカバリコード（生）を1度だけ返す。{ recoveryCodes: [...] }
+export const enableMfa = (code) => client.post('/auth/mfa/enable', { code }).then((r) => r.data);
 
 export const disableMfa = (code) => client.post('/auth/mfa/disable', { code });
+
+// #241 リカバリコード残数。{ remaining, lowThreshold }
+export const getRecoveryStatus = () =>
+  client.get('/auth/mfa/recovery-codes').then((r) => r.data);
+
+// #241 リカバリコード再生成（現 TOTP コードで本人確認）。{ recoveryCodes: [...] }
+export const regenerateRecoveryCodes = (code) =>
+  client.post('/auth/mfa/recovery-codes/regenerate', { code }).then((r) => r.data);

--- a/review-board/frontend/src/pages/ProfilePage.jsx
+++ b/review-board/frontend/src/pages/ProfilePage.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { fetchProfile, updateMyProfile } from '../api/profile';
 import { fetchNotificationPrefs, updateNotificationPrefs } from '../api/notificationPrefs';
-import { setupMfa, enableMfa, disableMfa } from '../api/mfa';
+import { setupMfa, enableMfa, disableMfa, getRecoveryStatus, regenerateRecoveryCodes } from '../api/mfa';
 import { ROLE_LABEL, EVAL_LABEL } from '../constants';
 import { useAuth } from '../context/AuthContext';
 import Avatar from '../components/Avatar';
@@ -292,6 +292,7 @@ function Toggle({ label, desc, checked, onChange, disabled = false }) {
 }
 
 // C-6（#235）二要素認証（TOTP）設定：本人のみ。setup→QR表示→コードで有効化／コードで無効化。
+// #241 有効化時にリカバリコードを表示・残数表示・再生成も担う（端末紛失時の自己復旧手段）。
 function MfaCard() {
   const { user, refreshUser } = useAuth();
   const enabled = !!user?.mfaEnabled;
@@ -299,6 +300,16 @@ function MfaCard() {
   const [code, setCode] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
+  const [recoveryCodes, setRecoveryCodes] = useState(null); // 発行直後だけ生コードを保持（1度きり表示）
+  const [recovery, setRecovery] = useState(null); // { remaining, lowThreshold }
+  const [regenerating, setRegenerating] = useState(false);
+  const [regenCode, setRegenCode] = useState('');
+
+  // 有効時のみ残数を取得（コード一覧表示中は再取得しない＝消えないように）。
+  useEffect(() => {
+    if (!enabled) { setRecovery(null); return; }
+    getRecoveryStatus().then(setRecovery).catch(() => setRecovery(null));
+  }, [enabled, recoveryCodes]);
 
   const startSetup = async () => {
     setError('');
@@ -317,10 +328,11 @@ function MfaCard() {
     setError('');
     setBusy(true);
     try {
-      await enableMfa(code);
+      const res = await enableMfa(code);
       await refreshUser();
       setSetup(null);
       setCode('');
+      setRecoveryCodes(res.recoveryCodes); // 1度きりの表示
     } catch (err) {
       setError(err.response?.status === 400 ? 'コードが正しくありません' : '有効化に失敗しました');
     } finally {
@@ -336,8 +348,25 @@ function MfaCard() {
       await disableMfa(code);
       await refreshUser();
       setCode('');
+      setRecoveryCodes(null);
     } catch (err) {
       setError(err.response?.status === 400 ? 'コードが正しくありません' : '無効化に失敗しました');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const confirmRegenerate = async (e) => {
+    e.preventDefault();
+    setError('');
+    setBusy(true);
+    try {
+      const res = await regenerateRecoveryCodes(regenCode);
+      setRecoveryCodes(res.recoveryCodes);
+      setRegenerating(false);
+      setRegenCode('');
+    } catch (err) {
+      setError(err.response?.status === 400 ? 'コードが正しくありません' : '再生成に失敗しました');
     } finally {
       setBusy(false);
     }
@@ -356,15 +385,20 @@ function MfaCard() {
       </p>
       {error && <p className="mb-3 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
 
+      {/* 発行直後のリカバリコード一覧（1度きり表示・最優先） */}
+      {recoveryCodes && (
+        <RecoveryCodesPanel codes={recoveryCodes} onDone={() => setRecoveryCodes(null)} />
+      )}
+
       {/* 無効 & setup 未開始：開始ボタン */}
-      {!enabled && !setup && (
+      {!recoveryCodes && !enabled && !setup && (
         <button onClick={startSetup} disabled={busy} className="mac-btn-brand">
           {busy ? '準備中…' : '二要素認証を設定する'}
         </button>
       )}
 
       {/* setup 中：QR ＋ コード入力で有効化 */}
-      {!enabled && setup && (
+      {!recoveryCodes && !enabled && setup && (
         <form onSubmit={confirmEnable} className="space-y-3">
           <p className="text-sm text-gray-600">認証アプリ（Google Authenticator 等）で以下の QR コードを読み取ってください。</p>
           <img src={setup.qrDataUri} alt="TOTP QR コード" className="h-44 w-44 rounded-lg ring-1 ring-black/5" />
@@ -386,24 +420,103 @@ function MfaCard() {
         </form>
       )}
 
-      {/* 有効：コード入力で無効化 */}
-      {enabled && (
-        <form onSubmit={confirmDisable} className="space-y-3">
-          <label className="mac-label" htmlFor="mfa-disable-code">無効化するには現在の6桁コードを入力</label>
-          <input
-            id="mfa-disable-code"
-            type="text"
-            inputMode="numeric"
-            autoComplete="one-time-code"
-            placeholder="123456"
-            value={code}
-            onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
-            className="mac-input"
-          />
-          <button type="submit" disabled={busy} className="mac-btn-ghost text-red-600">{busy ? '確認中…' : '二要素認証を無効にする'}</button>
-        </form>
+      {/* 有効：残数表示＋再生成＋無効化 */}
+      {!recoveryCodes && enabled && (
+        <div className="space-y-4">
+          {recovery && (
+            <div className={`rounded-xl px-3 py-2 text-sm ${recovery.remaining <= recovery.lowThreshold ? 'bg-amber-50 text-amber-700' : 'bg-gray-50 text-gray-600'}`}>
+              リカバリコードの残り：<span className="font-semibold">{recovery.remaining}</span> 個
+              {recovery.remaining <= recovery.lowThreshold && (
+                <span className="ml-1">— 残りが少なくなっています。再生成をおすすめします。</span>
+              )}
+              <button type="button" onClick={() => { setRegenerating((v) => !v); setError(''); }} className="ml-2 underline">
+                {regenerating ? 'キャンセル' : '再生成する'}
+              </button>
+            </div>
+          )}
+
+          {/* 再生成：現在の6桁コードで本人確認 */}
+          {regenerating && (
+            <form onSubmit={confirmRegenerate} className="space-y-2">
+              <label className="mac-label" htmlFor="mfa-regen-code">再生成するには現在の6桁コードを入力</label>
+              <input
+                id="mfa-regen-code"
+                type="text"
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                placeholder="123456"
+                value={regenCode}
+                onChange={(e) => setRegenCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+                className="mac-input"
+              />
+              <p className="text-xs text-gray-500">再生成すると、これまでのリカバリコードはすべて使えなくなります。</p>
+              <button type="submit" disabled={busy} className="mac-btn-brand">{busy ? '再生成中…' : 'リカバリコードを再生成'}</button>
+            </form>
+          )}
+
+          <form onSubmit={confirmDisable} className="space-y-3 border-t border-black/5 pt-4">
+            <label className="mac-label" htmlFor="mfa-disable-code">無効化するには現在の6桁コードを入力</label>
+            <input
+              id="mfa-disable-code"
+              type="text"
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              placeholder="123456"
+              value={code}
+              onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+              className="mac-input"
+            />
+            <button type="submit" disabled={busy} className="mac-btn-ghost text-red-600">{busy ? '確認中…' : '二要素認証を無効にする'}</button>
+          </form>
+        </div>
       )}
     </section>
+  );
+}
+
+// #241 発行直後のリカバリコードを1度だけ表示する。コピー／ダウンロードを提供し、保存後に閉じる。
+function RecoveryCodesPanel({ codes, onDone }) {
+  const [copied, setCopied] = useState(false);
+  const text = codes.join('\n');
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* クリップボード不可の環境は無視（ダウンロードで代替） */
+    }
+  };
+
+  const download = () => {
+    const blob = new Blob([`${text}\n`], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'review-board-recovery-codes.txt';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="space-y-3 rounded-xl bg-amber-50 p-4">
+      <p className="text-sm font-semibold text-amber-800">リカバリコード（今だけ表示されます）</p>
+      <p className="text-xs text-amber-700">
+        認証アプリを使えなくなったとき、これらのコードで1回ずつログインできます。安全な場所に保管してください。
+        この画面を閉じると二度と表示できません。
+      </p>
+      <ul className="grid grid-cols-2 gap-1.5 rounded-lg bg-white p-3 font-mono text-sm text-gray-800">
+        {codes.map((c) => (
+          <li key={c} className="tracking-wider">{c}</li>
+        ))}
+      </ul>
+      <div className="flex flex-wrap gap-2">
+        <button type="button" onClick={copy} className="mac-btn-ghost">{copied ? 'コピーしました' : 'コピー'}</button>
+        <button type="button" onClick={download} className="mac-btn-ghost">ダウンロード</button>
+        <button type="button" onClick={onDone} className="mac-btn-brand">保存しました（閉じる）</button>
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## 関連 Issue

Closes #241

---

## 変更の概要

二要素認証（#235・QR一本化 #240）で認証アプリ／端末を失った場合の**自己復旧手段**を追加する。手入力キーを削除済みのため、紛失すると自力でログインできなくなる穴（ロックアウト）を塞ぐ。

- migration **V18** `mfa_recovery_codes`（`user_id` FK CASCADE / `code_hash` CHAR(64) UNIQUE / `used_at` / `created_at`）。生コードは保存せず **SHA-256 hex** のみ（refresh / invite / password-reset と同方針）
- MFA 有効化（`MfaService.enable`）成功時に **10個**のランダムコード（`xxxx-xxxx` 形式・紛らわしい文字を除外した英数字）を生成→ハッシュ保存→**生コードは応答で1度だけ**返す
- ログイン2段目（`/api/auth/login/mfa`）は **TOTP → 未使用リカバリコード** の順に検証。一致したコードは消費（`used_at`）
- 再生成 `POST /api/auth/mfa/recovery-codes/regenerate`（認証＋現TOTP本人確認・旧コード全破棄）／残数取得 `GET /api/auth/mfa/recovery-codes`
- `disable` でリカバリコードも全削除
- フロント `MfaCard`：有効化時にコード一覧（コピー／ダウンロード・1度きり表示）・残数表示（残り少で警告）・再生成

## 変更の種別

- [x] feat（新機能の追加）

---

## セキュリティ（重点軸）

- 生コードは DB に残さず、照合は `code_hash` の UNIQUE lookup（timing 比較なし）
- `/api/auth/login/mfa` は permitAll かつ**レートリミット対象を維持**（リカバリコードの総当たり対策）
- 使用済み・未知・他人のコードはいずれも 401
- 認可：MFA 関連エンドポイントは全て認証必須（残数取得の未認証は 401 をテストで確認）

## 動作確認チェックリスト

- [x] `DOCKER_API_VERSION=1.44 ./gradlew test` green（リカバリコード正常系＋拒否系を追加：成功→再利用401／TOTP併用／未知コード401／残数減少／再生成で旧無効化／disableで全削除／未認証401）
- [x] `npm run build` / `npm run lint` green（既存の AuthContext 警告のみ・無関係）
- [x] `.env` ファイルやパスワードをコミットしていない

---

## 補足

- 本番未反映（CDは手動昇格）。マージ後の本番反映は別途判断。
