### PR TITLE
feat: エンゲージメント計測基盤API（運営限定・compute-on-read）

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/domain/insights/EngagementMetricsService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/insights/EngagementMetricsService.java
@@ -1,0 +1,198 @@
+package com.reviewboard.domain.insights;
+
+import com.reviewboard.domain.auth.AuthPrincipal;
+import com.reviewboard.domain.insights.dto.EngagementMetricsResponse;
+import com.reviewboard.domain.insights.dto.EngagementMetricsResponse.Members;
+import com.reviewboard.domain.insights.dto.EngagementMetricsResponse.Posts;
+import com.reviewboard.domain.insights.dto.EngagementMetricsResponse.Quality;
+import com.reviewboard.domain.insights.dto.EngagementMetricsResponse.Reviews;
+import com.reviewboard.domain.insights.dto.EngagementMetricsResponse.StagnantMember;
+import com.reviewboard.domain.insights.dto.EngagementMetricsResponse.Ttfr;
+import com.reviewboard.domain.post.PostRepository;
+import com.reviewboard.domain.review.ReviewAxisCommentRepository;
+import com.reviewboard.domain.review.ReviewRepository;
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRepository;
+import com.reviewboard.domain.user.UserRole;
+import com.reviewboard.domain.user.UserStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * エンゲージメント指標の算出（#273・compute-on-read）。
+ * すべて principal.cohortId に閉じる（S軸）。新規テーブル/バッチは持たず、既存テーブルの集計で都度算出する。
+ */
+@Service
+public class EngagementMetricsService {
+
+    /** 停滞判定の既定窓（日）。?days= で上書き可能。 */
+    public static final int DEFAULT_STAGNANT_DAYS = 14;
+    /** time-to-first-review のサンプル窓（直近30日の投稿対象）。 */
+    private static final int TTFR_WINDOW_DAYS = 30;
+    /** 週次アクティブ等のローリング窓。 */
+    private static final int WEEKLY_WINDOW_DAYS = 7;
+
+    private final PostRepository postRepository;
+    private final ReviewRepository reviewRepository;
+    private final ReviewAxisCommentRepository axisCommentRepository;
+    private final UserRepository userRepository;
+
+    public EngagementMetricsService(PostRepository postRepository,
+                                    ReviewRepository reviewRepository,
+                                    ReviewAxisCommentRepository axisCommentRepository,
+                                    UserRepository userRepository) {
+        this.postRepository = postRepository;
+        this.reviewRepository = reviewRepository;
+        this.axisCommentRepository = axisCommentRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public EngagementMetricsResponse compute(AuthPrincipal principal, int stagnantDays) {
+        Long cohortId = principal.cohortId();
+        OffsetDateTime now = OffsetDateTime.now();
+        OffsetDateTime since7 = now.minusDays(WEEKLY_WINDOW_DAYS);
+        OffsetDateTime since30 = now.minusDays(TTFR_WINDOW_DAYS);
+        OffsetDateTime stagnantThreshold = now.minusDays(stagnantDays);
+
+        // ---- メンバー ----
+        List<User> activeMembers = userRepository.findByCohortIdAndStatus(cohortId, UserStatus.ACTIVE);
+        long students = activeMembers.stream().filter(u -> u.getRole() == UserRole.STUDENT).count();
+        long teachers = activeMembers.stream().filter(u -> u.getRole() == UserRole.TEACHER).count();
+        Members members = new Members(activeMembers.size(), students, teachers);
+
+        // ---- 投稿 ----
+        long postsTotal = postRepository.countByCohortIdAndDeletedAtIsNull(cohortId);
+        long postsLast7d = postRepository.countByCohortIdAndDeletedAtIsNullAndCreatedAtAfter(cohortId, since7);
+        long unreviewed = postRepository.countByCohortIdAndDeletedAtIsNullAndReviewCount(cohortId, 0);
+        Posts posts = new Posts(postsTotal, postsLast7d, unreviewed);
+        double reviewCoverageRate = postsTotal == 0 ? 0.0 : round4((double) (postsTotal - unreviewed) / postsTotal);
+
+        // ---- レビュー ----
+        long reviewsTotal = reviewRepository.countReviewsInCohort(cohortId);
+        long reviewsLast7d = reviewRepository.countReviewsInCohortSince(cohortId, since7);
+        Reviews reviews = new Reviews(reviewsTotal, reviewsLast7d);
+
+        // ---- time-to-first-review（Java 側で median/p95/avg を算出・DB 非依存） ----
+        Ttfr ttfr = computeTtfr(cohortId, since30, now);
+
+        // ---- 週次アクティブ ----
+        long weeklyActiveReviewers = reviewRepository.countDistinctActiveReviewers(cohortId, since7);
+        double weeklyActiveReviewerRate =
+                activeMembers.isEmpty() ? 0.0 : round4((double) weeklyActiveReviewers / activeMembers.size());
+        long weeklyActivePosters = postRepository.countDistinctActivePosters(cohortId, since7);
+
+        // ---- 質指標 ----
+        long axisComments = axisCommentRepository.countAxisCommentsInCohort(cohortId);
+        long thankedReviews = reviewRepository.countThankedReviewsInCohort(cohortId);
+        long bestSelected = postRepository.countByCohortIdAndDeletedAtIsNullAndBestReviewIdIsNotNull(cohortId);
+        Quality quality = new Quality(
+                reviewsTotal == 0 ? 0.0 : round4((double) axisComments / reviewsTotal),
+                reviewsTotal == 0 ? 0.0 : round4((double) thankedReviews / reviewsTotal),
+                bestSelected);
+
+        // ---- 停滞メンバー ----
+        List<StagnantMember> stagnant = computeStagnant(cohortId, activeMembers, stagnantThreshold, now);
+
+        return new EngagementMetricsResponse(
+                cohortId, now, members, posts, reviews, reviewCoverageRate, ttfr,
+                weeklyActiveReviewers, weeklyActiveReviewerRate, weeklyActivePosters, quality, stagnant);
+    }
+
+    private Ttfr computeTtfr(Long cohortId, OffsetDateTime since30, OffsetDateTime now) {
+        List<Object[]> rows = postRepository.firstReviewTimings(cohortId, since30);
+        List<Double> reviewedHours = new ArrayList<>();
+        long awaitingCount = 0;
+        Double oldestAwaitingHours = null;
+        for (Object[] row : rows) {
+            OffsetDateTime postCreatedAt = (OffsetDateTime) row[1];
+            OffsetDateTime firstReviewAt = (OffsetDateTime) row[2];
+            if (firstReviewAt != null) {
+                reviewedHours.add(hoursBetween(postCreatedAt, firstReviewAt));
+            } else {
+                awaitingCount++;
+                double waiting = hoursBetween(postCreatedAt, now);
+                if (oldestAwaitingHours == null || waiting > oldestAwaitingHours) {
+                    oldestAwaitingHours = waiting;
+                }
+            }
+        }
+        reviewedHours.sort(Comparator.naturalOrder());
+        Double median = percentile(reviewedHours, 0.50);
+        Double p95 = percentile(reviewedHours, 0.95);
+        Double avg = reviewedHours.isEmpty() ? null
+                : round2(reviewedHours.stream().mapToDouble(Double::doubleValue).average().orElse(0));
+        return new Ttfr(reviewedHours.size(), median, p95, avg,
+                awaitingCount, oldestAwaitingHours == null ? null : round2(oldestAwaitingHours));
+    }
+
+    private List<StagnantMember> computeStagnant(Long cohortId, List<User> activeMembers,
+                                                 OffsetDateTime threshold, OffsetDateTime now) {
+        Map<Long, OffsetDateTime> lastPost = toLastActiveMap(postRepository.lastPostAtByAuthor(cohortId));
+        Map<Long, OffsetDateTime> lastReview = toLastActiveMap(reviewRepository.lastReviewAtByReviewer(cohortId));
+
+        List<StagnantMember> result = new ArrayList<>();
+        for (User m : activeMembers) {
+            OffsetDateTime lastActiveAt = maxNullable(lastPost.get(m.getId()), lastReview.get(m.getId()));
+            boolean stagnant = lastActiveAt == null || lastActiveAt.isBefore(threshold);
+            if (!stagnant) {
+                continue;
+            }
+            OffsetDateTime since = lastActiveAt != null ? lastActiveAt : m.getCreatedAt();
+            long daysInactive = since == null ? 0 : ChronoUnit.DAYS.between(since, now);
+            result.add(new StagnantMember(m.getId(), m.getDisplayName(), lastActiveAt, daysInactive));
+        }
+        result.sort(Comparator.comparingLong(StagnantMember::daysInactive).reversed());
+        return result;
+    }
+
+    private Map<Long, OffsetDateTime> toLastActiveMap(List<Object[]> rows) {
+        Map<Long, OffsetDateTime> map = new HashMap<>();
+        for (Object[] row : rows) {
+            map.put((Long) row[0], (OffsetDateTime) row[1]);
+        }
+        return map;
+    }
+
+    private static OffsetDateTime maxNullable(OffsetDateTime a, OffsetDateTime b) {
+        if (a == null) {
+            return b;
+        }
+        if (b == null) {
+            return a;
+        }
+        return a.isAfter(b) ? a : b;
+    }
+
+    private static double hoursBetween(OffsetDateTime from, OffsetDateTime to) {
+        return round2(Duration.between(from, to).toMinutes() / 60.0);
+    }
+
+    /** ソート済みリストから最近接ランク法で percentile を算出（空なら null）。 */
+    private static Double percentile(List<Double> sorted, double q) {
+        if (sorted.isEmpty()) {
+            return null;
+        }
+        int n = sorted.size();
+        int rank = (int) Math.ceil(q * n);
+        int idx = Math.min(Math.max(rank - 1, 0), n - 1);
+        return sorted.get(idx);
+    }
+
+    private static double round2(double v) {
+        return Math.round(v * 100.0) / 100.0;
+    }
+
+    private static double round4(double v) {
+        return Math.round(v * 10000.0) / 10000.0;
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/insights/InsightsController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/insights/InsightsController.java
@@ -1,0 +1,41 @@
+package com.reviewboard.domain.insights;
+
+import com.reviewboard.domain.auth.AuthPrincipal;
+import com.reviewboard.domain.insights.dto.EngagementMetricsResponse;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * エンゲージメント計測 API（#273・★S軸・運営限定）。
+ * 講師/管理者のみが自 cohort の「使われ方」を取得できる（受講生403・未認証401・他 cohort 不可視）。
+ * 非競争方針：本 API は運営専用で、学生 UI には一切露出しない。
+ */
+@RestController
+@RequestMapping("/api/insights")
+public class InsightsController {
+
+    private final EngagementMetricsService engagementMetricsService;
+
+    public InsightsController(EngagementMetricsService engagementMetricsService) {
+        this.engagementMetricsService = engagementMetricsService;
+    }
+
+    /**
+     * 自 cohort のエンゲージメント指標。
+     *
+     * @param days 停滞メンバー判定の窓（日）。1〜365 にクランプ。既定は 14。
+     */
+    @PreAuthorize("hasAnyRole('TEACHER','ADMIN')")
+    @GetMapping("/engagement")
+    public EngagementMetricsResponse engagement(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @RequestParam(name = "days", required = false,
+                    defaultValue = "" + EngagementMetricsService.DEFAULT_STAGNANT_DAYS) int days) {
+        int clamped = Math.min(Math.max(days, 1), 365);
+        return engagementMetricsService.compute(principal, clamped);
+    }
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/insights/dto/EngagementMetricsResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/insights/dto/EngagementMetricsResponse.java
@@ -1,0 +1,53 @@
+package com.reviewboard.domain.insights.dto;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * エンゲージメント指標（#273・運営限定・compute-on-read）。
+ * cohort 単位の「使われ方」を運営（講師/管理者）が把握するための集計値。
+ * 学生 UI には一切露出しない（非競争方針）。
+ */
+public record EngagementMetricsResponse(
+        Long cohortId,
+        OffsetDateTime generatedAt,
+        Members members,
+        Posts posts,
+        Reviews reviews,
+        double reviewCoverageRate,
+        Ttfr timeToFirstReview,
+        long weeklyActiveReviewers,
+        double weeklyActiveReviewerRate,
+        long weeklyActivePosters,
+        Quality quality,
+        List<StagnantMember> stagnantMembers
+) {
+
+    /** ACTIVE メンバーの内訳。 */
+    public record Members(long active, long students, long teachers) {}
+
+    /** 投稿の概況。last7d はローリング7日窓、unreviewed は review_count=0。 */
+    public record Posts(long total, long last7d, long unreviewed) {}
+
+    /** レビューの概況。 */
+    public record Reviews(long total, long last7d) {}
+
+    /**
+     * time-to-first-review（直近30日の投稿対象）。percentile は Java 側算出（DB 非依存）。
+     * <ul>
+     *   <li>{@code sampleCount}：レビュー済み投稿の件数（median/p95/avg の母数）。0 のとき各 hours は null。</li>
+     *   <li>{@code awaitingCount}：直近30日の未レビュー投稿数、{@code oldestAwaitingHours} はその最古の待機時間。</li>
+     * </ul>
+     */
+    public record Ttfr(int sampleCount, Double medianHours, Double p95Hours, Double avgHours,
+                       long awaitingCount, Double oldestAwaitingHours) {}
+
+    /** 質指標（任意）：avg観点数/レビュー・🙏率・ベスト選出数。 */
+    public record Quality(double avgAspectsPerReview, double thanksRate, long bestSelectedCount) {}
+
+    /**
+     * 停滞メンバー（ケア対象）。直近 N 日に投稿もレビューも無い ACTIVE メンバー。
+     * {@code lastActiveAt} は活動皆無のとき null（その場合 daysInactive はアカウント作成からの経過日数）。
+     */
+    public record StagnantMember(Long userId, String displayName, OffsetDateTime lastActiveAt, long daysInactive) {}
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/PostRepository.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/PostRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -23,6 +24,40 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     /** 週次ダイジェスト（C-5・#233）：cohort 内の未レビュー（review_count=0）成果物の件数。 */
     int countByCohortIdAndDeletedAtIsNullAndReviewCount(Long cohortId, int reviewCount);
+
+    // ---- エンゲージメント計測（#273・運営限定・compute-on-read） ----
+
+    /** cohort 内の非削除投稿総数（レビュー網羅率の分母）。 */
+    long countByCohortIdAndDeletedAtIsNull(Long cohortId);
+
+    /** cohort 内・直近窓（since 以降）の非削除投稿数。 */
+    long countByCohortIdAndDeletedAtIsNullAndCreatedAtAfter(Long cohortId, OffsetDateTime since);
+
+    /** cohort 内・ベスト選出済み（best_review_id 非 null）の非削除投稿数（質指標）。 */
+    long countByCohortIdAndDeletedAtIsNullAndBestReviewIdIsNotNull(Long cohortId);
+
+    /**
+     * time-to-first-review 用：直近窓の各投稿について「投稿時刻」と「最初の未削除レビュー時刻（無ければ null）」を返す。
+     * percentile は DB 非依存とするため duration の算出・集計は Java 側で行う。
+     * 返却：{@code [postId, postCreatedAt, firstReviewAtOrNull]}。
+     */
+    @Query("""
+            select p.id, p.createdAt, min(r.createdAt)
+            from Post p left join Review r on r.postId = p.id and r.deletedAt is null
+            where p.cohortId = :cohortId and p.deletedAt is null and p.createdAt > :since
+            group by p.id, p.createdAt
+            """)
+    List<Object[]> firstReviewTimings(@Param("cohortId") Long cohortId, @Param("since") OffsetDateTime since);
+
+    /** cohort 内・直近窓に投稿した distinct な投稿者数（週次アクティブ投稿者）。 */
+    @Query("select count(distinct p.authorUserId) from Post p "
+            + "where p.cohortId = :cohortId and p.deletedAt is null and p.createdAt > :since")
+    long countDistinctActivePosters(@Param("cohortId") Long cohortId, @Param("since") OffsetDateTime since);
+
+    /** 停滞判定用：cohort 内の投稿者ごとの最終投稿時刻。返却：{@code [authorUserId, max(createdAt)]}。 */
+    @Query("select p.authorUserId, max(p.createdAt) from Post p "
+            + "where p.cohortId = :cohortId and p.deletedAt is null group by p.authorUserId")
+    List<Object[]> lastPostAtByAuthor(@Param("cohortId") Long cohortId);
 
     /**
      * 一覧・検索・絞り込み（F-POST-03 / F-SEARCH-01 / F-FILTER-01）。

--- a/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewAxisCommentRepository.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewAxisCommentRepository.java
@@ -1,6 +1,8 @@
 package com.reviewboard.domain.review;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -9,4 +11,13 @@ public interface ReviewAxisCommentRepository extends JpaRepository<ReviewAxisCom
     List<ReviewAxisComment> findByReviewId(Long reviewId);
 
     List<ReviewAxisComment> findByReviewIdIn(List<Long> reviewIds);
+
+    /**
+     * 質指標（#273）：cohort 内の未削除レビューに紐づく観点コメント総数。
+     * avg観点数/レビュー の分子（分母は未削除レビュー総数）。
+     */
+    @Query("select count(c) from ReviewAxisComment c "
+            + "join Review r on r.id = c.reviewId join Post p on p.id = r.postId "
+            + "where p.cohortId = :cohortId and r.deletedAt is null")
+    long countAxisCommentsInCohort(@Param("cohortId") Long cohortId);
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewRepository.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -36,4 +37,31 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("select count(r) from Review r where r.deletedAt is null "
             + "and r.postId in (select p.id from Post p where p.authorUserId = :authorId)")
     int countReceivedForAuthor(@Param("authorId") Long authorId);
+
+    // ---- エンゲージメント計測（#273・運営限定）。cohort 境界は review.postId → post.cohortId の join で絞る ----
+
+    /** cohort 内の未削除レビュー総数。 */
+    @Query("select count(r) from Review r join Post p on p.id = r.postId "
+            + "where p.cohortId = :cohortId and r.deletedAt is null")
+    long countReviewsInCohort(@Param("cohortId") Long cohortId);
+
+    /** cohort 内・直近窓（since 以降）の未削除レビュー数。 */
+    @Query("select count(r) from Review r join Post p on p.id = r.postId "
+            + "where p.cohortId = :cohortId and r.deletedAt is null and r.createdAt > :since")
+    long countReviewsInCohortSince(@Param("cohortId") Long cohortId, @Param("since") OffsetDateTime since);
+
+    /** cohort 内・直近窓に1件以上レビューした distinct なレビュアー数（週次アクティブレビュアー）。 */
+    @Query("select count(distinct r.reviewerUserId) from Review r join Post p on p.id = r.postId "
+            + "where p.cohortId = :cohortId and r.deletedAt is null and r.createdAt > :since")
+    long countDistinctActiveReviewers(@Param("cohortId") Long cohortId, @Param("since") OffsetDateTime since);
+
+    /** 質指標：cohort 内で🙏を1件以上受けた未削除レビュー数（🙏率の分子）。 */
+    @Query("select count(r) from Review r join Post p on p.id = r.postId "
+            + "where p.cohortId = :cohortId and r.deletedAt is null and r.thanksCount > 0")
+    long countThankedReviewsInCohort(@Param("cohortId") Long cohortId);
+
+    /** 停滞判定用：cohort 内のレビュアーごとの最終レビュー時刻。返却：{@code [reviewerUserId, max(createdAt)]}。 */
+    @Query("select r.reviewerUserId, max(r.createdAt) from Review r join Post p on p.id = r.postId "
+            + "where p.cohortId = :cohortId and r.deletedAt is null group by r.reviewerUserId")
+    List<Object[]> lastReviewAtByReviewer(@Param("cohortId") Long cohortId);
 }

--- a/review-board/backend/src/test/java/com/reviewboard/domain/insights/EngagementMetricsIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/insights/EngagementMetricsIntegrationTest.java
@@ -1,0 +1,155 @@
+package com.reviewboard.domain.insights;
+
+import com.reviewboard.domain.post.Post;
+import com.reviewboard.domain.review.Review;
+import com.reviewboard.domain.review.ReviewAxis;
+import com.reviewboard.domain.review.ReviewAxisComment;
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRole;
+import com.reviewboard.support.AbstractIntegrationTest;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * エンゲージメント指標の「正しさ」検証（#273）。
+ * タイムスタンプを作り込んで網羅率・ttfr・週次アクティブ・質指標・停滞者を確定値で検証する。
+ *
+ * <p>データ設計（cohort A・now 基準）：投稿5件中3件レビュー済み（網羅率0.6・未レビュー2）。
+ * ttfr は 2h/4h/10h（median=4・p95=10・avg=5.33）。直近7日のレビュアー distinct=2。
+ */
+class EngagementMetricsIntegrationTest extends AbstractIntegrationTest {
+
+    private Cookie teacher;
+    private long s1Id;
+    private long s4Id;
+
+    @BeforeEach
+    void seed() throws Exception {
+        var a = newCohort("A");
+        User teacherA = newUser("teacherA@example.com", UserRole.TEACHER, a.getId());
+        User s1 = newUser("s1@example.com", UserRole.STUDENT, a.getId());
+        User s2 = newUser("s2@example.com", UserRole.STUDENT, a.getId());
+        User s3 = newUser("s3@example.com", UserRole.STUDENT, a.getId());
+        User s4 = newUser("s4@example.com", UserRole.STUDENT, a.getId()); // 活動皆無＝停滞者
+        s1Id = s1.getId();
+        s4Id = s4.getId();
+
+        OffsetDateTime now = OffsetDateTime.now();
+
+        // 投稿5件（全て直近30日内）。reviewCount は非正規化カウンタとして明示設定。
+        long p1 = post(s1.getId(), a.getId(), now.minusDays(5), 1);
+        long p2 = post(s1.getId(), a.getId(), now.minusDays(4), 1);
+        long p3 = post(s2.getId(), a.getId(), now.minusDays(3), 1);
+        post(s2.getId(), a.getId(), now.minusDays(2), 0); // 未レビュー（最古待機48h）
+        post(s3.getId(), a.getId(), now.minusDays(1), 0); // 未レビュー（待機24h）
+
+        // レビュー3件（ttfr=2h/4h/10h・全て直近7日内）。
+        long r1 = review(p1, s2.getId(), now.minusDays(5).plusHours(2), 2);  // thanks>0
+        long r2 = review(p2, s3.getId(), now.minusDays(4).plusHours(4), 0);
+        long r3 = review(p3, s3.getId(), now.minusDays(3).plusHours(10), 1); // thanks>0
+
+        // 観点コメント：r1=2件・r2=1件・r3=0件 → 計3件 / レビュー3件 = avg 1.0
+        axis(r1, ReviewAxis.CORRECTNESS);
+        axis(r1, ReviewAxis.SECURITY);
+        axis(r2, ReviewAxis.PERFORMANCE);
+
+        // ベスト選出：p1 が r1 を選ぶ → bestSelectedCount=1
+        Post p1e = postRepository.findById(p1).orElseThrow();
+        p1e.setBestReviewId(r1);
+        postRepository.save(p1e);
+
+        teacher = login(teacherA.getEmail());
+    }
+
+    @Test
+    void engagement_metrics_are_computed_correctly() throws Exception {
+        mockMvc.perform(get("/api/insights/engagement").cookie(teacher))
+                .andExpect(status().isOk())
+                // メンバー：ACTIVE 5（講師1・受講生4）
+                .andExpect(jsonPath("$.members.active").value(5))
+                .andExpect(jsonPath("$.members.students").value(4))
+                .andExpect(jsonPath("$.members.teachers").value(1))
+                // 投稿：総数5・直近7日5・未レビュー2
+                .andExpect(jsonPath("$.posts.total").value(5))
+                .andExpect(jsonPath("$.posts.last7d").value(5))
+                .andExpect(jsonPath("$.posts.unreviewed").value(2))
+                // レビュー：総数3・直近7日3
+                .andExpect(jsonPath("$.reviews.total").value(3))
+                .andExpect(jsonPath("$.reviews.last7d").value(3))
+                // 網羅率 0.6
+                .andExpect(jsonPath("$.reviewCoverageRate").value(0.6))
+                // ttfr：median4・p95=10・avg≈5.33・待機2件・最古48h
+                .andExpect(jsonPath("$.timeToFirstReview.sampleCount").value(3))
+                .andExpect(jsonPath("$.timeToFirstReview.medianHours").value(4.0))
+                .andExpect(jsonPath("$.timeToFirstReview.p95Hours").value(10.0))
+                .andExpect(jsonPath("$.timeToFirstReview.avgHours").value(5.33))
+                .andExpect(jsonPath("$.timeToFirstReview.awaitingCount").value(2))
+                .andExpect(jsonPath("$.timeToFirstReview.oldestAwaitingHours").value(48.0))
+                // 週次アクティブ：レビュアー2（S2/S3）・率0.4・投稿者3（S1/S2/S3）
+                .andExpect(jsonPath("$.weeklyActiveReviewers").value(2))
+                .andExpect(jsonPath("$.weeklyActiveReviewerRate").value(0.4))
+                .andExpect(jsonPath("$.weeklyActivePosters").value(3))
+                // 質指標：avg観点1.0・🙏率0.6667・ベスト1
+                .andExpect(jsonPath("$.quality.avgAspectsPerReview").value(1.0))
+                .andExpect(jsonPath("$.quality.thanksRate").value(0.6667))
+                .andExpect(jsonPath("$.quality.bestSelectedCount").value(1));
+    }
+
+    @Test
+    void stagnant_lists_inactive_member_and_excludes_active_one() throws Exception {
+        // S4（活動皆無）は停滞者に出る。S1（直近に投稿）は出ない。
+        mockMvc.perform(get("/api/insights/engagement").cookie(teacher))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.stagnantMembers[?(@.userId == " + s4Id + ")]").exists())
+                .andExpect(jsonPath("$.stagnantMembers[?(@.userId == " + s1Id + ")]").doesNotExist());
+    }
+
+    @Test
+    void days_param_widens_stagnant_window() throws Exception {
+        // days=1 にすると、最終活動が1日より前の S1 等も停滞扱いになる（窓が効いている証拠）。
+        mockMvc.perform(get("/api/insights/engagement").param("days", "1").cookie(teacher))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.stagnantMembers[?(@.userId == " + s1Id + ")]").exists());
+    }
+
+    // ---- タイムスタンプを作り込むためエンティティを直接生成（API は createdAt=now 固定のため） ----
+
+    private long post(Long author, Long cohort, OffsetDateTime createdAt, int reviewCount) {
+        Post p = new Post();
+        p.setAuthorUserId(author);
+        p.setCohortId(cohort);
+        p.setTitle("作品");
+        p.setDescription("説明");
+        p.setReviewCount(reviewCount);
+        p.setCreatedAt(createdAt);
+        p.setUpdatedAt(createdAt);
+        return postRepository.save(p).getId();
+    }
+
+    private long review(long postId, Long reviewer, OffsetDateTime createdAt, int thanks) {
+        Review r = new Review();
+        r.setPostId(postId);
+        r.setReviewerUserId(reviewer);
+        r.setGood("良い点");
+        r.setImprovement("改善点");
+        r.setThanksCount(thanks);
+        r.setCreatedAt(createdAt);
+        r.setUpdatedAt(createdAt);
+        return reviewRepository.save(r).getId();
+    }
+
+    private void axis(long reviewId, ReviewAxis axis) {
+        ReviewAxisComment c = new ReviewAxisComment();
+        c.setReviewId(reviewId);
+        c.setAxis(axis);
+        c.setComment("観点コメント");
+        axisCommentRepository.save(c);
+    }
+}

--- a/review-board/backend/src/test/java/com/reviewboard/domain/insights/InsightsAuthorizationIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/insights/InsightsAuthorizationIntegrationTest.java
@@ -1,0 +1,81 @@
+package com.reviewboard.domain.insights;
+
+import com.reviewboard.domain.post.Post;
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRole;
+import com.reviewboard.support.AbstractIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * エンゲージメント計測 API の認可（#273・★S軸）。
+ * 運営限定（講師/管理者）・自 cohort のみ・受講生403・未認証401・他 cohort 越境不可を検証する。
+ */
+class InsightsAuthorizationIntegrationTest extends AbstractIntegrationTest {
+
+    private String studentEmail;
+    private String teacherAEmail;
+    private String teacherBEmail;
+    private String adminEmail;
+
+    @BeforeEach
+    void seed() {
+        var a = newCohort("A");
+        var b = newCohort("B");
+        User student = newUser("student@example.com", UserRole.STUDENT, a.getId());
+        studentEmail = student.getEmail();
+        teacherAEmail = newUser("teacherA@example.com", UserRole.TEACHER, a.getId()).getEmail();
+        teacherBEmail = newUser("teacherB@example.com", UserRole.TEACHER, b.getId()).getEmail();
+        adminEmail = newUser("admin@example.com", UserRole.ADMIN, a.getId()).getEmail();
+
+        // cohort A にのみ投稿を1件置く（他 cohort 越境テスト用）。
+        Post p = new Post();
+        p.setAuthorUserId(student.getId());
+        p.setCohortId(a.getId());
+        p.setTitle("作品");
+        p.setDescription("説明");
+        p.setReviewCount(0);
+        p.setCreatedAt(OffsetDateTime.now());
+        p.setUpdatedAt(OffsetDateTime.now());
+        postRepository.save(p);
+    }
+
+    @Test
+    void teacher_can_view_own_cohort_metrics() throws Exception {
+        mockMvc.perform(get("/api/insights/engagement").cookie(login(teacherAEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.posts.total").value(1));
+    }
+
+    @Test
+    void admin_can_view_metrics() throws Exception {
+        mockMvc.perform(get("/api/insights/engagement").cookie(login(adminEmail)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void student_is_forbidden_returns403() throws Exception {
+        mockMvc.perform(get("/api/insights/engagement").cookie(login(studentEmail)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void unauthenticated_is_rejected_returns401() throws Exception {
+        mockMvc.perform(get("/api/insights/engagement"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    /** cohort 分離：他 cohort の講師には A の投稿が見えない（自 cohort の数値のみ＝0）。 */
+    @Test
+    void teacher_sees_only_own_cohort_not_other() throws Exception {
+        mockMvc.perform(get("/api/insights/engagement").cookie(login(teacherBEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.posts.total").value(0));
+    }
+}


### PR DESCRIPTION
## 関連 Issue

Closes #273

---

## 変更の概要

既存テーブル（posts / reviews / users）の集計で都度算出する **compute-on-read** 方式の運営（講師/管理者）専用 API `GET /api/insights/engagement` を追加しました。新規テーブル・migration はありません。

新パッケージ `com.reviewboard.domain.insights`：
- `InsightsController` — `@PreAuthorize("hasAnyRole('TEACHER','ADMIN')")`・cohort は `AuthPrincipal` 由来
- `EngagementMetricsService`（`@Transactional(readOnly=true)`）
- `EngagementMetricsResponse`（record・ネスト）

**算出する指標：**
- メンバー内訳（active / students / teachers）
- 投稿（total / 直近7日 / 未レビュー）／レビュー（total / 直近7日）
- レビュー網羅率
- time-to-first-review（直近30日・median / p95 / avg を **Java 側で算出**＝DB 非依存・待機件数 / 最古待機時間）
- 週次アクティブレビュアー（数＋対メンバー比）／週次アクティブ投稿者
- 停滞メンバー一覧（既定14日・`?days=` で上書き）
- 質指標：avg観点数/レビュー・🙏率・ベスト選出数

**設計の核：**
- cohort 境界（重点軸）：reviews は cohortId 直持ちでないため `review.postId → post.cohortId` の join で絞る
- 非競争方針：運営限定 API。学生 UI には一切露出しない（ランキング化しない）
- 依存追加なし（可視化は別 Issue【3】運営ダッシュボードで実施）

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（`DOCKER_API_VERSION=1.44 ./gradlew test jacocoTestCoverageVerification` green）
- [x] 既存の機能が壊れていないことを確認した（全テスト green・カバレッジ床 INSTRUCTION≥0.75 / BRANCH≥0.50 維持）
- [x] `.env` ファイルやパスワードをコミットしていない

---

## レビュー時に特に確認してほしい点

- **認可・cohort 境界**：講師200 / 管理者200 / 受講生403 / 未認証401 / 他 cohort 越境なし を `InsightsAuthorizationIntegrationTest` で検証。
- **指標の正しさ**：`EngagementMetricsIntegrationTest` でタイムスタンプを作り込み、網羅率0.6・ttfr(median=4/p95=10/avg≈5.33)・週次アクティブ・質指標・停滞者を確定値で検証。
- **time-to-first-review の待機件数/最古待機時間** は直近30日の投稿窓を対象としている点（窓外の古い未レビューは対象外）。
