### PR TITLE
chore: term-board を GitHub Pages で公開（ログイン不要・Discord共有対応）

### DIFF
--- a/.github/workflows/term-board-pages.yml
+++ b/.github/workflows/term-board-pages.yml
@@ -1,0 +1,81 @@
+name: term-board Pages deploy
+
+# term-board（静的SPA）を GitHub Pages へ公開する（Issue #285）。
+# 認証・サーバー・DBを持たない学習アプリのため、静的配信のみで「誰でもURLを開けば使える」。
+# 進捗は各利用者のブラウザの localStorage に保存される。
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "term-board/**"
+      - ".github/workflows/term-board-pages.yml"
+  workflow_dispatch:
+
+# deploy-pages に必要な最小権限。
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# 同時実行を1本に絞る（古いデプロイをキャンセル）。
+concurrency:
+  group: term-board-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: term-board
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node (use .nvmrc = 24 LTS)
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: term-board/.nvmrc
+          cache: npm
+          cache-dependency-path: term-board/package-lock.json
+
+      - name: Install (clean, reproducible)
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Stage site (/term-board/ にネームスペース＋ルートはリダイレクト)
+        run: |
+          mkdir -p ../_site/term-board
+          cp -r dist/* ../_site/term-board/
+          # ルート（/hideharu-AI/）アクセスを term-board へ誘導する。
+          cat > ../_site/index.html <<'HTML'
+          <!doctype html>
+          <html lang="ja">
+            <head>
+              <meta charset="utf-8" />
+              <title>IT用語ボード</title>
+              <meta http-equiv="refresh" content="0; url=./term-board/" />
+            </head>
+            <body>
+              <a href="./term-board/">IT用語ボードへ移動</a>
+            </body>
+          </html>
+          HTML
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/term-board/README.md
+++ b/term-board/README.md
@@ -1,0 +1,72 @@
+# IT用語ボード（term-board）
+
+IT業界への就職・転職を目指す**未経験者**向けの、IT用語学習アプリ。
+4択クイズで知識を定着させ、用語を「**面接で自分の言葉で言える**」まで運ぶことを目的とする。
+
+## 🌐 公開URL（誰でも使えます・ログイン不要）
+
+**https://80-cloud.github.io/hideharu-AI/term-board/**
+
+- **ログイン不要。** URLを開けばすぐに学習を始められます。
+- **進捗はお使いのブラウザに保存されます**（localStorage）。アカウントもサーバーもありません。
+- 別の端末・別のブラウザではそれぞれ独立した進捗になります（端末間の同期はしません）。
+- スマホのスキマ時間にも使えるようモバイル最適化しています。
+
+### 📣 Discord などで共有する
+
+上記URLを Discord・X・LINE などに貼るだけで誰でも使えます。
+URLを貼ると **タイトル・説明つきのリンクプレビュー**（OGP）が表示されます。
+
+```
+IT用語ボードで面接対策しよう（ログイン不要・無料）
+https://80-cloud.github.io/hideharu-AI/term-board/
+```
+
+> 補足：プレビューに画像サムネイルも出したい場合は、`og:image`（絶対URLのPNG/JPG）を
+> 追加すればOK。現状はテキストのみのプレビュー（タイトル＋説明）で軽量に共有できます。
+
+> なぜアカウントが無いのか：学習アプリは各自が一人で使い、データを他人と共有しません。
+> 不要な認証・サーバーを持たないことで、安全（攻撃面ゼロ）・無料・高速を実現しています
+> （詳細は [docs/要件定義書.md](./docs/要件定義書.md) §1-5）。
+
+## 🛠 技術スタック
+
+| レイヤ | 採用 |
+|---|---|
+| フロント | React 19 + Vite + TypeScript + Tailwind CSS v4 |
+| 永続化 | localStorage（`api/` 層で隔離。将来サーバー化時は差し替えのみ） |
+| ホスティング | GitHub Pages（静的配信・GitHub Actions で自動デプロイ） |
+| Node | 24 LTS（`.nvmrc` 固定） |
+
+## 💻 ローカル開発
+
+```bash
+# Node 24 を使う（nvm 利用時）
+nvm use            # .nvmrc により 24 LTS
+
+npm install
+npm run dev        # http://localhost:5176/ で起動
+npm run build      # 本番ビルド（dist/）
+npm run preview    # 本番ビルドをローカル確認（base付き = /hideharu-AI/term-board/）
+```
+
+> ポートは **5176 固定**（他アプリと分離・[../CLAUDE.md](../CLAUDE.md) §10）。
+
+## 🚀 公開（デプロイ）
+
+`main` ブランチへ `term-board/**` の変更が入ると、GitHub Actions
+（[../.github/workflows/term-board-pages.yml](../.github/workflows/term-board-pages.yml)）が
+自動でビルドして GitHub Pages へ公開します。手動実行（workflow_dispatch）も可能です。
+
+## 📂 構成
+
+```
+term-board/
+├── src/
+│   ├── api/          # データ取得・保存の隔離層（localStorage実装）
+│   ├── hooks/        # 学習ロジック（useQuiz 等）
+│   ├── components/   # 表示
+│   ├── data/         # 用語データ（terms.json）
+│   └── types.ts      # Term / Progress 型
+└── docs/要件定義書.md
+```

--- a/term-board/index.html
+++ b/term-board/index.html
@@ -7,8 +7,19 @@
       rel="icon"
       href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ctext y='14' font-size='14'%3E%F0%9F%93%9A%3C/text%3E%3C/svg%3E"
     />
-    <title>IT用語ボード</title>
-    <meta name="description" content="IT業界就職の面接対策：IT用語を4択で定着させ、面接で言えるまで運ぶ学習アプリ" />
+    <title>IT用語ボード｜IT未経験者の面接対策クイズ</title>
+    <meta name="description" content="IT業界へ初めて転職する人向け。IT用語を4択クイズで定着させ、面接で自分の言葉で言えるまで練習できる無料アプリ。ログイン不要、ブラウザだけで今すぐ。" />
+
+    <!-- Open Graph / Twitter Card: Discord 等にURLを貼ったときのリンクプレビュー用（Issue #285） -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="IT用語ボード" />
+    <meta property="og:title" content="IT用語ボード｜IT未経験者の面接対策クイズ" />
+    <meta property="og:description" content="IT用語を4択クイズで定着させ、面接で言えるまで練習。ログイン不要・無料・ブラウザだけで今すぐ。" />
+    <meta property="og:url" content="https://80-cloud.github.io/hideharu-AI/term-board/" />
+    <meta property="og:locale" content="ja_JP" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="IT用語ボード｜IT未経験者の面接対策クイズ" />
+    <meta name="twitter:description" content="IT用語を4択クイズで定着させ、面接で言えるまで練習。ログイン不要・無料・ブラウザだけで今すぐ。" />
   </head>
   <body>
     <div id="root"></div>

--- a/term-board/vite.config.ts
+++ b/term-board/vite.config.ts
@@ -4,7 +4,13 @@ import tailwindcss from "@tailwindcss/vite";
 
 // 要件定義書 §ローカルポート: term-board は 5176 固定（他アプリと分離・CLAUDE.md §10）。
 // 別ポートでの代替起動は禁止のため strictPort: true で競合時はエラーにする。
+//
+// base: GitHub Pages のサブパス配信用（Issue #285）。
+// 公開URL = https://80-cloud.github.io/hideharu-AI/term-board/ なので、
+// 本番ビルドのアセット参照を "/hideharu-AI/term-board/" 起点にする。
+// dev（npm run dev）では base は "/" 相当で問題なく動く（プロダクションビルドのみ影響）。
 export default defineConfig({
+  base: "/hideharu-AI/term-board/",
   plugins: [react(), tailwindcss()],
   server: {
     port: 5176,


### PR DESCRIPTION
## 関連 Issue

Closes #285

---

## 変更の概要

term-board を **誰でもURLを開けば使える** よう GitHub Pages で静的公開し、**Discord 等での共有**に対応する。

### このアプリに合わせたやり方（重要な設計判断）
- 学習アプリはデータを他人と共有しない → **認証・サーバー・DBを持たない**。sns-board のフルスタック認証は採用せず、参照したのは「静的フロント配信」の考え方のみ。
- 進捗は各利用者のブラウザの localStorage に保存（過去問道場と同じ思想・要件定義書 §1-5）。
- 不要な認証/サーバーを持たない＝**攻撃面ゼロ・無料・高速**（CLAUDE.md §12 の品質低下リスク回避に整合）。

### 変更点
| ファイル | 内容 |
|---|---|
| `.github/workflows/term-board-pages.yml` | push to main(`term-board/**`) でビルド→Pages公開。Node は `.nvmrc`(24)。手動実行も可 |
| `term-board/vite.config.ts` | `base="/hideharu-AI/term-board/"`（Pagesサブパス配信） |
| `term-board/index.html` | **OG / Twitter Card メタ追加**＝Discordにリンクを貼るとタイトル・説明つきプレビュー表示 |
| `term-board/README.md` | 公開URL・ログイン不要・進捗はブラウザ保存・**Discord共有手順**を明記 |

### 公開URL
**https://80-cloud.github.io/hideharu-AI/term-board/** （ルートはここへリダイレクト）

## 変更の種別

- [x] chore（設定・ツールの変更）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（`vite preview` でサブパス配信を実ブラウザ検証：アセット解決・4択クイズ動作OK）
- [x] 本番ビルドに base と OGタグが反映されることを確認
- [x] `.env`・パスワードをコミットしていない
- [x] Pages を Actions ソースで有効化済み（`build_type=workflow`）

> マージ後にワークフローが走り、上記URLで公開されます（初回デプロイ）。

---

## レビュー時に特に確認してほしい点

- サブパス `/hideharu-AI/term-board/` 設計（将来 他の静的アプリを足す余地を残しつつ、ルートはリダイレクト）。
- OGプレビューは現状テキストのみ（タイトル＋説明）。画像サムネイルが欲しければ `og:image` を後追いで追加可（READMEに補足済み）。