### PR TITLE
feat: TOTPシークレットの at-rest 暗号化（AES-GCM）

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/AuthService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/AuthService.java
@@ -23,11 +23,13 @@ public class AuthService {
     private final InviteService inviteService;
     private final com.reviewboard.domain.mfa.TotpService totpService;
     private final com.reviewboard.domain.mfa.RecoveryCodeService recoveryCodeService;
+    private final com.reviewboard.domain.mfa.SecretCipher secretCipher;
 
     public AuthService(UserRepository userRepository, PasswordEncoder passwordEncoder,
                        JwtService jwtService, RefreshTokenService refreshTokenService,
                        InviteService inviteService, com.reviewboard.domain.mfa.TotpService totpService,
-                       com.reviewboard.domain.mfa.RecoveryCodeService recoveryCodeService) {
+                       com.reviewboard.domain.mfa.RecoveryCodeService recoveryCodeService,
+                       com.reviewboard.domain.mfa.SecretCipher secretCipher) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.jwtService = jwtService;
@@ -35,6 +37,7 @@ public class AuthService {
         this.inviteService = inviteService;
         this.totpService = totpService;
         this.recoveryCodeService = recoveryCodeService;
+        this.secretCipher = secretCipher;
     }
 
     /**
@@ -96,7 +99,7 @@ public class AuthService {
         if (!user.isMfaEnabled()) {
             throw new BadCredentialsException();
         }
-        boolean ok = totpService.verify(user.getTotpSecret(), code)
+        boolean ok = totpService.verify(secretCipher.decrypt(user.getTotpSecret()), code)
                 || recoveryCodeService.consume(userId, code);
         if (!ok) {
             throw new BadCredentialsException();

--- a/review-board/backend/src/main/java/com/reviewboard/domain/mfa/MfaService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/mfa/MfaService.java
@@ -25,12 +25,14 @@ public class MfaService {
     private final UserRepository userRepository;
     private final TotpService totpService;
     private final RecoveryCodeService recoveryCodeService;
+    private final SecretCipher secretCipher;
 
     public MfaService(UserRepository userRepository, TotpService totpService,
-                      RecoveryCodeService recoveryCodeService) {
+                      RecoveryCodeService recoveryCodeService, SecretCipher secretCipher) {
         this.userRepository = userRepository;
         this.totpService = totpService;
         this.recoveryCodeService = recoveryCodeService;
+        this.secretCipher = secretCipher;
     }
 
     /** TOTP セットアップ開始。新しいシークレットを保存（pending）し、認証アプリ取り込み用の情報を返す。 */
@@ -43,7 +45,8 @@ public class MfaService {
             throw new InvalidRequestException("二要素認証は既に有効です");
         }
         String secret = totpService.generateSecret();
-        user.setTotpSecret(secret);
+        // #249 at-rest 暗号化：DB には暗号文（v1:...）で保存。QR には生シークレットを内包する。
+        user.setTotpSecret(secretCipher.encrypt(secret));
         user.setMfaEnabled(false);
         user.setUpdatedAt(OffsetDateTime.now());
         // 生シークレットは返さず QR にのみ内包する（取り込みは QR スキャン一本化・#239）。
@@ -64,7 +67,7 @@ public class MfaService {
         if (user.getTotpSecret() == null) {
             throw new InvalidRequestException("先に二要素認証のセットアップを開始してください");
         }
-        if (!totpService.verify(user.getTotpSecret(), code)) {
+        if (!totpService.verify(secretCipher.decrypt(user.getTotpSecret()), code)) {
             throw new InvalidRequestException("コードが正しくありません");
         }
         user.setMfaEnabled(true);
@@ -83,7 +86,7 @@ public class MfaService {
         if (!user.isMfaEnabled()) {
             throw new InvalidRequestException("二要素認証は有効になっていません");
         }
-        if (!totpService.verify(user.getTotpSecret(), code)) {
+        if (!totpService.verify(secretCipher.decrypt(user.getTotpSecret()), code)) {
             throw new InvalidRequestException("コードが正しくありません");
         }
         user.setMfaEnabled(false);
@@ -105,7 +108,7 @@ public class MfaService {
         if (!user.isMfaEnabled()) {
             throw new InvalidRequestException("二要素認証は有効になっていません");
         }
-        if (!totpService.verify(user.getTotpSecret(), code)) {
+        if (!totpService.verify(secretCipher.decrypt(user.getTotpSecret()), code)) {
             throw new InvalidRequestException("コードが正しくありません");
         }
         return recoveryCodeService.regenerate(userId);

--- a/review-board/backend/src/main/java/com/reviewboard/domain/mfa/SecretCipher.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/mfa/SecretCipher.java
@@ -1,0 +1,96 @@
+package com.reviewboard.domain.mfa;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Base64;
+
+/**
+ * 機微な秘密（TOTP シークレット）の at-rest 暗号化（Issue #249）。AES-256-GCM。
+ *
+ * <p>保存形式は {@code v1:base64(iv(12B) || ciphertext+tag)}。IV はリクエストごとにランダム
+ * （GCM の nonce 再利用を避ける）。鍵は {@code app.mfa.enc-key}（env {@code MFA_ENC_KEY}・
+ * base64 の 32 バイト）。本番は SSM SecureString で注入する。
+ *
+ * <p>後方互換：{@code v1:} 接頭辞の無い値は legacy 平文として {@link #decrypt} がそのまま返す
+ * （V17 時代の平文シークレット）。次回 setup で暗号化形式に置き換わるためロックアウトを起こさない。
+ *
+ * <p>鍵未設定（空）時：暗号化/復号（v1 値）の呼び出し時のみ例外。MFA を使わない運用は影響を受けない。
+ */
+@Component
+public class SecretCipher {
+
+    private static final String PREFIX = "v1:";
+    private static final String TRANSFORMATION = "AES/GCM/NoPadding";
+    private static final int IV_BYTES = 12;     // GCM 推奨 96bit
+    private static final int TAG_BITS = 128;
+
+    private final SecretKeySpec key; // null = 鍵未設定
+    private final SecureRandom random = new SecureRandom();
+
+    public SecretCipher(@Value("${app.mfa.enc-key:}") String base64Key) {
+        if (base64Key == null || base64Key.isBlank()) {
+            this.key = null;
+            return;
+        }
+        byte[] raw = Base64.getDecoder().decode(base64Key.trim());
+        if (raw.length != 16 && raw.length != 24 && raw.length != 32) {
+            throw new IllegalStateException("app.mfa.enc-key は base64 の 16/24/32 バイト（AES鍵長）で指定してください");
+        }
+        this.key = new SecretKeySpec(raw, "AES");
+    }
+
+    /** 平文を暗号化し {@code v1:...} 形式で返す。鍵未設定なら例外。 */
+    public String encrypt(String plaintext) {
+        requireKey();
+        try {
+            byte[] iv = new byte[IV_BYTES];
+            random.nextBytes(iv);
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(TAG_BITS, iv));
+            byte[] ct = cipher.doFinal(plaintext.getBytes(StandardCharsets.UTF_8));
+            byte[] out = new byte[iv.length + ct.length];
+            System.arraycopy(iv, 0, out, 0, iv.length);
+            System.arraycopy(ct, 0, out, iv.length, ct.length);
+            return PREFIX + Base64.getEncoder().encodeToString(out);
+        } catch (Exception e) {
+            throw new IllegalStateException("TOTP シークレットの暗号化に失敗しました", e);
+        }
+    }
+
+    /**
+     * 暗号文（{@code v1:...}）を復号する。接頭辞の無い legacy 平文はそのまま返す（後方互換）。
+     * v1 値の復号で鍵未設定なら例外。
+     */
+    public String decrypt(String stored) {
+        if (stored == null) {
+            return null;
+        }
+        if (!stored.startsWith(PREFIX)) {
+            return stored; // legacy 平文（V17）。次回 setup で暗号化形式に置き換わる。
+        }
+        requireKey();
+        try {
+            byte[] all = Base64.getDecoder().decode(stored.substring(PREFIX.length()));
+            byte[] iv = Arrays.copyOfRange(all, 0, IV_BYTES);
+            byte[] ct = Arrays.copyOfRange(all, IV_BYTES, all.length);
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(TAG_BITS, iv));
+            return new String(cipher.doFinal(ct), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new IllegalStateException("TOTP シークレットの復号に失敗しました", e);
+        }
+    }
+
+    private void requireKey() {
+        if (key == null) {
+            throw new IllegalStateException("MFA_ENC_KEY（app.mfa.enc-key）が未設定です。MFA の暗号化に必要です。");
+        }
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/user/User.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/user/User.java
@@ -51,8 +51,11 @@ public class User {
     @Column(name = "avatar_key", length = 512)
     private String avatarKey;
 
-    /** TOTP シークレット（Base32・#235）。setup 中は値を持つが mfaEnabled=false（pending）。未設定は null。 */
-    @Column(name = "totp_secret", length = 64)
+    /**
+     * TOTP シークレット（#235）。setup 中は値を持つが mfaEnabled=false（pending）。未設定は null。
+     * #249 以降は at-rest 暗号化（"v1:..." 形式）で保存（V20 で 255 文字へ拡張）。
+     */
+    @Column(name = "totp_secret", length = 255)
     private String totpSecret;
 
     /** 二要素認証（TOTP）が有効か（#235）。true のときだけログインで TOTP を要求する。 */

--- a/review-board/backend/src/main/resources/application.yml
+++ b/review-board/backend/src/main/resources/application.yml
@@ -131,6 +131,10 @@ app:
   digest:
     enabled: ${DIGEST_ENABLED:true}
     cron: ${DIGEST_CRON:0 0 8 * * MON}
+  # C-6 MFA（#249）。TOTP シークレットの at-rest 暗号化鍵（base64 エンコードした 32 バイト＝AES-256）。
+  # 未設定なら MFA の暗号化/復号が必要になった時だけ失敗（MFA 未使用の運用は無影響）。本番は SSM SecureString。
+  mfa:
+    enc-key: ${MFA_ENC_KEY:}
 
 ---
 # dev プロファイル：自動サムネを ON にし、mac の Chrome を既定パスで使う（env で上書き可）。

--- a/review-board/backend/src/main/resources/db/migration/V20__widen_totp_secret.sql
+++ b/review-board/backend/src/main/resources/db/migration/V20__widen_totp_secret.sql
@@ -1,0 +1,8 @@
+-- TOTP シークレット at-rest 暗号化（Issue #249）に伴うカラム拡張。
+--
+-- V17 は平文 Base32（最長 64 文字）想定で totp_secret VARCHAR(64) としていた。
+-- AES-GCM 暗号化後は "v1:" + base64(iv(12B) + ciphertext + tag(16B)) となり 64 文字を超える
+-- （32 バイトの Base32 シークレットで約 83 文字）。余裕を持って 255 文字に拡張する。
+
+ALTER TABLE users
+    ALTER COLUMN totp_secret TYPE VARCHAR(255);

--- a/review-board/backend/src/test/java/com/reviewboard/domain/mfa/MfaIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/mfa/MfaIntegrationTest.java
@@ -49,7 +49,7 @@ class MfaIntegrationTest extends AbstractIntegrationTest {
         assertThat(JsonPath.<String>read(setup.getResponse().getContentAsString(), "$.qrDataUri"))
                 .startsWith("data:image");
         // コード生成用のシークレットは QR に内包される。テストは DB から取得して算出する。
-        String secret = userRepository.findByEmail(EMAIL).orElseThrow().getTotpSecret();
+        String secret = secretCipher.decrypt(userRepository.findByEmail(EMAIL).orElseThrow().getTotpSecret());
 
         // #241 有効化はリカバリコード 10 個を1度だけ返す（200）。
         mockMvc.perform(post("/api/auth/mfa/enable").cookie(access)
@@ -64,7 +64,7 @@ class MfaIntegrationTest extends AbstractIntegrationTest {
     @SuppressWarnings("unchecked")
     private java.util.List<String> setupAndEnableCapturingCodes(Cookie access) throws Exception {
         mockMvc.perform(post("/api/auth/mfa/setup").cookie(access)).andExpect(status().isOk());
-        String secret = userRepository.findByEmail(EMAIL).orElseThrow().getTotpSecret();
+        String secret = secretCipher.decrypt(userRepository.findByEmail(EMAIL).orElseThrow().getTotpSecret());
         MvcResult res = mockMvc.perform(post("/api/auth/mfa/enable").cookie(access)
                         .contentType("application/json")
                         .content("{\"code\":\"" + currentCode(secret) + "\"}"))
@@ -231,7 +231,7 @@ class MfaIntegrationTest extends AbstractIntegrationTest {
     void totp_still_works_after_recovery_exists() throws Exception {
         Cookie access = login(EMAIL);
         java.util.List<String> codes = setupAndEnableCapturingCodes(access);
-        String secret = userRepository.findByEmail(EMAIL).orElseThrow().getTotpSecret();
+        String secret = secretCipher.decrypt(userRepository.findByEmail(EMAIL).orElseThrow().getTotpSecret());
 
         // リカバリコードで1回ログイン。
         Cookie mfa1 = passwordLogin(EMAIL).getResponse().getCookie("mfa_token");
@@ -288,7 +288,7 @@ class MfaIntegrationTest extends AbstractIntegrationTest {
     void regenerate_invalidates_old_codes() throws Exception {
         Cookie access = login(EMAIL);
         java.util.List<String> oldCodes = setupAndEnableCapturingCodes(access);
-        String secret = userRepository.findByEmail(EMAIL).orElseThrow().getTotpSecret();
+        String secret = secretCipher.decrypt(userRepository.findByEmail(EMAIL).orElseThrow().getTotpSecret());
 
         MvcResult res = mockMvc.perform(post("/api/auth/mfa/recovery-codes/regenerate").cookie(access)
                         .contentType("application/json")
@@ -329,7 +329,7 @@ class MfaIntegrationTest extends AbstractIntegrationTest {
     void disable_clears_recovery_codes() throws Exception {
         Cookie access = login(EMAIL);
         setupAndEnableCapturingCodes(access);
-        String secret = userRepository.findByEmail(EMAIL).orElseThrow().getTotpSecret();
+        String secret = secretCipher.decrypt(userRepository.findByEmail(EMAIL).orElseThrow().getTotpSecret());
 
         mockMvc.perform(post("/api/auth/mfa/disable").cookie(access)
                         .contentType("application/json")

--- a/review-board/backend/src/test/java/com/reviewboard/domain/mfa/SecretCipherTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/mfa/SecretCipherTest.java
@@ -1,0 +1,64 @@
+package com.reviewboard.domain.mfa;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * TOTP シークレット at-rest 暗号化（#249）の単体テスト。Spring 不要・鍵を直接渡す。
+ */
+class SecretCipherTest {
+
+    private static final String KEY = Base64.getEncoder()
+            .encodeToString("test-mfa-enc-key-32-bytes-long!!".getBytes(StandardCharsets.UTF_8));
+
+    private final SecretCipher cipher = new SecretCipher(KEY);
+
+    @Test
+    void encrypt_then_decrypt_roundtrips() {
+        String plain = "JBSWY3DPEHPK3PXP"; // Base32 TOTP シークレット相当
+        String enc = cipher.encrypt(plain);
+        assertThat(enc).startsWith("v1:").isNotEqualTo(plain);
+        assertThat(cipher.decrypt(enc)).isEqualTo(plain);
+    }
+
+    @Test
+    void encrypt_uses_random_iv_so_ciphertexts_differ() {
+        String plain = "SAMESECRET123456";
+        assertThat(cipher.encrypt(plain)).isNotEqualTo(cipher.encrypt(plain));
+        // ただしどちらも同じ平文に復号できる。
+        assertThat(cipher.decrypt(cipher.encrypt(plain))).isEqualTo(plain);
+    }
+
+    @Test
+    void decrypt_passes_through_legacy_plaintext() {
+        // v1: 接頭辞の無い値（V17 時代の平文）はそのまま返す（後方互換）。
+        assertThat(cipher.decrypt("LEGACYPLAINTEXT1")).isEqualTo("LEGACYPLAINTEXT1");
+    }
+
+    @Test
+    void decrypt_null_is_null() {
+        assertThat(cipher.decrypt(null)).isNull();
+    }
+
+    @Test
+    void no_key_fails_only_on_use() {
+        SecretCipher noKey = new SecretCipher("");
+        // 鍵未設定でも legacy 平文の読み取りは可能（MFA 未使用運用は無影響）。
+        assertThat(noKey.decrypt("plain")).isEqualTo("plain");
+        assertThat(noKey.decrypt(null)).isNull();
+        // 暗号化・v1 値の復号は明確に失敗。
+        assertThatThrownBy(() -> noKey.encrypt("x")).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> noKey.decrypt("v1:zzzz")).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void invalid_key_length_is_rejected() {
+        assertThatThrownBy(() -> new SecretCipher(Base64.getEncoder().encodeToString("short".getBytes())))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/review-board/backend/src/test/java/com/reviewboard/support/AbstractIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/support/AbstractIntegrationTest.java
@@ -70,6 +70,9 @@ public abstract class AbstractIntegrationTest {
         registry.add("spring.datasource.username", POSTGRES::getUsername);
         registry.add("spring.datasource.password", POSTGRES::getPassword);
         registry.add("app.jwt.secret", () -> "test-secret-please-change-32chars-minimum");
+        // #249 TOTP at-rest 暗号鍵（base64 32バイト＝AES-256）。テスト用固定鍵。
+        registry.add("app.mfa.enc-key", () -> java.util.Base64.getEncoder()
+                .encodeToString("test-mfa-enc-key-32-bytes-long!!".getBytes(java.nio.charset.StandardCharsets.UTF_8)));
         registry.add("app.storage.s3.endpoint", MINIO::getS3URL);
         registry.add("app.storage.s3.access-key", MINIO::getUserName);
         registry.add("app.storage.s3.secret-key", MINIO::getPassword);
@@ -93,6 +96,7 @@ public abstract class AbstractIntegrationTest {
     @Autowired protected com.reviewboard.domain.notificationpref.UserNotificationPrefRepository notificationPrefRepository;
     @Autowired protected com.reviewboard.domain.invite.CohortInviteRepository inviteRepository;
     @Autowired protected com.reviewboard.domain.mfa.MfaRecoveryCodeRepository mfaRecoveryCodeRepository;
+    @Autowired protected com.reviewboard.domain.mfa.SecretCipher secretCipher;
     @Autowired protected org.springframework.security.crypto.password.PasswordEncoder passwordEncoder;
     @Autowired protected com.reviewboard.domain.auth.RateLimitFilter rateLimitFilter;
 


### PR DESCRIPTION
## 関連 Issue

Closes #249

---

## 変更の概要

MFA の TOTP シークレット（`users.totp_secret`）を**平文保存から AES-256-GCM 暗号化保存**へ。DB 流出時のシークレット漏えいを防ぐ（V17 に将来課題として明記していた at-rest 暗号化を実装）。

- `SecretCipher`：AES/GCM/NoPadding（256bit 鍵・96bit ランダム IV・128bit タグ）。保存形式 `v1:base64(iv+ciphertext+tag)`。鍵は `app.mfa.enc-key`（env `MFA_ENC_KEY`・base64 32 バイト）。
- `MfaService.setup` で暗号化保存、`enable`/`disable`/`regenerate` と `AuthService.verifyMfaAndLogin` で復号して照合。
- **後方互換**：`v1:` 接頭辞の無い値は legacy 平文としてそのまま読む（V17 時代の値）。次回 setup で暗号化形式に置き換わる＝**ロックアウトを起こさない**。鍵未設定時は暗号化/`v1:` 復号の呼び出し時のみ失敗（MFA 未使用運用は無影響）。
- migration **V20**：暗号文は 64 文字を超えるため `totp_secret` を `VARCHAR(255)` に拡張（entity の `@Column(length)` も更新）。

## 変更の種別

- [x] feat（新機能の追加）

---

## セキュリティ（重点軸）

- 鍵はコード直書き禁止・env/SSM。`MFA_ENC_KEY` は機密。IV はリクエストごとにランダム（GCM nonce 再利用回避）。

## 動作確認チェックリスト

- [x] `DOCKER_API_VERSION=1.44 ./gradlew test` 全 green（SecretCipher 単体：往復／ランダムIV／legacy 透過／null／鍵未設定／不正鍵長。MFA 結合：暗号化保存下で setup→2段階ログイン・リカバリ・再生成が通る）
- [x] `.env` ファイルやパスワードをコミットしていない

## 本番反映時の注意（人間・修練城）

- 本番で MFA setup を使う前に **`MFA_ENC_KEY`（base64 32バイト）を SSM SecureString に登録**し env 注入する。既存の平文シークレット（あれば）は後方互換で読め、次回 setup で暗号化される。
- migration V20 は列拡張のみ（非破壊）。
