### PR TITLE
chore: コストアラート強化（最初の課金を早期検知する多段しきい値）

### DIFF
--- a/review-board/infra/budgets.tf
+++ b/review-board/infra/budgets.tf
@@ -11,13 +11,18 @@ resource "aws_budgets_budget" "monthly" {
   limit_unit   = "USD"
   time_unit    = "MONTHLY"
 
-  # 実コストがしきい値の 80% に達したら通知
-  notification {
-    comparison_operator        = "GREATER_THAN"
-    threshold                  = 80
-    threshold_type             = "PERCENTAGE"
-    notification_type          = "ACTUAL"
-    subscriber_email_addresses = [var.budget_notify_email]
+  # 多段の実コスト通知（無料枠運用は本来 $0＝最初の課金を最速で掴む。修練城の事故予防方針）。
+  # しきい値 $0.50 に対し 1%=$0.005 / 50%=$0.25 / 80%=$0.40 / 100%=$0.50。
+  # 1% は実質「最初の課金（数セント）」の検知点。暴走コストの兆候を早期に通知する。
+  dynamic "notification" {
+    for_each = toset([1, 50, 80, 100])
+    content {
+      comparison_operator        = "GREATER_THAN"
+      threshold                  = notification.value
+      threshold_type             = "PERCENTAGE"
+      notification_type          = "ACTUAL"
+      subscriber_email_addresses = [var.budget_notify_email]
+    }
   }
 
   # 予測コストがしきい値の 100% を超える見込みで通知（先回り）


### PR DESCRIPTION
## 関連 Issue

Closes #245

---

## 変更の概要

AWS Budgets の実コスト通知を**多段しきい値**に拡充し、無料枠運用で本来 $0 のはずの環境で **最初の課金（数セント）を最速検知** する。暴走コストの兆候を早期に掴む（修練城の事故予防方針）。

- `infra/budgets.tf`：実コスト通知を **1% / 50% / 80% / 100%**（$0.50 に対し $0.005 / $0.25 / $0.40 / $0.50）の多段に拡充（`dynamic notification` で記述）。予測 100% 通知は維持。通知先は既存 `budget_notify_email`（直接メール）。

## 変更の種別

- [x] chore（設定の変更）

---

## 動作確認チェックリスト

- [x] `terraform fmt -check` / `terraform validate` クリーン（Success! The configuration is valid.）
- [x] `.env` ファイルやパスワードをコミットしていない
- [ ] （運用）反映は人間が外部Terminalで実行（修練城ルール）。差分が budgets の notification 追加のみ（意図しないリソース破棄が無い）ことを確認してから反映
