### PR TITLE
feat: 運営ダッシュボード（/dashboard）＋週次トレンドAPI

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/domain/insights/EngagementMetricsService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/insights/EngagementMetricsService.java
@@ -8,6 +8,8 @@ import com.reviewboard.domain.insights.dto.EngagementMetricsResponse.Quality;
 import com.reviewboard.domain.insights.dto.EngagementMetricsResponse.Reviews;
 import com.reviewboard.domain.insights.dto.EngagementMetricsResponse.StagnantMember;
 import com.reviewboard.domain.insights.dto.EngagementMetricsResponse.Ttfr;
+import com.reviewboard.domain.insights.dto.WeeklyTrendResponse;
+import com.reviewboard.domain.insights.dto.WeeklyTrendResponse.WeekBucket;
 import com.reviewboard.domain.post.PostRepository;
 import com.reviewboard.domain.review.ReviewAxisCommentRepository;
 import com.reviewboard.domain.review.ReviewRepository;
@@ -106,6 +108,29 @@ public class EngagementMetricsService {
         return new EngagementMetricsResponse(
                 cohortId, now, members, posts, reviews, reviewCoverageRate, ttfr,
                 weeklyActiveReviewers, weeklyActiveReviewerRate, weeklyActivePosters, quality, stagnant);
+    }
+
+    /**
+     * 週次トレンド（#275）。直近 weeks 週を 7 日バケットで集計し、古い週 → 新しい週の順で返す。
+     * 週数が小さい（既定8）ため週ごとに期間付きクエリをループで叩く（材料化は不要）。
+     */
+    @Transactional(readOnly = true)
+    public WeeklyTrendResponse computeTrend(AuthPrincipal principal, int weeks) {
+        Long cohortId = principal.cohortId();
+        OffsetDateTime now = OffsetDateTime.now();
+        List<WeekBucket> buckets = new ArrayList<>();
+        // i=0 が最古、i=weeks-1 が最新（now で終わる窓）。
+        for (int i = 0; i < weeks; i++) {
+            OffsetDateTime start = now.minusDays(7L * (weeks - i));
+            OffsetDateTime end = now.minusDays(7L * (weeks - i - 1));
+            buckets.add(new WeekBucket(
+                    start,
+                    reviewRepository.countDistinctReviewersInRange(cohortId, start, end),
+                    postRepository.countDistinctPostersInRange(cohortId, start, end),
+                    postRepository.countPostsInRange(cohortId, start, end),
+                    reviewRepository.countReviewsInRange(cohortId, start, end)));
+        }
+        return new WeeklyTrendResponse(cohortId, now, buckets);
     }
 
     private Ttfr computeTtfr(Long cohortId, OffsetDateTime since30, OffsetDateTime now) {

--- a/review-board/backend/src/main/java/com/reviewboard/domain/insights/InsightsController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/insights/InsightsController.java
@@ -2,6 +2,7 @@ package com.reviewboard.domain.insights;
 
 import com.reviewboard.domain.auth.AuthPrincipal;
 import com.reviewboard.domain.insights.dto.EngagementMetricsResponse;
+import com.reviewboard.domain.insights.dto.WeeklyTrendResponse;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -37,5 +38,19 @@ public class InsightsController {
                     defaultValue = "" + EngagementMetricsService.DEFAULT_STAGNANT_DAYS) int days) {
         int clamped = Math.min(Math.max(days, 1), 365);
         return engagementMetricsService.compute(principal, clamped);
+    }
+
+    /**
+     * 自 cohort の週次トレンド（#275・運営ダッシュボードの推移グラフ用）。
+     *
+     * @param weeks 取得する週数（7 日バケット）。1〜52 にクランプ。既定は 8。
+     */
+    @PreAuthorize("hasAnyRole('TEACHER','ADMIN')")
+    @GetMapping("/engagement/trend")
+    public WeeklyTrendResponse engagementTrend(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @RequestParam(name = "weeks", required = false, defaultValue = "8") int weeks) {
+        int clamped = Math.min(Math.max(weeks, 1), 52);
+        return engagementMetricsService.computeTrend(principal, clamped);
     }
 }

--- a/review-board/backend/src/main/java/com/reviewboard/domain/insights/dto/WeeklyTrendResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/insights/dto/WeeklyTrendResponse.java
@@ -1,0 +1,24 @@
+package com.reviewboard.domain.insights.dto;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * 週次トレンド（#275・運営限定）。直近 N 週を 7 日バケットで集計し、運営ダッシュボードで推移を可視化する。
+ * weeks は古い週 → 新しい週の順。最新バケットは generatedAt で終わる 7 日窓。
+ */
+public record WeeklyTrendResponse(
+        Long cohortId,
+        OffsetDateTime generatedAt,
+        List<WeekBucket> weeks
+) {
+
+    /** 1 週分（7 日窓）の集計。weekStart は窓の開始時刻 [weekStart, weekStart+7d)。 */
+    public record WeekBucket(
+            OffsetDateTime weekStart,
+            long activeReviewers,
+            long activePosters,
+            long newPosts,
+            long newReviews
+    ) {}
+}

--- a/review-board/backend/src/main/java/com/reviewboard/domain/post/PostRepository.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/post/PostRepository.java
@@ -59,6 +59,20 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             + "where p.cohortId = :cohortId and p.deletedAt is null group by p.authorUserId")
     List<Object[]> lastPostAtByAuthor(@Param("cohortId") Long cohortId);
 
+    // ---- 週次トレンド（#275）：期間 [start, end) の集計（週バケットをループで叩く） ----
+
+    /** cohort 内・期間 [start, end) の非削除投稿数。 */
+    @Query("select count(p) from Post p where p.cohortId = :cohortId and p.deletedAt is null "
+            + "and p.createdAt >= :start and p.createdAt < :end")
+    long countPostsInRange(@Param("cohortId") Long cohortId,
+                           @Param("start") OffsetDateTime start, @Param("end") OffsetDateTime end);
+
+    /** cohort 内・期間 [start, end) の distinct な投稿者数。 */
+    @Query("select count(distinct p.authorUserId) from Post p where p.cohortId = :cohortId and p.deletedAt is null "
+            + "and p.createdAt >= :start and p.createdAt < :end")
+    long countDistinctPostersInRange(@Param("cohortId") Long cohortId,
+                                     @Param("start") OffsetDateTime start, @Param("end") OffsetDateTime end);
+
     /**
      * 一覧・検索・絞り込み（F-POST-03 / F-SEARCH-01 / F-FILTER-01）。
      * ★cohort 境界（IDOR 遮断）は常に効かせたまま、任意条件を AND で重ねる。

--- a/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewRepository.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewRepository.java
@@ -64,4 +64,18 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("select r.reviewerUserId, max(r.createdAt) from Review r join Post p on p.id = r.postId "
             + "where p.cohortId = :cohortId and r.deletedAt is null group by r.reviewerUserId")
     List<Object[]> lastReviewAtByReviewer(@Param("cohortId") Long cohortId);
+
+    // ---- 週次トレンド（#275）：期間 [start, end) の集計 ----
+
+    /** cohort 内・期間 [start, end) の非削除レビュー数。 */
+    @Query("select count(r) from Review r join Post p on p.id = r.postId "
+            + "where p.cohortId = :cohortId and r.deletedAt is null and r.createdAt >= :start and r.createdAt < :end")
+    long countReviewsInRange(@Param("cohortId") Long cohortId,
+                             @Param("start") OffsetDateTime start, @Param("end") OffsetDateTime end);
+
+    /** cohort 内・期間 [start, end) の distinct なレビュアー数。 */
+    @Query("select count(distinct r.reviewerUserId) from Review r join Post p on p.id = r.postId "
+            + "where p.cohortId = :cohortId and r.deletedAt is null and r.createdAt >= :start and r.createdAt < :end")
+    long countDistinctReviewersInRange(@Param("cohortId") Long cohortId,
+                                       @Param("start") OffsetDateTime start, @Param("end") OffsetDateTime end);
 }

--- a/review-board/backend/src/test/java/com/reviewboard/domain/insights/InsightsTrendIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/insights/InsightsTrendIntegrationTest.java
@@ -1,0 +1,105 @@
+package com.reviewboard.domain.insights;
+
+import com.reviewboard.domain.post.Post;
+import com.reviewboard.domain.review.Review;
+import com.reviewboard.domain.user.User;
+import com.reviewboard.domain.user.UserRole;
+import com.reviewboard.support.AbstractIntegrationTest;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 週次トレンド API（#275）の認可と週バケット集計の正しさ。
+ * 講師200 / 受講生403 / 未認証401・自 cohort のみ。タイムスタンプを作り込み、
+ * 7 日バケットに正しく振り分けられることを確定値で検証する。
+ */
+class InsightsTrendIntegrationTest extends AbstractIntegrationTest {
+
+    private Cookie teacher;
+    private String studentEmail;
+
+    @BeforeEach
+    void seed() throws Exception {
+        var a = newCohort("A");
+        User teacherA = newUser("teacherA@example.com", UserRole.TEACHER, a.getId());
+        User s1 = newUser("s1@example.com", UserRole.STUDENT, a.getId());
+        User s2 = newUser("s2@example.com", UserRole.STUDENT, a.getId());
+        studentEmail = s1.getEmail();
+
+        OffsetDateTime now = OffsetDateTime.now();
+        // 最新週 [now-7d, now)：投稿1・レビュー1
+        long p1 = post(s1.getId(), a.getId(), now.minusDays(2));
+        review(p1, s2.getId(), now.minusDays(1));
+        // 2番目に新しい週 [now-14d, now-7d)：投稿1のみ（レビューなし）
+        post(s1.getId(), a.getId(), now.minusDays(10));
+
+        teacher = login(teacherA.getEmail());
+    }
+
+    @Test
+    void trend_returns_requested_number_of_weekly_buckets() throws Exception {
+        mockMvc.perform(get("/api/insights/engagement/trend").cookie(teacher))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.weeks.length()").value(8)); // 既定8週
+        mockMvc.perform(get("/api/insights/engagement/trend").param("weeks", "4").cookie(teacher))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.weeks.length()").value(4));
+    }
+
+    @Test
+    void trend_buckets_aggregate_by_period_correctly() throws Exception {
+        // weeks=8：index7=最新週・index6=その前の週。
+        mockMvc.perform(get("/api/insights/engagement/trend").cookie(teacher))
+                .andExpect(status().isOk())
+                // 最新週：投稿1・レビュー1・投稿者1・レビュアー1
+                .andExpect(jsonPath("$.weeks[7].newPosts").value(1))
+                .andExpect(jsonPath("$.weeks[7].newReviews").value(1))
+                .andExpect(jsonPath("$.weeks[7].activePosters").value(1))
+                .andExpect(jsonPath("$.weeks[7].activeReviewers").value(1))
+                // 前の週：投稿1・レビュー0
+                .andExpect(jsonPath("$.weeks[6].newPosts").value(1))
+                .andExpect(jsonPath("$.weeks[6].newReviews").value(0));
+    }
+
+    @Test
+    void student_is_forbidden_returns403() throws Exception {
+        mockMvc.perform(get("/api/insights/engagement/trend").cookie(login(studentEmail)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void unauthenticated_is_rejected_returns401() throws Exception {
+        mockMvc.perform(get("/api/insights/engagement/trend"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    private long post(Long author, Long cohort, OffsetDateTime createdAt) {
+        Post p = new Post();
+        p.setAuthorUserId(author);
+        p.setCohortId(cohort);
+        p.setTitle("作品");
+        p.setDescription("説明");
+        p.setReviewCount(0);
+        p.setCreatedAt(createdAt);
+        p.setUpdatedAt(createdAt);
+        return postRepository.save(p).getId();
+    }
+
+    private void review(long postId, Long reviewer, OffsetDateTime createdAt) {
+        Review r = new Review();
+        r.setPostId(postId);
+        r.setReviewerUserId(reviewer);
+        r.setGood("良い点");
+        r.setImprovement("改善点");
+        r.setCreatedAt(createdAt);
+        r.setUpdatedAt(createdAt);
+        reviewRepository.save(r);
+    }
+}

--- a/review-board/frontend/src/App.jsx
+++ b/review-board/frontend/src/App.jsx
@@ -18,6 +18,7 @@ import WorksPage from './pages/WorksPage';
 import ReviewsPage from './pages/ReviewsPage';
 import ProfilePage from './pages/ProfilePage';
 import NotificationsPage from './pages/NotificationsPage';
+import DashboardPage from './pages/DashboardPage';
 
 // ページ（パス）が切り替わったらスクロール位置を先頭へ戻す。
 // React Router は既定でスクロールを復元しないため、長いページから遷移すると
@@ -63,6 +64,8 @@ export default function App() {
         <Route path="/reviews" element={<Shell><ReviewsPage /></Shell>} />
         <Route path="/users/:id/profile" element={<Shell><ProfilePage /></Shell>} />
         <Route path="/notifications" element={<Shell><NotificationsPage /></Shell>} />
+        {/* 運営ダッシュボード（講師/管理者専用・#275）。真の防御は backend 403。 */}
+        <Route path="/dashboard" element={<Shell><DashboardPage /></Shell>} />
       </Routes>
     </AuthProvider>
   );

--- a/review-board/frontend/src/api/insights.js
+++ b/review-board/frontend/src/api/insights.js
@@ -1,0 +1,8 @@
+import client from './client';
+
+// エンゲージメント計測（#273/#275・運営限定）。講師/管理者のみ 200、受講生は 403。
+export const getEngagement = (days) =>
+  client.get('/insights/engagement', { params: days ? { days } : {} }).then((r) => r.data);
+
+export const getEngagementTrend = (weeks = 8) =>
+  client.get('/insights/engagement/trend', { params: { weeks } }).then((r) => r.data);

--- a/review-board/frontend/src/components/Header.jsx
+++ b/review-board/frontend/src/components/Header.jsx
@@ -59,7 +59,10 @@ export default function Header() {
             </form>
             <Link to="/posts/new" className="hidden shrink-0 whitespace-nowrap rounded-lg bg-wrblue-500 px-3.5 py-2 text-sm font-bold text-white shadow-sm transition hover:bg-wrblue-600 sm:inline-flex">＋ 投稿する</Link>
             {(user.role === 'TEACHER' || user.role === 'ADMIN') && (
-              <Link to="/invites" className="hidden shrink-0 whitespace-nowrap text-sm font-medium text-gray-600 transition hover:text-navy-700 lg:inline">招待</Link>
+              <>
+                <Link to="/dashboard" className="hidden shrink-0 whitespace-nowrap text-sm font-medium text-gray-600 transition hover:text-navy-700 lg:inline">ダッシュボード</Link>
+                <Link to="/invites" className="hidden shrink-0 whitespace-nowrap text-sm font-medium text-gray-600 transition hover:text-navy-700 lg:inline">招待</Link>
+              </>
             )}
             <Link to="/notifications" className="relative text-gray-500 transition hover:text-navy-700" aria-label={`通知${unread > 0 ? `（未読 ${unread} 件）` : ''}`}>
               <span className="inline-block text-xl leading-none">🔔</span>

--- a/review-board/frontend/src/pages/DashboardPage.jsx
+++ b/review-board/frontend/src/pages/DashboardPage.jsx
@@ -1,0 +1,188 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { getEngagement, getEngagementTrend } from '../api/insights';
+import { useAuth } from '../context/AuthContext';
+
+// 運営ダッシュボード（講師/管理者専用・Issue #275）。
+// エンゲージメント指標（#273）と週次トレンドを可視化する。非競争方針：学生には露出しない。
+// 真の防御は backend の 403（@PreAuthorize）。本ページの role 分岐は UX 補助。
+
+const pct = (v) => `${Math.round((v ?? 0) * 100)}%`;
+const hrs = (v) => (v == null ? '—' : `${v} 時間`);
+const fmtDate = (dt) => (dt ? new Date(dt).toLocaleDateString('ja-JP', { month: 'numeric', day: 'numeric' }) : '—');
+
+// 閾値で色付け（網羅率<60%・停滞≥1人 は amber で注意喚起）。
+function StatCard({ label, value, sub, tone = 'normal' }) {
+  const toneCls = tone === 'warn' ? 'border-amber-300 bg-amber-50' : 'border-gray-200 bg-white';
+  return (
+    <div className={`rounded-xl border ${toneCls} p-4 shadow-sm`}>
+      <div className="text-xs font-medium text-gray-500">{label}</div>
+      <div className="mt-1 text-2xl font-extrabold text-navy-700">{value}</div>
+      {sub && <div className="mt-0.5 text-xs text-gray-500">{sub}</div>}
+    </div>
+  );
+}
+
+// CSS 製の簡易バー（チャートライブラリは入れない＝バンドル肥大回避）。
+function TrendBar({ label, value, max, colorCls }) {
+  const width = max > 0 ? Math.max((value / max) * 100, value > 0 ? 4 : 0) : 0;
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-16 shrink-0 text-right text-xs text-gray-400">{label}</span>
+      <div className="h-3 flex-1 overflow-hidden rounded bg-gray-100" role="img" aria-label={`${label} ${value}`}>
+        <div className={`h-full rounded ${colorCls}`} style={{ width: `${width}%` }} />
+      </div>
+      <span className="w-6 shrink-0 text-xs font-medium tabular-nums text-gray-600">{value}</span>
+    </div>
+  );
+}
+
+export default function DashboardPage() {
+  const { user } = useAuth();
+  const [metrics, setMetrics] = useState(null);
+  const [trend, setTrend] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const isOps = user && (user.role === 'TEACHER' || user.role === 'ADMIN');
+
+  useEffect(() => {
+    if (!isOps) {
+      setLoading(false);
+      return;
+    }
+    let active = true;
+    (async () => {
+      try {
+        const [m, t] = await Promise.all([getEngagement(), getEngagementTrend(8)]);
+        if (active) {
+          setMetrics(m);
+          setTrend(t);
+        }
+      } catch {
+        if (active) setError('ダッシュボードの取得に失敗しました。');
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [isOps]);
+
+  if (!isOps) {
+    return (
+      <main className="mx-auto max-w-2xl px-4 py-16 text-center">
+        <h1 className="text-xl font-extrabold text-navy-700">権限がありません</h1>
+        <p className="mt-2 text-sm text-gray-500">このページは講師・管理者専用です。</p>
+      </main>
+    );
+  }
+
+  if (loading) {
+    return <main className="mx-auto max-w-5xl px-4 py-10 text-gray-500">読み込み中…</main>;
+  }
+  if (error || !metrics) {
+    return <main className="mx-auto max-w-5xl px-4 py-10 text-rose-600">{error || 'データがありません。'}</main>;
+  }
+
+  const { members, posts, reviews, reviewCoverageRate, timeToFirstReview, quality, stagnantMembers } = metrics;
+  const trendMax = Math.max(
+    1,
+    ...(trend?.weeks ?? []).flatMap((w) => [w.newReviews, w.activeReviewers]),
+  );
+
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-8">
+      <header className="mb-6">
+        <h1 className="text-2xl font-extrabold tracking-tight text-navy-700">運営ダッシュボード</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          cohort の「使われ方」を把握し、停滞メンバーのケアに役立てるための運営限定ビューです。
+        </p>
+      </header>
+
+      {/* 上段：数値カード */}
+      <section aria-label="概況" className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+        <StatCard label="メンバー数（ACTIVE）" value={members.active} sub={`受講生 ${members.students}・講師 ${members.teachers}`} />
+        <StatCard
+          label="レビュー網羅率"
+          value={pct(reviewCoverageRate)}
+          sub={`未レビュー ${posts.unreviewed} 件`}
+          tone={reviewCoverageRate < 0.6 ? 'warn' : 'normal'}
+        />
+        <StatCard label="投稿（直近7日 / 総数）" value={`${posts.last7d} / ${posts.total}`} />
+        <StatCard label="レビュー（直近7日 / 総数）" value={`${reviews.last7d} / ${reviews.total}`} />
+        <StatCard
+          label="週次アクティブレビュアー"
+          value={metrics.weeklyActiveReviewers}
+          sub={`対メンバー比 ${pct(metrics.weeklyActiveReviewerRate)}`}
+        />
+        <StatCard label="週次アクティブ投稿者" value={metrics.weeklyActivePosters} />
+        <StatCard label="初レビューまで（中央値）" value={hrs(timeToFirstReview.medianHours)} sub={`待機 ${timeToFirstReview.awaitingCount} 件`} />
+        <StatCard label="ベスト選出 / avg観点 / 🙏率" value={`${quality.bestSelectedCount} / ${quality.avgAspectsPerReview.toFixed(1)} / ${pct(quality.thanksRate)}`} />
+      </section>
+
+      {/* 中段：週次トレンド（CSS 製の簡易バー） */}
+      <section aria-label="週次トレンド" className="mt-8">
+        <h2 className="mb-3 text-sm font-bold text-navy-700">週次トレンド（直近8週）</h2>
+        <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+          <div className="mb-2 flex items-center gap-4 text-xs text-gray-500">
+            <span className="inline-flex items-center gap-1"><span className="inline-block h-2 w-3 rounded bg-wrblue-500" />レビュー数</span>
+            <span className="inline-flex items-center gap-1"><span className="inline-block h-2 w-3 rounded bg-emerald-400" />アクティブレビュアー</span>
+          </div>
+          <ul className="space-y-3">
+            {(trend?.weeks ?? []).map((w) => (
+              <li key={w.weekStart}>
+                <div className="mb-1 text-xs font-medium text-gray-400">{fmtDate(w.weekStart)} の週</div>
+                <div className="space-y-1">
+                  <TrendBar label="レビュー" value={w.newReviews} max={trendMax} colorCls="bg-wrblue-500" />
+                  <TrendBar label="レビュアー" value={w.activeReviewers} max={trendMax} colorCls="bg-emerald-400" />
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      {/* 下段：停滞メンバー一覧（ケア対象・支援トーン） */}
+      <section aria-label="停滞メンバー" className="mt-8">
+        <h2 className="mb-1 text-sm font-bold text-navy-700">
+          ケア対象メンバー
+          {stagnantMembers.length > 0 && (
+            <span className="ml-2 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
+              {stagnantMembers.length} 名
+            </span>
+          )}
+        </h2>
+        <p className="mb-3 text-xs text-gray-500">
+          直近14日に投稿もレビューも無いメンバーです。声かけや個別フォローの参考にしてください。
+        </p>
+        {stagnantMembers.length === 0 ? (
+          <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700">
+            全員が直近14日に活動しています 🎉
+          </div>
+        ) : (
+          <ul className="divide-y divide-gray-100 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+            {stagnantMembers.map((m) => (
+              <li key={m.userId} className="flex items-center justify-between gap-3 px-4 py-3">
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-medium text-navy-700">{m.displayName}</div>
+                  <div className="text-xs text-gray-500">
+                    {m.lastActiveAt ? `最終活動から ${m.daysInactive} 日` : 'これまで活動なし'}
+                  </div>
+                </div>
+                <Link
+                  to={`/users/${m.userId}/profile`}
+                  className="shrink-0 whitespace-nowrap rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-600 transition hover:border-navy-700 hover:text-navy-700"
+                >
+                  プロフィール
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+        {/* TODO(#175 メール実稼働後)：ここに「リマインド送信」ボタンを追加する（タスク2に依存）。 */}
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## 関連 Issue

Closes #275

---

## 変更の概要

エンゲージメント計測（#273）を可視化する講師/管理者専用ページ `/dashboard` と、週次トレンド API を追加しました。

**backend（trend API）**
- `GET /api/insights/engagement/trend?weeks=8` → `WeeklyTrendResponse`（`@PreAuthorize("hasAnyRole('TEACHER','ADMIN')")`・cohort 境界維持）
- `List<WeekBucket>`：`{ weekStart, activeReviewers, activePosters, newPosts, newReviews }` を直近 N 週（既定8・1〜52 クランプ・7日バケット）で返す。期間 `[start, end)` の集計クエリを週ごとにループ（週数が小さいため材料化不要）。

**frontend**
- `api/insights.js`：`getEngagement()` / `getEngagementTrend(weeks)`
- `pages/DashboardPage.jsx`（運営専用）
  - 上段：数値カード（メンバー数・網羅率%・投稿/レビュー・週次アクティブ・ttfr median・質指標）。網羅率<60% は amber で注意喚起。
  - 中段：週次トレンドを **CSS 製の簡易バー**（チャートライブラリは入れない＝依存追加なし）。
  - 下段：停滞メンバー一覧（支援トーン・経過日数・プロフィール導線）。リマインド送信はタスク2（メール実稼働）後に追加する旨をコメントで明記。
- `App.jsx`：`/dashboard` を ProtectedRoute 配下に追加。受講生は「権限がありません」を表示。
- `Header.jsx`：講師/管理者のときだけ「ダッシュボード」ナビを表示（招待リンクと同じ role 分岐）。

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（下記 実機確認参照）
- [x] 既存の機能が壊れていないことを確認した（backend 全テスト＋カバレッジ床維持・frontend lint 0 error / build green）
- [x] `.env` ファイルやパスワードをコミットしていない

---

## レビュー時に特に確認してほしい点

- **認可・cohort 境界**：trend も `InsightsTrendIntegrationTest` で講師200 / 受講生403 / 未認証401・自 cohort のみを検証。週バケット集計の正しさはタイムスタンプ作り込みで確定値検証。
- **Chrome DevTools 実機確認**（dev・講師 teacher@example.com / 受講生 student@example.com）：
  - 講師 `/dashboard`：数値カード・週次トレンドバー・停滞メンバー一覧＋プロフィール導線が描画。網羅率38%が amber 表示。**コンソールエラーゼロ**。
  - 受講生：ヘッダーに「ダッシュボード」「招待」リンクが非表示。`/dashboard` 直アクセスで「権限がありません」を表示（真の防御は backend 403）。**コンソールエラーゼロ**。
- **依存追加なし**：トレンドは CSS バーで表現（recharts 等は導入していない）。
