### PR TITLE
test: JaCoCo カバレッジゲート（回帰床を CI で強制）

### DIFF
--- a/.github/workflows/review-board-ci.yml
+++ b/.github/workflows/review-board-ci.yml
@@ -57,6 +57,10 @@ jobs:
       - name: Test
         run: ./gradlew test --no-daemon
 
+      # カバレッジ回帰床ゲート（母 M-9・#251）。閾値割れで fail。
+      - name: Coverage gate (JaCoCo)
+        run: ./gradlew jacocoTestCoverageVerification --no-daemon
+
       # 失敗時にテストレポートを保全（M-10：ログを残す）。
       - name: Upload test report
         if: always()

--- a/review-board/backend/build.gradle
+++ b/review-board/backend/build.gradle
@@ -93,11 +93,32 @@ tasks.named('test') {
 	finalizedBy jacocoTestReport
 }
 
-// JaCoCo カバレッジ。Phase 1 はレポート生成のみ・閾値ゲートなし（テスト計画書 §5）。
+// JaCoCo カバレッジ。レポート生成＋回帰床ゲート（母 M-9・#251）。
 jacocoTestReport {
 	dependsOn test
 	reports {
 		xml.required = true
 		html.required = true
+	}
+}
+
+// カバレッジ回帰床（#251）。満点目標ではなく「静かに下がるのを防ぐ床」。
+// 現状（INSTRUCTION 83% / BRANCH 61%）に余裕を持たせて flaky 化を避ける。
+// テスト拡充に伴い将来引き上げてよい。
+jacocoTestCoverageVerification {
+	dependsOn jacocoTestReport
+	violationRules {
+		rule {
+			limit {
+				counter = 'INSTRUCTION'
+				value = 'COVEREDRATIO'
+				minimum = 0.75
+			}
+			limit {
+				counter = 'BRANCH'
+				value = 'COVEREDRATIO'
+				minimum = 0.50
+			}
+		}
 	}
 }


### PR DESCRIPTION
## 関連 Issue

Closes #251

## 変更の概要

JaCoCo の閾値ゲートを追加し、カバレッジの静かな低下（回帰）を CI で防ぐ（M-9）。**満点目標ではなく床**。

- `backend/build.gradle`：`jacocoTestCoverageVerification`（bundle **INSTRUCTION ≥ 0.75 / BRANCH ≥ 0.50**）。現状 INSTRUCTION 83.3% / BRANCH 61.4% に余裕を持たせ flaky 化を回避。
- `review-board-ci.yml`：`test` の後に `jacocoTestCoverageVerification` ステップを追加（閾値割れで fail）。

## 変更の種別

- [x] test / chore

## 動作確認チェックリスト

- [x] ローカルで `./gradlew jacocoTestCoverageVerification` green（現状で通過）
- [x] `.env` ファイルやパスワードをコミットしていない