### PR TITLE
chore: 本番のオンデマンド起動/停止スクリプト（コスト抑制）

### DIFF
--- a/review-board/infra/deploy/down.sh
+++ b/review-board/infra/deploy/down.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# down.sh — review-board 本番をオンデマンド停止する（時間制限コスト抑制の「停止」側）。
+#
+# やること：
+#   (1) EC2(review-board-prod-ec2) を停止（稼働中なら）— 先にアプリ側を落とす
+#   (2) RDS(review-board-prod-db) を停止（available なら）
+#
+# 重要な性質：
+#   - これは「停止(stop)」であり削除ではない。データ・EBS・EIP は保持され、
+#     up.sh で同じ IP のまま数分で復帰できる（Discord 共有URLは維持）。
+#   - 停止中も EBS と パブリックIPv4(EIP) の少額課金は継続する（削れるのは EC2/RDS の計算費）。
+#   - RDS は仕様上「停止後 最大7日で自動再開」する。長期に止めたい場合も up/down を回す前提。
+#   - 対象は review-board の本番リソースのみ。recipe-board / task-board には触れない。
+#
+# 使い方：
+#   ./down.sh            # 確認プロンプトの後に停止
+#   ./down.sh --dry-run  # 実行せず対象と現状だけ表示
+#   ./down.sh --yes      # 確認プロンプトをスキップ（自動化用・取り扱い注意）
+#
+set -euo pipefail
+
+REGION="ap-northeast-1"
+EC2_NAME="review-board-prod-ec2"
+DB_ID="review-board-prod-db"
+DRY_RUN=0
+ASSUME_YES=0
+case "${1:-}" in
+  --dry-run) DRY_RUN=1 ;;
+  --yes)     ASSUME_YES=1 ;;
+  "")        ;;
+  *) echo "unknown option: $1"; exit 2 ;;
+esac
+
+c() { printf '\033[%sm%s\033[0m\n' "$1" "$2"; }
+log()  { c "0;36" "==> $*"; }
+ok()   { c "0;32" "OK  $*"; }
+warn() { c "1;33" "!!  $*"; }
+err()  { c "0;31" "ERR $*" >&2; }
+
+resolve_ec2() {
+  aws ec2 describe-instances --region "$REGION" \
+    --filters "Name=tag:Name,Values=${EC2_NAME}" "Name=instance-state-name,Values=stopped,stopping,running,pending" \
+    --query 'Reservations[].Instances[].InstanceId' --output text
+}
+
+INSTANCE_ID="$(resolve_ec2)"
+if [ -z "$INSTANCE_ID" ] || [ "$INSTANCE_ID" = "None" ]; then
+  err "EC2(Name=${EC2_NAME}) が見つかりません。"; exit 1
+fi
+if [ "$(printf '%s\n' "$INSTANCE_ID" | wc -w)" -ne 1 ]; then
+  err "EC2 が複数該当しました（誤爆防止のため中止）: ${INSTANCE_ID}"; exit 1
+fi
+
+EC2_STATE="$(aws ec2 describe-instances --region "$REGION" --instance-ids "$INSTANCE_ID" \
+  --query 'Reservations[0].Instances[0].State.Name' --output text)"
+DB_STATE="$(aws rds describe-db-instances --region "$REGION" --db-instance-identifier "$DB_ID" \
+  --query 'DBInstances[0].DBInstanceStatus' --output text)"
+
+log "対象  EC2=${INSTANCE_ID}(${EC2_NAME}, 現状:${EC2_STATE}) / RDS=${DB_ID}(現状:${DB_STATE}) / region=${REGION}"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  warn "--dry-run：実行はしません。EC2 を stopped へ、RDS を stopped へ停止する想定です。"
+  exit 0
+fi
+
+# ---- 確認（停止＝本番をオフラインにする操作のため） ----
+if [ "$ASSUME_YES" -ne 1 ]; then
+  warn "本番(review-board)を停止します。停止中は https://${REGION} のサイトはオフラインになります（データ・URLは保持）。"
+  printf "  上記の review-board リソースのみを停止します。実行しますか? [yes/NO]: "
+  read -r ans
+  if [ "$ans" != "yes" ]; then err "中止しました。"; exit 1; fi
+fi
+
+# ---- (1) EC2 停止（稼働中のときだけ）— 先にアプリ側を落とす ----
+if [ "$EC2_STATE" = "running" ]; then
+  log "EC2 停止中…"
+  aws ec2 stop-instances --region "$REGION" --instance-ids "$INSTANCE_ID" >/dev/null
+  aws ec2 wait instance-stopped --region "$REGION" --instance-ids "$INSTANCE_ID"
+  ok "EC2 stopped"
+else
+  warn "EC2 は ${EC2_STATE} のため stop 不要（スキップ）。"
+fi
+
+# ---- (2) RDS 停止（available のときだけ） ----
+if [ "$DB_STATE" = "available" ]; then
+  log "RDS 停止中…"
+  aws rds stop-db-instance --region "$REGION" --db-instance-identifier "$DB_ID" >/dev/null
+  ok "RDS 停止リクエスト受付（stopped まで数分。完了は describe-db-instances で確認可）"
+else
+  warn "RDS は ${DB_STATE} のため stop 不要（スキップ）。"
+fi
+
+ok "停止手続き完了。再開は ./up.sh（同じ IP で復帰）。"
+warn "注意：RDS は最大7日で自動再開します。長く止める場合も up/down の運用を継続してください。"

--- a/review-board/infra/deploy/up.sh
+++ b/review-board/infra/deploy/up.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# up.sh — review-board 本番をオンデマンド起動する（時間制限コスト抑制の「起動」側）。
+#
+# やること：
+#   (1) RDS(review-board-prod-db) を起動（停止中なら）
+#   (2) EC2(review-board-prod-ec2) を起動（停止中なら）
+#   (3) 両方の Ready を待機 → EIP(同じIP)で復帰 → ヘルスチェック
+#
+# 前提：
+#   - EIP のため public IP は停止/再開で変わらない（Discord 共有URLは維持される）。
+#   - アプリは systemd(review-board.service, enable 済) + nginx(enable 済) で
+#     インスタンス起動時に自動復帰する（手動デプロイ不要）。
+#   - 対象は review-board の本番リソースのみ。recipe-board / task-board には触れない。
+#
+# 使い方：
+#   ./up.sh            # 起動
+#   ./up.sh --dry-run  # 実行せず対象と現状だけ表示
+#
+set -euo pipefail
+
+REGION="ap-northeast-1"
+EC2_NAME="review-board-prod-ec2"
+DB_ID="review-board-prod-db"
+DRY_RUN=0
+[ "${1:-}" = "--dry-run" ] && DRY_RUN=1
+
+# ---- ログ整形（sns-board の作法を踏襲） ----
+c() { printf '\033[%sm%s\033[0m\n' "$1" "$2"; }
+log()  { c "0;36" "==> $*"; }
+ok()   { c "0;32" "OK  $*"; }
+warn() { c "1;33" "!!  $*"; }
+err()  { c "0;31" "ERR $*" >&2; }
+
+# ---- 対象 EC2 を Name タグから厳密解決（必ず1台に限定） ----
+resolve_ec2() {
+  aws ec2 describe-instances --region "$REGION" \
+    --filters "Name=tag:Name,Values=${EC2_NAME}" "Name=instance-state-name,Values=stopped,stopping,running,pending" \
+    --query 'Reservations[].Instances[].InstanceId' --output text
+}
+
+INSTANCE_ID="$(resolve_ec2)"
+if [ -z "$INSTANCE_ID" ] || [ "$INSTANCE_ID" = "None" ]; then
+  err "EC2(Name=${EC2_NAME}) が見つかりません。"; exit 1
+fi
+if [ "$(printf '%s\n' "$INSTANCE_ID" | wc -w)" -ne 1 ]; then
+  err "EC2 が複数該当しました（誤爆防止のため中止）: ${INSTANCE_ID}"; exit 1
+fi
+
+EC2_STATE="$(aws ec2 describe-instances --region "$REGION" --instance-ids "$INSTANCE_ID" \
+  --query 'Reservations[0].Instances[0].State.Name' --output text)"
+DB_STATE="$(aws rds describe-db-instances --region "$REGION" --db-instance-identifier "$DB_ID" \
+  --query 'DBInstances[0].DBInstanceStatus' --output text)"
+
+log "対象  EC2=${INSTANCE_ID}(${EC2_NAME}, 現状:${EC2_STATE}) / RDS=${DB_ID}(現状:${DB_STATE}) / region=${REGION}"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  warn "--dry-run：実行はしません。RDS を available へ、EC2 を running へ起動する想定です。"
+  exit 0
+fi
+
+# ---- (1) RDS 起動（停止中のときだけ） ----
+if [ "$DB_STATE" = "stopped" ]; then
+  log "RDS 起動中…"
+  aws rds start-db-instance --region "$REGION" --db-instance-identifier "$DB_ID" >/dev/null
+else
+  warn "RDS は ${DB_STATE} のため start 不要（スキップ）。"
+fi
+
+# ---- (2) EC2 起動（停止中のときだけ） ----
+if [ "$EC2_STATE" = "stopped" ]; then
+  log "EC2 起動中…"
+  aws ec2 start-instances --region "$REGION" --instance-ids "$INSTANCE_ID" >/dev/null
+else
+  warn "EC2 は ${EC2_STATE} のため start 不要（スキップ）。"
+fi
+
+# ---- (3) Ready 待機 ----
+log "RDS が available になるまで待機（数分かかります）…"
+aws rds wait db-instance-available --region "$REGION" --db-instance-identifier "$DB_ID"
+ok "RDS available"
+
+log "EC2 が running になるまで待機…"
+aws ec2 wait instance-running --region "$REGION" --instance-ids "$INSTANCE_ID"
+ok "EC2 running"
+
+PUB_IP="$(aws ec2 describe-instances --region "$REGION" --instance-ids "$INSTANCE_ID" \
+  --query 'Reservations[0].Instances[0].PublicIpAddress' --output text)"
+log "アプリ(systemd)起動を待ってヘルスチェック（最大90秒）… https://${PUB_IP}/"
+for i in $(seq 1 18); do
+  code="$(curl -sk -o /dev/null -w '%{http_code}' --max-time 5 "https://${PUB_IP}/actuator/health" || true)"
+  if [ "$code" = "200" ]; then ok "アプリ応答 200（https://${PUB_IP}/ で閲覧可）"; exit 0; fi
+  sleep 5
+done
+warn "ヘルスチェックが 200 になりませんでした。EC2/RDS は起動済みですが、アプリ(java/nginx)の起動完了に少し時間がかかっている可能性があります。1〜2分後に https://${PUB_IP}/ を再確認してください。"


### PR DESCRIPTION
## 関連 Issue

Closes #277

---

## 変更の概要

本番(EC2+RDS)をオンデマンドで起動/停止する運用スクリプトを `infra/deploy/` に追加しました。稼働時間を絞ってコストを抑えるためのツールです。

- `up.sh`：RDS→EC2 を起動・Ready 待機・同じ EIP で復帰・ヘルスチェック（`--dry-run` 対応）
- `down.sh`：EC2→RDS を停止（`--dry-run`・確認プロンプト・`--yes` 対応）

### 前提・性質
- 18.176.19.160 は Elastic IP のため stop/start しても同じ IP で復帰（共有URLは維持）。
- アプリは systemd(review-board.service, enable 済) + nginx で起動時に自動復帰（手動デプロイ不要）。
- 削減できるのは EC2/RDS の計算費。パブリックIPv4(EIP)・EBS は停止中も少額課金が継続。
- RDS は仕様上「停止後 最大7日で自動再開」する（up/down 運用を継続する前提）。

### 安全設計（sns-board の teardown 作法を踏襲）
- 対象を Name タグで厳密限定（`review-board-prod-ec2` / `review-board-prod-db`）。recipe-board / task-board には触れない。複数該当時は誤爆防止で中止。
- 状態ガードで冪等（停止中のみ start・稼働中のみ stop）。
- stop/start のみで可逆（削除系コマンドは含まない）。

## 変更の種別

- [x] chore（設定・ツール・依存関係の変更）

---

## 動作確認チェックリスト

- [x] ローカルで `./down.sh --dry-run` を実行し、対象が review-board 本番リソースのみに限定されることを確認
- [x] 既存の機能が壊れていないことを確認した（インフラ定義は変更なし・運用スクリプト追加のみ）
- [x] `.env` ファイルやパスワードをコミットしていない

---

## レビュー時に特に確認してほしい点

- 対象限定が Name タグ厳密一致（`review-board-prod-*`）で、他アプリのリソースに触れない設計になっている点。
- 可逆な stop/start のみで、削除系を含まない点。
- 実際の停止/起動は運用者が手動で実行する想定（自動スケジューラは本PRに含めない）。
