### PR TITLE
ci: サプライチェーン強化（Dependabot + CodeQL SAST + SBOM）

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,56 @@
+# Dependabot：依存の自動更新 PR（#253）。供給網の脆弱性を放置しないための定期更新。
+# monorepo のため review-board の各エコシステムをディレクトリ指定で個別に対象化する。
+# 更新はまとめて（grouped）週次で出し、PR 洪水を避ける。ラベルは chore。
+version: 2
+updates:
+  # backend（Gradle）
+  - package-ecosystem: gradle
+    directory: /review-board/backend
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - chore
+    groups:
+      backend-deps:
+        patterns:
+          - "*"
+
+  # frontend（npm）
+  - package-ecosystem: npm
+    directory: /review-board/frontend
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - chore
+    groups:
+      frontend-deps:
+        patterns:
+          - "*"
+
+  # e2e（Playwright・npm）
+  - package-ecosystem: npm
+    directory: /review-board/e2e
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - chore
+    groups:
+      e2e-deps:
+        patterns:
+          - "*"
+
+  # GitHub Actions のワークフローで使う action のバージョン更新
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - chore
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/review-board-codeql.yml
+++ b/.github/workflows/review-board-codeql.yml
@@ -1,0 +1,76 @@
+name: review-board CodeQL (SAST)
+
+# ============================================================
+# CodeQL による静的アプリケーションセキュリティテスト（SAST・#253）。
+# Java（backend）と JavaScript/TypeScript（frontend）を解析する。
+# 公開リポジトリのため CodeQL は無料。paths は review-board に限定し、
+# monorepo の他アプリ（task-board 等）には走らせない。
+# ============================================================
+
+on:
+  pull_request:
+    paths:
+      - 'review-board/backend/**'
+      - 'review-board/frontend/**'
+      - '.github/workflows/review-board-codeql.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'review-board/backend/**'
+      - 'review-board/frontend/**'
+      - '.github/workflows/review-board-codeql.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: rb-codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write   # CodeQL の結果を Security タブに上げる
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: java-kotlin
+            build-mode: manual
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Java は解析にコンパイルが要る。foojay toolchain が JDK 25 を取得する想定で JDK 21 を入れる。
+      - name: Set up JDK 21
+        if: matrix.language == 'java-kotlin'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # 解析対象を review-board に限定（他アプリのソースを取り込まない）。
+          config: |
+            paths:
+              - review-board/backend/src
+              - review-board/frontend/src
+
+      # manual build：CodeQL がトレースできるよう backend をコンパイルする。
+      - name: Build backend (for CodeQL trace)
+        if: matrix.language == 'java-kotlin'
+        working-directory: review-board/backend
+        run: ./gradlew compileJava --no-daemon
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/review-board-sbom.yml
+++ b/.github/workflows/review-board-sbom.yml
@@ -1,0 +1,78 @@
+name: review-board SBOM (CycloneDX)
+
+# ============================================================
+# SBOM（ソフトウェア部品表）を CycloneDX 形式で生成する（#253）。
+# 供給網の可視化：何のライブラリをどのバージョンで同梱しているかを成果物化する。
+# backend は bootJar を Syft で走査（transitive まで網羅）、frontend は
+# package-lock.json を走査する。生成物はアーティファクトとして保全。
+# ============================================================
+
+on:
+  pull_request:
+    paths:
+      - 'review-board/backend/**'
+      - 'review-board/frontend/**'
+      - '.github/workflows/review-board-sbom.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'review-board/backend/**'
+      - 'review-board/frontend/**'
+      - '.github/workflows/review-board-sbom.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: rb-sbom-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sbom-backend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      # fat jar の BOOT-INF/lib に transitive 依存が同梱される＝網羅的な SBOM になる。
+      - name: Build bootJar
+        working-directory: review-board/backend
+        run: ./gradlew bootJar --no-daemon
+
+      - name: Generate backend SBOM (CycloneDX)
+        uses: anchore/sbom-action@v0
+        with:
+          path: review-board/backend/build/libs
+          format: cyclonedx-json
+          artifact-name: sbom-backend-cyclonedx.json
+
+  sbom-frontend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      # package-lock.json を Syft の npm カタロガが解釈する（ビルド不要）。
+      - name: Generate frontend SBOM (CycloneDX)
+        uses: anchore/sbom-action@v0
+        with:
+          path: review-board/frontend
+          format: cyclonedx-json
+          artifact-name: sbom-frontend-cyclonedx.json


### PR DESCRIPTION
## 関連 Issue

Closes #253

## 変更の概要

依存スキャン（Trivy）・gitleaks に加え、**SAST（CodeQL）・依存自動更新（Dependabot）・SBOM 生成**を整備し供給網を強化（公開リポは CodeQL 無料）。

- `.github/dependabot.yml`：gradle（backend）・npm（frontend・e2e）・github-actions を**週次グループ更新**（PR 洪水回避・ラベル chore）。
- `review-board-codeql.yml`：CodeQL SAST。`java-kotlin`（manual build＝gradle compile）＋ `javascript-typescript`（none）。**paths を review-board に限定**（他アプリを走らせない）。
- `review-board-sbom.yml`：CycloneDX SBOM。backend は bootJar を Syft 走査（transitive 網羅）、frontend は package-lock を走査。アーティファクト保全。

## 変更の種別

- [x] chore（CI）

## 動作確認

- 本 PR は各 workflow の自己 path を変更するため、**CodeQL / SBOM は本 PR 上で実走して検証される**。
- Dependabot 設定は GitHub の Dependabot パーサが検証（PR チェックには出ない）。
- `.env` ファイルやパスワードはコミットしていない。