### PR TITLE
perf: 投稿検索を pg_trgm GIN 索引で高速化

### DIFF
--- a/review-board/backend/src/main/resources/db/migration/V22__add_post_search_trgm_index.sql
+++ b/review-board/backend/src/main/resources/db/migration/V22__add_post_search_trgm_index.sql
@@ -1,0 +1,16 @@
+-- 投稿検索の高速化（Issue #265）。pg_trgm トライグラム GIN 索引。
+--
+-- PostRepository.search はタイトル/説明の `lower(col) LIKE lower('%q%')` 部分一致を使う。
+-- tsvector('simple') は空白区切り前提で日本語の部分一致に弱い（劣化）ため不採用。
+-- pg_trgm はトライグラム単位の索引で、ILIKE のセマンティクスを保ったまま部分一致を索引化でき、
+-- 日本語にも有効。クエリは変更せず、planner が本索引を使う。
+--
+-- pg_trgm は RDS PostgreSQL・postgres:16（contrib 同梱）とも利用可能。
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX idx_posts_title_trgm
+    ON posts USING gin (lower(title) gin_trgm_ops);
+
+CREATE INDEX idx_posts_description_trgm
+    ON posts USING gin (lower(description) gin_trgm_ops);


### PR DESCRIPTION
## 関連 Issue

Closes #265

## 変更の概要

投稿検索（`PostRepository.search`）の ILIKE 部分一致を **pg_trgm（トライグラム）GIN 索引**で高速化（母 P-1/P-3）。

- migration **V22**：`CREATE EXTENSION IF NOT EXISTS pg_trgm` ＋ `posts(lower(title))` / `posts(lower(description))` への gin_trgm_ops GIN 索引。
- クエリは**変更しない**。`lower(col) LIKE lower('%q%')` を planner が trgm 索引で評価＝挙動不変・高速化のみ。
- `tsvector('simple')` は日本語の部分一致に弱く不採用、`pg_bigm` は拡張前提が増えるため見送り、**日本語に強くRDS/postgres:16 で使える pg_trgm を採用**（判断を Issue/migration に記録）。

## 変更の種別

- [x] chore / perf

## 動作確認チェックリスト

- [x] `PostSearchIntegrationTest` green（Testcontainers で V22 適用・非回帰）
- [x] `.env`・パスワード非コミット