### PR TITLE
fix: 「いいね人気ランキング」を撤去（非競争方針との矛盾解消）

### DIFF
--- a/review-board/frontend/src/components/WorksList.jsx
+++ b/review-board/frontend/src/components/WorksList.jsx
@@ -37,7 +37,6 @@ export default function WorksList({ posts, loading, error, applied, setFilter, o
           className="rounded-xl border border-black/10 bg-white px-3 py-1.5 text-sm text-gray-700 outline-none">
           <option value="newest">新着順</option>
           <option value="reviews">レビュー数順</option>
-          <option value="likes">いいね順</option>
         </select>
         {applied.q && (
           <span className="rounded-full bg-brand-400/15 px-3 py-1 text-xs font-medium text-brand-600">

--- a/review-board/frontend/src/pages/PostsPage.jsx
+++ b/review-board/frontend/src/pages/PostsPage.jsx
@@ -37,7 +37,6 @@ export default function PostsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [stats, setStats] = useState(null);
-  const [ranking, setRanking] = useState([]);
 
   // 検索・絞り込み・並び替え。初期 q はヘッダー検索からの URL パラメータを尊重。
   const [q, setQ] = useState(searchParams.get('q') ?? '');
@@ -51,7 +50,7 @@ export default function PostsPage() {
     setQ(urlQ);
     setApplied((p) => ({ ...p, q: urlQ }));
     if (urlQ) {
-      // レイアウト確定後にスクロール（ランキング・統計の読み込みでズレないよう少し待つ）。
+      // レイアウト確定後にスクロール（統計の読み込みでズレないよう少し待つ）。
       const t = setTimeout(scrollToWorks, 120);
       return () => clearTimeout(t);
     }
@@ -69,8 +68,6 @@ export default function PostsPage() {
 
   useEffect(() => {
     fetchLandingStats().then(setStats).catch(() => {});
-    // いいね人気ランキング：いいね数順の上位3件。
-    fetchPosts({ sort: 'likes' }, 0, 3).then((s) => setRanking(s.content ?? [])).catch(() => {});
   }, []);
 
   const submitSearch = (e) => {
@@ -183,34 +180,7 @@ export default function PostsPage() {
         </div>
       </section>
 
-      {/* RANKING：いいね数順の人気成果物トップ3（👍 が基準） */}
-      {ranking.length > 0 && (
-        <section className="mx-auto max-w-6xl px-6 py-14">
-          <Eyebrow>RANKING</Eyebrow>
-          <SectionHeading>いいね人気ランキング</SectionHeading>
-          <div className="mt-9 grid grid-cols-1 gap-5 md:grid-cols-3">
-            {ranking.map((p, i) => {
-              const medal = ['🥇', '🥈', '🥉'][i] ?? `#${i + 1}`;
-              return (
-                <Link key={p.id} to={`/posts/${p.id}`}
-                  className="group relative flex items-center gap-4 rounded-2xl border border-black/5 bg-white p-5 shadow-mac-sm transition hover:-translate-y-1 hover:shadow-mac">
-                  <span className="text-3xl leading-none">{medal}</span>
-                  <div className="min-w-0 flex-1">
-                    <h3 className="line-clamp-2 text-[15px] font-bold leading-snug text-navy-700">{p.title}</h3>
-                    <div className="mt-1 flex items-center gap-2 text-xs text-gray-500">
-                      <Avatar name={p.authorDisplayName ?? ''} size="sm" />
-                      <span className="truncate">{p.authorDisplayName ?? '—'}</span>
-                    </div>
-                  </div>
-                  <span className="flex flex-shrink-0 items-center gap-1 rounded-full bg-navy-700/[0.06] px-3 py-1 text-sm font-bold text-navy-700">
-                    👍 <span className="tabular-nums">{p.likeCount}</span>
-                  </span>
-                </Link>
-              );
-            })}
-          </div>
-        </section>
-      )}
+      {/* いいね人気ランキングは非競争方針との矛盾のため撤去（#269）。👍 は各投稿に「軽い励まし」として残す。 */}
 
       {/* WORKS：成果物一覧（検索/絞り込み/並び替えの機能はここに集約。専用ページ /works と共通部品で共有） */}
       <section id="works" className="mx-auto max-w-6xl px-6 py-14">


### PR DESCRIPTION
## 関連 Issue

Closes #269

## 変更の概要

要件の「非競争」方針（成長記録が主役・🙏ありがとうで支え合う）に対し、トップの**メダル付き「いいね人気ランキング」**が最も競争的で矛盾するため撤去。**いいね（👍）は「軽い励まし」として各投稿に残す**（ユーザー判断）。

- `PostsPage.jsx`：トップの「RANKING / いいね人気ランキング」セクション（🥇🥈🥉・いいね数順トップ3）と取得・state を削除。
- `WorksList.jsx`：並び替えの「いいね順」を削除（新着順・レビュー数順は残す）。
- 👍いいねボタン・likeCount は存続。backend の `sort=likes`・いいね API も据え置き（UI から露出しないだけ）。

## 変更の種別

- [x] fix / enhancement

## 動作確認チェックリスト

- [x] `npm run lint` / `npm run build` green（既存 AuthContext 警告のみ）
- [x] トップにランキング非表示・「いいね順」ソート無し（auth保護ページのため CI の Playwright smoke が実機描画を検証）
- [x] `.env`・パスワード非コミット