### PR TITLE
feat: レートリミットを Postgres ストア化（多インスタンス対応・Redis不要）

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/RateLimitFilter.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/RateLimitFilter.java
@@ -14,18 +14,13 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * ★SEC-12：認証エンドポイントの総当たり・列挙対策（軽量な in-memory 固定窓レートリミット）。
+ * ★SEC-12：認証エンドポイントの総当たり・列挙対策（固定窓レートリミット）。
  *
- * <p>POST /api/auth/{login,register,refresh} に IP 単位で上限を課す。超過は 429（JSON）。
- * 新規依存を避け、{@link ConcurrentHashMap} の固定窓で実装する。
- *
- * <p>制約：単一インスタンス前提（メモリ保持）。多インスタンス化時は共有ストア（Redis 等）が要る。
- * 本番は nginx の {@code limit_req} と併用して多層化することも可能。
+ * <p>POST /api/auth/{login,register,refresh,login/mfa,password-reset/request} に IP 単位で上限を課す。
+ * 超過は 429（JSON）。カウントは {@link RateLimitStore}（Postgres）で共有するため**多インスタンスでも有効**
+ * （#267 で in-memory から移行）。本番は nginx の {@code limit_req} と併用して多層化することも可能。
  *
  * <p>{@code @Component} の {@link OncePerRequestFilter} は Spring Boot がサーブレットチェーンへ自動登録する。
  * {@code @Order(HIGHEST_PRECEDENCE)} で Security チェーンより前段に置き、認証処理前に総当たりを弾く。
@@ -36,11 +31,12 @@ public class RateLimitFilter extends OncePerRequestFilter {
 
     private final RateLimitProperties props;
     private final ObjectMapper objectMapper;
-    private final Map<String, Window> windows = new ConcurrentHashMap<>();
+    private final RateLimitStore store;
 
-    public RateLimitFilter(RateLimitProperties props, ObjectMapper objectMapper) {
+    public RateLimitFilter(RateLimitProperties props, ObjectMapper objectMapper, RateLimitStore store) {
         this.props = props;
         this.objectMapper = objectMapper;
+        this.store = store;
     }
 
     /** 対象は POST の login/register/refresh のみ。それ以外と無効時は素通し。 */
@@ -85,17 +81,9 @@ public class RateLimitFilter extends OncePerRequestFilter {
         };
     }
 
-    /** 固定窓カウント。窓を跨いだらリセット。上限超過なら true。 */
+    /** 固定窓カウント（Postgres 共有・#267）。窓を跨いだらキーが変わりリセット。上限超過なら true。 */
     private boolean overLimit(String key, int limit) {
-        long now = System.currentTimeMillis();
-        long windowMs = props.windowSeconds() * 1000L;
-        Window w = windows.compute(key, (k, cur) -> {
-            if (cur == null || now - cur.startMs >= windowMs) {
-                return new Window(now);
-            }
-            return cur;
-        });
-        return w.count.incrementAndGet() > limit;
+        return store.incrementAndCount(key, props.windowSeconds()) > limit;
     }
 
     /** X-Forwarded-For（nginx 経由）の先頭ホップを優先。無ければ remoteAddr。 */
@@ -110,15 +98,6 @@ public class RateLimitFilter extends OncePerRequestFilter {
 
     /** テスト用：窓カウントを全消去（テスト間で状態を持ち越さないため）。 */
     public void clear() {
-        windows.clear();
-    }
-
-    private static final class Window {
-        final long startMs;
-        final AtomicInteger count = new AtomicInteger(0);
-
-        Window(long startMs) {
-            this.startMs = startMs;
-        }
+        store.clear();
     }
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/auth/RateLimitStore.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/auth/RateLimitStore.java
@@ -1,0 +1,62 @@
+package com.reviewboard.domain.auth;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+
+/**
+ * レートリミットの共有カウントストア（Issue #267・SEC-12）。Postgres を共有ストアにすることで
+ * 多インスタンスでも総当たり防御が効く（in-memory 固定窓の単一インスタンス制約を解消）。
+ *
+ * <p>固定窓は「最初のリクエスト時刻から {@code windowSeconds}」。窓が満了するまでは increment、満了後は
+ * count=1・window_started_at=now にリセットする（バースト中に壁時計境界をまたいで誤って窓が変わるのを防ぐ）。
+ * 増分は原子的アップサート（{@code INSERT ... ON CONFLICT DO UPDATE ... RETURNING}）で1文に収める。
+ */
+@Component
+public class RateLimitStore {
+
+    // 窓満了の判定（window_started_at + windowSeconds 秒 > now）で increment か reset かを分岐する。
+    private static final String INCREMENT_SQL = """
+            INSERT INTO rate_limit_buckets (bucket_key, window_started_at, request_count)
+            VALUES (?, ?, 1)
+            ON CONFLICT (bucket_key) DO UPDATE SET
+                request_count = CASE
+                    WHEN rate_limit_buckets.window_started_at + (? * interval '1 second') > ?
+                    THEN rate_limit_buckets.request_count + 1 ELSE 1 END,
+                window_started_at = CASE
+                    WHEN rate_limit_buckets.window_started_at + (? * interval '1 second') > ?
+                    THEN rate_limit_buckets.window_started_at ELSE ? END
+            RETURNING request_count
+            """;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public RateLimitStore(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    /** {@code ip|uri} の窓内カウントを 1 増やし、増分後のカウントを返す。 */
+    public int incrementAndCount(String key, int windowSeconds) {
+        Timestamp now = Timestamp.from(Instant.now());
+        Integer count = jdbcTemplate.queryForObject(
+                INCREMENT_SQL, Integer.class,
+                key, now, windowSeconds, now, windowSeconds, now, now);
+        return count == null ? 1 : count;
+    }
+
+    /** 期限切れバケットの定期削除（残骸の肥大化防止）。既定 1 時間ごと。窓は分単位なので 1 時間超は確実に満了。 */
+    @Scheduled(fixedDelayString = "${app.ratelimit.purge-interval-ms:3600000}")
+    public void purgeExpired() {
+        jdbcTemplate.update(
+                "DELETE FROM rate_limit_buckets WHERE window_started_at < ?",
+                Timestamp.from(Instant.now().minusSeconds(3600)));
+    }
+
+    /** テスト用：全バケットを消去（テスト間で状態を持ち越さない）。 */
+    public void clear() {
+        jdbcTemplate.update("DELETE FROM rate_limit_buckets");
+    }
+}

--- a/review-board/backend/src/main/resources/db/migration/V23__add_rate_limit_buckets.sql
+++ b/review-board/backend/src/main/resources/db/migration/V23__add_rate_limit_buckets.sql
@@ -1,0 +1,14 @@
+-- レートリミットの Postgres ストア化（Issue #267・SEC-12 多インスタンス対応）。
+--
+-- bucket_key = "<ip>|<uri>"。window_started_at は「窓の開始時刻」で、最初のリクエスト時に now で立て、
+-- 窓が満了するまでは increment、満了後は count=1・window_started_at=now にリセットする
+-- （in-memory 版と同じ「最初のリクエストから windowSeconds」の固定窓＝バースト中の窓跨ぎを避ける）。
+-- 増分は原子的アップサート（INSERT ... ON CONFLICT DO UPDATE ... RETURNING）で1文。多インスタンスで共有。
+-- 期限切れ行は @Scheduled で定期削除する。
+CREATE TABLE rate_limit_buckets (
+    bucket_key        VARCHAR(255) PRIMARY KEY,
+    window_started_at TIMESTAMPTZ  NOT NULL,
+    request_count     INTEGER      NOT NULL
+);
+
+CREATE INDEX idx_rate_limit_buckets_window ON rate_limit_buckets (window_started_at);


### PR DESCRIPTION
## 関連 Issue

Closes #267

## 変更の概要

in-memory 固定窓（単一インスタンス前提）の SEC-12 レートリミットを **Postgres 共有ストア**に移行。水平スケール時もインスタンス間でカウントを共有し総当たり防御を維持（Redis 不要）。

- migration **V23**：`rate_limit_buckets(bucket_key PK, window_started_at, request_count)`。
- `RateLimitStore`：`INSERT ... ON CONFLICT DO UPDATE ... RETURNING` の**原子的アップサート**で窓内カウント。窓は「最初のリクエストから `windowSeconds`」で、満了まで increment・満了後 `count=1` にリセット（**バースト中の壁時計境界またぎを避ける＝CI フレーキー回避**）。`@Scheduled` で期限切れ行を定期削除。
- `RateLimitFilter` を in-memory Map から `RateLimitStore` へ差し替え（挙動＝`count > limit` で 429 は不変）。`clear()` は全行削除に委譲。

## 変更の種別

- [x] feat（新機能の追加）

## 動作確認チェックリスト

- [x] `RateLimitIntegrationTest`（20→21回目429・Retry-After）green
- [x] 全テストを**2回連続**＋カバレッジゲート green（フレーキーなしを確認）
- [x] `.env`・パスワード非コミット

## 補足

- 当初 epoch 境界固定窓にしたところ全体実行で稀に 429 が出ず失敗（バーストが60秒境界をまたぐと窓キーが変わるため）。窓開始時刻を行に保持し条件付きリセットする方式（in-memory と同じ意味論）で解消。