### PR TITLE
fix: 分野ラベルのコントラスト不足を解消（A-5 Accessibility=100）

### DIFF
--- a/term-board/src/components/QuizView.tsx
+++ b/term-board/src/components/QuizView.tsx
@@ -35,7 +35,7 @@ export function QuizView({ question, selected, isCorrect, onAnswer, onNext }: Pr
   return (
     <section className="flex flex-col gap-5" aria-live="polite">
       <div className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-200">
-        <p className="text-sm font-medium text-sky-600">{question.term.category}</p>
+        <p className="text-sm font-medium text-sky-700">{question.term.category}</p>
         <h2 className="mt-1 text-2xl font-bold text-slate-900">
           「{question.term.term}」の意味は？
         </h2>


### PR DESCRIPTION
## 関連 Issue

Closes #292

## 変更の概要
Lighthouse（モバイル）で唯一失敗していた **color-contrast** を解消し、受入条件 **A-5** を満たす。
`QuizView` の分野ラベルを `text-sky-600` → `text-sky-700`（白背景上で約6.4:1・WCAG 2.1 AA合格）。

## 計測結果（本番ビルドをローカルpreviewでLighthouse再計測）
| 項目 | 修正前 | 修正後 |
|---|---|---|
| Accessibility | 95 | **100**（全45項目パス・失敗0） |
| Best Practices | 100 | 100 |
| SEO | 100 | 100 |
| Performance | LCP 92ms / CLS 0.00 | 同（Perf≥90相当） |

## 変更の種別
- [x] fix（バグ修正）

## 動作確認チェックリスト
- [x] ローカルで動作確認（Lighthouse モバイル navigation）
- [x] 既存表示・動作を壊さない（色のトーンのみ変更）
- [x] `.env`・パスワード未コミット

> マージで term-board/** が変わるため Pages が再デプロイされます（公開中のため想定内）。