### PR TITLE
feat: 監査ログ改ざん防止（cohort単位のハッシュ連鎖）

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/domain/audit/AuditController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/audit/AuditController.java
@@ -1,5 +1,6 @@
 package com.reviewboard.domain.audit;
 
+import com.reviewboard.domain.audit.dto.AuditChainVerifyResponse;
 import com.reviewboard.domain.audit.dto.AuditLogResponse;
 import com.reviewboard.domain.auth.AuthPrincipal;
 import org.springframework.data.domain.Page;
@@ -30,5 +31,12 @@ public class AuditController {
     public Page<AuditLogResponse> list(@AuthenticationPrincipal AuthPrincipal principal,
                                        @PageableDefault(size = 50) Pageable pageable) {
         return auditService.listForCohort(principal, pageable).map(AuditLogResponse::from);
+    }
+
+    /** 連鎖の改ざん検証（#247・講師限定・自 cohort）。整合が破れた最初の行 ID を返す。 */
+    @PreAuthorize("hasRole('TEACHER')")
+    @GetMapping("/verify")
+    public AuditChainVerifyResponse verify(@AuthenticationPrincipal AuthPrincipal principal) {
+        return AuditChainVerifyResponse.from(auditService.verifyChain(principal));
     }
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/audit/AuditHasher.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/audit/AuditHasher.java
@@ -1,0 +1,41 @@
+package com.reviewboard.domain.audit;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+
+/**
+ * 監査ログのハッシュ連鎖の計算（#247）。記録時と検証時で **同一の正規化** を使うことが要。
+ *
+ * <p>entry_hash = SHA256( prev_hash + "|" + 正規化レコード )。prev_hash が null（genesis）は空文字で扱う。
+ * createdAt は epoch millis で正規化する（DB は TIMESTAMPTZ で micros 保存・Java は nanos のため、
+ * 書き込み時と再読込時で差が出ないよう millis に丸める）。
+ */
+final class AuditHasher {
+
+    private AuditHasher() {
+    }
+
+    /** 連鎖計算用の正規化レコード（区切りはパイプ・各フィールドは決定的な文字列表現）。 */
+    static String canonical(AuditLog log) {
+        return String.join("|",
+                String.valueOf(log.getActorUserId()),
+                log.getAction().name(),
+                log.getTargetType().name(),
+                String.valueOf(log.getTargetId()),
+                String.valueOf(log.getCohortId()),
+                String.valueOf(log.getCreatedAt().toInstant().toEpochMilli()));
+    }
+
+    /** entry_hash = SHA256(prevHash + "|" + canonical)。prevHash null は "" 扱い。 */
+    static String entryHash(String prevHash, AuditLog log) {
+        String material = (prevHash == null ? "" : prevHash) + "|" + canonical(log);
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] hash = md.digest(material.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash); // 64 文字 hex（audit_logs.entry_hash CHAR(64)）
+        } catch (Exception e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/audit/AuditLog.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/audit/AuditLog.java
@@ -41,4 +41,12 @@ public class AuditLog {
 
     @Column(name = "created_at", nullable = false)
     private OffsetDateTime createdAt;
+
+    /** 改ざん防止の連鎖（#247）：同 cohort の直前行の entry_hash。genesis は null。 */
+    @Column(name = "prev_hash", length = 64)
+    private String prevHash;
+
+    /** この行のハッシュ = SHA256(prev_hash + 正規化レコード)。V19 以降の新規行のみ持つ。 */
+    @Column(name = "entry_hash", length = 64)
+    private String entryHash;
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/audit/AuditLogRepository.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/audit/AuditLogRepository.java
@@ -3,9 +3,30 @@ package com.reviewboard.domain.audit;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface AuditLogRepository extends JpaRepository<AuditLog, Long> {
 
     /** 閲覧（★S軸）：自 cohort の監査ログのみ・新しい順。他 cohort は返さない。 */
     Page<AuditLog> findByCohortIdOrderByCreatedAtDesc(Long cohortId, Pageable pageable);
+
+    /** 連鎖の直前行（#247）：同 cohort で最新（id 最大）の行。genesis 判定に使う。 */
+    Optional<AuditLog> findTopByCohortIdOrderByIdDesc(Long cohortId);
+
+    /** 検証（#247）：同 cohort の連鎖済み行（entry_hash あり）を記録順（id 昇順）で。 */
+    List<AuditLog> findByCohortIdAndEntryHashIsNotNullOrderByIdAsc(Long cohortId);
+
+    /**
+     * 連鎖の single-writer 化（#247）：記録 TX 内で cohort をキーに排他ロックを取る。
+     * TX 終了時に自動解放。並行記録時の prev_hash 競合（連鎖の分岐）を防ぐ。
+     *
+     * <p>{@code pg_advisory_xact_lock} は void を返すため、{@code ::text}（空文字）にキャストして
+     * 結果セットを1行返す（戻り値は使わない＝ロック取得が目的）。
+     */
+    @Query(value = "SELECT cast(pg_advisory_xact_lock(:key) as text)", nativeQuery = true)
+    String acquireCohortChainLock(@Param("key") long key);
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/audit/AuditService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/audit/AuditService.java
@@ -4,9 +4,11 @@ import com.reviewboard.domain.auth.AuthPrincipal;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 
 /**
  * 監査ログの記録と閲覧（★S軸・要件 §4-1）。
@@ -14,6 +16,9 @@ import java.time.OffsetDateTime;
  * <p>記録は呼び出し元の {@code @Transactional} に参加する（{@code MANDATORY}）。これにより
  * 「操作がコミットされたときだけ監査行も残る」を保証し、ログだけ残る/操作だけ残るを防ぐ。
  * actor・cohort は principal（検証済み JWT）から導出し、クライアント入力を信用しない。
+ *
+ * <p>改ざん防止（#247）：cohort 単位のハッシュ連鎖で記録する。記録 TX 内で advisory lock を取り
+ * 直前行を確定させてから entry_hash を計算するため、並行記録でも連鎖が分岐しない。
  */
 @Service
 public class AuditService {
@@ -25,8 +30,11 @@ public class AuditService {
     }
 
     /** 監査行を記録する。認可チェックを通過した操作の後で呼ぶこと。 */
-    @Transactional(propagation = org.springframework.transaction.annotation.Propagation.MANDATORY)
+    @Transactional(propagation = Propagation.MANDATORY)
     public void record(AuthPrincipal actor, AuditAction action, AuditTargetType targetType, Long targetId) {
+        // #247 連鎖の single-writer 化：同 cohort の記録を直列化（TX 終了で自動解放）。
+        repository.acquireCohortChainLock(actor.cohortId());
+
         AuditLog log = new AuditLog();
         log.setActorUserId(actor.userId());
         log.setAction(action);
@@ -34,6 +42,13 @@ public class AuditService {
         log.setTargetId(targetId);
         log.setCohortId(actor.cohortId());
         log.setCreatedAt(OffsetDateTime.now());
+
+        // 直前行（同 cohort の連鎖済み最新行）の entry_hash を prev_hash に結ぶ。
+        String prevHash = repository.findTopByCohortIdOrderByIdDesc(actor.cohortId())
+                .map(AuditLog::getEntryHash)
+                .orElse(null); // cohort の genesis
+        log.setPrevHash(prevHash);
+        log.setEntryHash(AuditHasher.entryHash(prevHash, log));
         repository.save(log);
     }
 
@@ -41,5 +56,29 @@ public class AuditService {
     @Transactional(readOnly = true)
     public Page<AuditLog> listForCohort(AuthPrincipal principal, Pageable pageable) {
         return repository.findByCohortIdOrderByCreatedAtDesc(principal.cohortId(), pageable);
+    }
+
+    /**
+     * 連鎖の整合検証（#247・講師限定は Controller で担保）。自 cohort の連鎖済み行を記録順に
+     * 再計算し、prev_hash のリンクと entry_hash の再現を確認する。最初に破れた行 ID を返す。
+     */
+    @Transactional(readOnly = true)
+    public ChainVerification verifyChain(AuthPrincipal principal) {
+        List<AuditLog> chain = repository.findByCohortIdAndEntryHashIsNotNullOrderByIdAsc(principal.cohortId());
+        String expectedPrev = null; // genesis は null
+        for (AuditLog log : chain) {
+            // prev リンクの一致と entry_hash の再現の両方を確認する。
+            boolean linkOk = java.util.Objects.equals(expectedPrev, log.getPrevHash());
+            boolean hashOk = AuditHasher.entryHash(log.getPrevHash(), log).equals(log.getEntryHash());
+            if (!linkOk || !hashOk) {
+                return new ChainVerification(false, chain.size(), log.getId());
+            }
+            expectedPrev = log.getEntryHash();
+        }
+        return new ChainVerification(true, chain.size(), null);
+    }
+
+    /** 連鎖検証の結果。{@code valid=false} のとき {@code firstBrokenId} に最初の破れ行 ID。 */
+    public record ChainVerification(boolean valid, long count, Long firstBrokenId) {
     }
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/audit/dto/AuditChainVerifyResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/audit/dto/AuditChainVerifyResponse.java
@@ -1,0 +1,14 @@
+package com.reviewboard.domain.audit.dto;
+
+import com.reviewboard.domain.audit.AuditService;
+
+/**
+ * 監査ログ連鎖の検証結果（#247）。{@code valid=false} のとき {@code firstBrokenId} に
+ * 最初に整合が破れた行 ID が入る（改ざん検知）。{@code count} は検証対象（連鎖済み）行数。
+ */
+public record AuditChainVerifyResponse(boolean valid, long count, Long firstBrokenId) {
+
+    public static AuditChainVerifyResponse from(AuditService.ChainVerification v) {
+        return new AuditChainVerifyResponse(v.valid(), v.count(), v.firstBrokenId());
+    }
+}

--- a/review-board/backend/src/main/resources/db/migration/V19__add_audit_hash_chain.sql
+++ b/review-board/backend/src/main/resources/db/migration/V19__add_audit_hash_chain.sql
@@ -1,0 +1,20 @@
+-- 監査ログ改ざん防止（Issue #247）。cohort 単位のハッシュ連鎖（hash-chain）。
+--
+-- 仕組み：
+--  - 各行に entry_hash = SHA256(prev_hash + 正規化レコード) を持つ。prev_hash は同 cohort の
+--    直前行の entry_hash（cohort ごとに独立した連鎖）。1 行でも書き換えると以降の連鎖が破れる。
+--  - genesis（cohort の最初の行）は prev_hash = NULL。
+--
+-- セキュリティ（S軸）：
+--  - 後からの単独改ざんを検知できる。検証は講師限定 GET /api/audit-logs/verify（自 cohort）。
+--  - 並行書き込みの prev_hash 競合は、記録 TX 内の pg_advisory_xact_lock(cohort_id) で single-writer 化。
+--
+-- 前方連鎖の方針：
+--  - 既存行（V19 以前）はハッシュ無し（prev_hash/entry_hash = NULL）のまま残す。過去行の
+--    再ハッシュ（SQL での連鎖再構成）は Java 側の正規化と完全一致させる必要があり、誤差で検証が
+--    壊れるリスクが高いため行わない。連鎖と検証は **V19 以降の新規行から** 有効（entry_hash IS NOT NULL）。
+--  - そのため両列とも NULL 許容。
+
+ALTER TABLE audit_logs
+    ADD COLUMN prev_hash  CHAR(64),
+    ADD COLUMN entry_hash CHAR(64);

--- a/review-board/backend/src/test/java/com/reviewboard/domain/audit/AuditHashChainIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/audit/AuditHashChainIntegrationTest.java
@@ -1,0 +1,100 @@
+package com.reviewboard.domain.audit;
+
+import com.reviewboard.domain.user.UserRole;
+import com.reviewboard.support.AbstractIntegrationTest;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 監査ログのハッシュ連鎖（#247）。連鎖が valid に組まれること、途中行の改ざんを検知すること、
+ * 検証エンドポイントが講師限定・自 cohort であることを検証する。
+ */
+class AuditHashChainIntegrationTest extends AbstractIntegrationTest {
+
+    private String authorEmail;
+    private String teacherEmail;
+    private String teacherBEmail;
+
+    @BeforeEach
+    void seed() throws Exception {
+        var a = newCohort("A");
+        var b = newCohort("B");
+        authorEmail = newUser("author@example.com", UserRole.STUDENT, a.getId()).getEmail();
+        teacherEmail = newUser("teacher@example.com", UserRole.TEACHER, a.getId()).getEmail();
+        teacherBEmail = newUser("teacherB@example.com", UserRole.TEACHER, b.getId()).getEmail();
+
+        // cohort A で活動（監査行が複数残る）：投稿2件＋承認1件。
+        long p1 = createPost(login(authorEmail), "作品1");
+        createPost(login(authorEmail), "作品2");
+        mockMvc.perform(post("/api/posts/" + p1 + "/evaluation").cookie(login(teacherEmail))
+                        .contentType("application/json")
+                        .content("{\"result\":\"APPROVED\",\"comment\":\"合格\"}"))
+                .andExpect(status().isOk());
+    }
+
+    /** 連鎖は valid に組まれ、検証は対象行数を返す。 */
+    @Test
+    void chain_is_valid_after_recorded_actions() throws Exception {
+        mockMvc.perform(get("/api/audit-logs/verify").cookie(login(teacherEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.valid").value(true))
+                .andExpect(jsonPath("$.count").value(3))
+                .andExpect(jsonPath("$.firstBrokenId").doesNotExist());
+    }
+
+    /** 途中行の内容を書き換えると、その行で連鎖の破れを検知する。 */
+    @Test
+    void tampering_a_row_is_detected() throws Exception {
+        // cohort A の連鎖の2番目の行を書き換える（entry_hash は据え置き＝再計算で不一致になる）。
+        List<AuditLog> chain = auditLogRepository.findByCohortIdAndEntryHashIsNotNullOrderByIdAsc(
+                userRepository.findByEmail(teacherEmail).orElseThrow().getCohortId());
+        AuditLog victim = chain.get(1);
+        victim.setTargetId(victim.getTargetId() + 999_999); // 改ざん
+        auditLogRepository.save(victim);
+
+        mockMvc.perform(get("/api/audit-logs/verify").cookie(login(teacherEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.valid").value(false))
+                .andExpect(jsonPath("$.firstBrokenId").value(victim.getId()));
+    }
+
+    /** 検証は講師限定（受講生は 403）。 */
+    @Test
+    void student_cannot_verify_returns403() throws Exception {
+        mockMvc.perform(get("/api/audit-logs/verify").cookie(login(authorEmail)))
+                .andExpect(status().isForbidden());
+    }
+
+    /** 検証は未認証で 401。 */
+    @Test
+    void unauthenticated_verify_is_401() throws Exception {
+        mockMvc.perform(get("/api/audit-logs/verify"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    /** cohort 分離：他 cohort の講師は自 cohort（空の連鎖）を検証＝valid・count 0。 */
+    @Test
+    void other_cohort_teacher_verifies_own_empty_chain() throws Exception {
+        mockMvc.perform(get("/api/audit-logs/verify").cookie(login(teacherBEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.valid").value(true))
+                .andExpect(jsonPath("$.count").value(0));
+    }
+
+    private long createPost(Cookie cookie, String title) throws Exception {
+        MvcResult res = mockMvc.perform(post("/api/posts").cookie(cookie)
+                        .contentType("application/json")
+                        .content("{\"title\":\"" + title + "\",\"description\":\"説明\"}"))
+                .andExpect(status().isCreated()).andReturn();
+        return readId(res);
+    }
+}


### PR DESCRIPTION
## 関連 Issue

Closes #247

---

## 変更の概要

監査ログ（★重点軸）を**後から単独で書き換えても検知できる**よう、各行をハッシュ連鎖（hash-chain）で結ぶ。セキュリティを ★4→★5 へ。

- migration **V19**：`audit_logs` に `prev_hash` / `entry_hash`（CHAR(64)・nullable）を追加。
- `AuditService.record`：**cohort 単位**の連鎖。`entry_hash = SHA256(prev_hash + 正規化レコード)`、直前行は同 cohort の最新行（genesis は `prev_hash=null`）。
- 並行記録の prev_hash 競合：記録 TX 内の **`pg_advisory_xact_lock(cohortId)`** で single-writer 化（TX 終了で自動解放）。`pg_advisory_xact_lock` は void を返すため `::text` にキャストして1行返す。
- 検証：講師限定 `GET /api/audit-logs/verify`（自 cohort）で連鎖を再計算し、**破れた最初の行 ID** を返す。
- **前方連鎖**：V19 以降の新規行を連鎖。既存行（pre-V19）の再ハッシュはしない（SQL と Java の正規化を完全一致させる必要があり、誤差で検証が壊れるリスク回避）。検証は `entry_hash` ありの行が対象。
- 正規化は `createdAt` を **epoch millis** に丸め、書込時（nanos）と再読込時（micros）のズレを排除。

## 変更の種別

- [x] feat（新機能の追加）

---

## セキュリティ（重点軸）

- `record` は呼び出し元 TX に `MANDATORY` 参加（操作コミット時のみ記録）の方針を維持。連鎖計算は同 TX 内で順序保証。
- 検証は自 cohort のみ（cohort 境界維持）。受講生 403・未認証 401。

## 動作確認チェックリスト

- [x] `DOCKER_API_VERSION=1.44 ./gradlew test` 全 green（連鎖valid／途中行改ざんで破れ行ID検知／検証は講師限定・他cohortは自分の空連鎖／既存の監査認可テストも維持）
- [x] `.env` ファイルやパスワードをコミットしていない
