### PR TITLE
feat: 自分のデータのエクスポート（GET /api/me/export）

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/domain/me/DataExportService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/me/DataExportService.java
@@ -1,0 +1,69 @@
+package com.reviewboard.domain.me;
+
+import com.reviewboard.domain.me.dto.MyDataExportResponse;
+import com.reviewboard.domain.post.Post;
+import com.reviewboard.domain.post.PostRepository;
+import com.reviewboard.domain.review.Review;
+import com.reviewboard.domain.review.ReviewRepository;
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * 自分のデータのエクスポート（#261）。常に principal の userId のデータのみを集約する
+ * （他人の資源には触れない＝IDOR の余地を作らない）。論理削除済みは含めない。
+ */
+@Service
+public class DataExportService {
+
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final ReviewRepository reviewRepository;
+
+    public DataExportService(UserRepository userRepository, PostRepository postRepository,
+                             ReviewRepository reviewRepository) {
+        this.userRepository = userRepository;
+        this.postRepository = postRepository;
+        this.reviewRepository = reviewRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public MyDataExportResponse export(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalStateException("authenticated user not found"));
+
+        MyDataExportResponse.Profile profile = new MyDataExportResponse.Profile(
+                user.getId(), user.getEmail(), user.getDisplayName(), user.getRole().name(),
+                user.getCohortId(), user.getBio(), user.isMfaEnabled(),
+                user.getReceivedReviewsCount(), user.getGivenReviewsCount(), user.getThanksReceivedCount(),
+                user.getCreatedAt());
+
+        List<MyDataExportResponse.ExportedPost> posts =
+                postRepository.findByAuthorUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(userId).stream()
+                        .map(this::toPost).toList();
+
+        List<MyDataExportResponse.ExportedReview> reviews =
+                reviewRepository.findByReviewerUserIdAndDeletedAtIsNull(userId).stream()
+                        .map(this::toReview).toList();
+
+        return new MyDataExportResponse(OffsetDateTime.now(), profile, posts, reviews);
+    }
+
+    private MyDataExportResponse.ExportedPost toPost(Post p) {
+        return new MyDataExportResponse.ExportedPost(
+                p.getId(), p.getTitle(), p.getDescription(), p.getRepoUrl(), p.getDemoUrl(),
+                p.getRecruitStatus() == null ? null : p.getRecruitStatus().name(),
+                p.getReviewCount(), p.getLikeCount(), p.getCreatedAt());
+    }
+
+    private MyDataExportResponse.ExportedReview toReview(Review r) {
+        return new MyDataExportResponse.ExportedReview(
+                r.getId(), r.getPostId(), r.getGood(), r.getImprovement(),
+                r.getGrowthStatus() == null ? null : r.getGrowthStatus().name(),
+                r.getBeforeAfter(), r.getThanksCount(), r.getRepliesCount(), r.getCreatedAt());
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/me/MeController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/me/MeController.java
@@ -1,0 +1,35 @@
+package com.reviewboard.domain.me;
+
+import com.reviewboard.domain.auth.AuthPrincipal;
+import com.reviewboard.domain.me.dto.MyDataExportResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 自分自身のデータに対する操作（#261）。常に認証済み principal のデータのみ（本人限定）。
+ */
+@RestController
+@RequestMapping("/api/me")
+public class MeController {
+
+    private final DataExportService dataExportService;
+
+    public MeController(DataExportService dataExportService) {
+        this.dataExportService = dataExportService;
+    }
+
+    /** 自分のデータ（プロフィール・投稿・レビュー）を JSON で返す（ダウンロード）。 */
+    @GetMapping("/export")
+    public ResponseEntity<MyDataExportResponse> export(@AuthenticationPrincipal AuthPrincipal principal) {
+        MyDataExportResponse body = dataExportService.export(principal.userId());
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"my-data.json\"")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(body);
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/me/dto/MyDataExportResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/me/dto/MyDataExportResponse.java
@@ -1,0 +1,54 @@
+package com.reviewboard.domain.me.dto;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * 自分のデータのエクスポート（#261・GDPR 的なデータポータビリティの最小実装）。
+ * プロフィール＋自分の投稿＋自分が書いたレビューを JSON で返す。
+ * パスワードハッシュ・TOTP シークレット等の機密は含めない。
+ */
+public record MyDataExportResponse(
+        OffsetDateTime exportedAt,
+        Profile profile,
+        List<ExportedPost> posts,
+        List<ExportedReview> reviews) {
+
+    public record Profile(
+            Long id,
+            String email,
+            String displayName,
+            String role,
+            Long cohortId,
+            String bio,
+            boolean mfaEnabled,
+            int receivedReviewsCount,
+            int givenReviewsCount,
+            int thanksReceivedCount,
+            OffsetDateTime createdAt) {
+    }
+
+    public record ExportedPost(
+            Long id,
+            String title,
+            String description,
+            String repoUrl,
+            String demoUrl,
+            String recruitStatus,
+            int reviewCount,
+            int likeCount,
+            OffsetDateTime createdAt) {
+    }
+
+    public record ExportedReview(
+            Long id,
+            Long postId,
+            String good,
+            String improvement,
+            String growthStatus,
+            String beforeAfter,
+            int thanksCount,
+            int repliesCount,
+            OffsetDateTime createdAt) {
+    }
+}

--- a/review-board/backend/src/test/java/com/reviewboard/domain/me/DataExportIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/me/DataExportIntegrationTest.java
@@ -1,0 +1,79 @@
+package com.reviewboard.domain.me;
+
+import com.reviewboard.domain.user.UserRole;
+import com.reviewboard.support.AbstractIntegrationTest;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * 自分のデータのエクスポート（#261）。本人のデータのみ・機密を含まない・未認証 401 を検証する。
+ */
+class DataExportIntegrationTest extends AbstractIntegrationTest {
+
+    private String emailA;
+    private String emailB;
+
+    @BeforeEach
+    void seed() throws Exception {
+        var a = newCohort("A");
+        emailA = newUser("a@example.com", UserRole.STUDENT, a.getId()).getEmail();
+        emailB = newUser("b@example.com", UserRole.STUDENT, a.getId()).getEmail();
+
+        // A は自分の投稿を作る。B も投稿し、A はその B の投稿にレビューを書く。
+        createPost(login(emailA), "Aの作品");
+        long postB = createPost(login(emailB), "Bの作品");
+        mockMvc.perform(post("/api/posts/" + postB + "/reviews").cookie(login(emailA))
+                        .contentType("application/json")
+                        .content("{\"good\":\"いいね\",\"improvement\":\"ここ直そう\"}"))
+                .andExpect(status().isCreated());
+    }
+
+    /** 本人の投稿・レビューが含まれ、他人の投稿は含まれない。機密は含まれない。 */
+    @Test
+    void export_contains_own_data_only() throws Exception {
+        mockMvc.perform(get("/api/me/export").cookie(login(emailA)))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Disposition", org.hamcrest.Matchers.containsString("attachment")))
+                .andExpect(jsonPath("$.profile.email").value(emailA))
+                // 機密はそもそも DTO に存在しない。
+                .andExpect(jsonPath("$.profile.passwordHash").doesNotExist())
+                .andExpect(jsonPath("$.profile.totpSecret").doesNotExist())
+                // 自分の投稿は 1 件（Aの作品）。Bの作品は含まれない。
+                .andExpect(jsonPath("$.posts.length()").value(1))
+                .andExpect(jsonPath("$.posts[0].title").value("Aの作品"))
+                // 自分が書いたレビューは 1 件。
+                .andExpect(jsonPath("$.reviews.length()").value(1))
+                .andExpect(jsonPath("$.reviews[0].good").value("いいね"));
+    }
+
+    /** B の export には B の投稿のみ・A のレビューは含まれない。 */
+    @Test
+    void export_is_scoped_per_user() throws Exception {
+        mockMvc.perform(get("/api/me/export").cookie(login(emailB)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.profile.email").value(emailB))
+                .andExpect(jsonPath("$.posts.length()").value(1))
+                .andExpect(jsonPath("$.posts[0].title").value("Bの作品"))
+                .andExpect(jsonPath("$.reviews.length()").value(0));
+    }
+
+    /** 未認証は 401。 */
+    @Test
+    void unauthenticated_is_401() throws Exception {
+        mockMvc.perform(get("/api/me/export")).andExpect(status().isUnauthorized());
+    }
+
+    private long createPost(Cookie cookie, String title) throws Exception {
+        MvcResult res = mockMvc.perform(post("/api/posts").cookie(cookie)
+                        .contentType("application/json")
+                        .content("{\"title\":\"" + title + "\",\"description\":\"説明\"}"))
+                .andExpect(status().isCreated()).andReturn();
+        return readId(res);
+    }
+}

--- a/review-board/frontend/src/api/me.js
+++ b/review-board/frontend/src/api/me.js
@@ -1,0 +1,4 @@
+import client from './client';
+
+// 自分のデータのエクスポート（#261）。本人のプロフィール・投稿・レビューを JSON で取得。
+export const exportMyData = () => client.get('/me/export').then((r) => r.data);

--- a/review-board/frontend/src/pages/ProfilePage.jsx
+++ b/review-board/frontend/src/pages/ProfilePage.jsx
@@ -3,6 +3,7 @@ import { useParams, Link } from 'react-router-dom';
 import { fetchProfile, updateMyProfile } from '../api/profile';
 import { fetchNotificationPrefs, updateNotificationPrefs } from '../api/notificationPrefs';
 import { setupMfa, enableMfa, disableMfa, getRecoveryStatus, regenerateRecoveryCodes } from '../api/mfa';
+import { exportMyData } from '../api/me';
 import { ROLE_LABEL, EVAL_LABEL } from '../constants';
 import { useAuth } from '../context/AuthContext';
 import Avatar from '../components/Avatar';
@@ -68,6 +69,8 @@ export default function ProfilePage() {
       {isOwn && <NotificationPrefsCard />}
 
       {isOwn && <MfaCard />}
+
+      {isOwn && <DataPrivacyCard />}
 
       <section>
         <h3 className="mac-h mb-3 text-lg">投稿した成果物（{posts.length}）</h3>
@@ -517,6 +520,45 @@ function RecoveryCodesPanel({ codes, onDone }) {
         <button type="button" onClick={onDone} className="mac-btn-brand">保存しました（閉じる）</button>
       </div>
     </div>
+  );
+}
+
+// データと privacy（本人のみ・#261）。自分のデータを JSON でエクスポート（ダウンロード）。
+// 退会（アカウント削除）は後続で本カードに追加予定。
+function DataPrivacyCard() {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  const onExport = async () => {
+    setError('');
+    setBusy(true);
+    try {
+      const data = await exportMyData();
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'my-data.json';
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      setError('エクスポートに失敗しました');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section className="mac-panel p-5">
+      <h3 className="mac-h text-lg">データと privacy</h3>
+      <p className="mb-4 mt-1 text-xs text-gray-500">
+        あなたのプロフィール・投稿・レビューを JSON 形式でダウンロードできます。
+      </p>
+      {error && <p className="mb-3 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+      <button onClick={onExport} disabled={busy} className="mac-btn-ghost">
+        {busy ? '準備中…' : 'データをエクスポート'}
+      </button>
+    </section>
   );
 }
 


### PR DESCRIPTION
## 関連 Issue

Closes #261

## 変更の概要

プライバシーポリシー（#258）で約束したデータ主体の権利＝**エクスポート**を実装。利用者が自分のプロフィール・投稿・レビューを JSON でダウンロードできる。

- `GET /api/me/export`（認証必須・**本人のみ**。`principal.userId()` で自分の資源だけ集約＝IDOR の余地なし）。論理削除済みは除外。
- 機密（`passwordHash`/`totpSecret`）は DTO に含めない。
- `Content-Disposition: attachment` でダウンロード可能。
- frontend：プロフィール本人欄に「データと privacy」カード＋エクスポートボタン（クライアントで Blob 化してダウンロード）。

## 変更の種別

- [x] feat（新機能の追加）

## 動作確認チェックリスト

- [x] `DOCKER_API_VERSION=1.44 ./gradlew test jacocoTestCoverageVerification` green（本人のみ・機密なし・ユーザー単位スコープ・未認証401）
- [x] `npm run lint` / `npm run build` green
- [x] `.env`・パスワード非コミット