### PR TITLE
fix: 並び替えに「いいね順」を戻す

### DIFF
--- a/review-board/frontend/src/components/WorksList.jsx
+++ b/review-board/frontend/src/components/WorksList.jsx
@@ -37,6 +37,7 @@ export default function WorksList({ posts, loading, error, applied, setFilter, o
           className="rounded-xl border border-black/10 bg-white px-3 py-1.5 text-sm text-gray-700 outline-none">
           <option value="newest">新着順</option>
           <option value="reviews">レビュー数順</option>
+          <option value="likes">いいね順</option>
         </select>
         {applied.q && (
           <span className="rounded-full bg-brand-400/15 px-3 py-1 text-xs font-medium text-brand-600">


### PR DESCRIPTION
## 関連 Issue

Closes #271

## 変更の概要

#270 でメダル付き「いいね人気ランキング」を撤去した際に外した**「いいね順」ソートを復活**（ユーザー判断）。いいね順は順位表示ほど競争的でなく「軽い励まし」の範囲。メダル付きトップ3ランキングは撤去のまま。

- `WorksList.jsx` の並び替えに `いいね順` を再追加。backend は `sort=likes` 対応済みのため UI のみ。

## 変更の種別

- [x] fix

## 動作確認チェックリスト

- [x] `npm run lint` / `npm run build` green
- [x] 並び替えに 新着順 / レビュー数順 / いいね順 が表示（ローカル dev・Chrome DevTools で確認）
- [x] `.env`・パスワード非コミット