### PR TITLE
chore: term-board の CI 整備（型チェック/ビルド＋npm audit 常設）

### DIFF
--- a/.github/workflows/term-board-ci.yml
+++ b/.github/workflows/term-board-ci.yml
@@ -1,0 +1,44 @@
+name: term-board CI
+
+# term-board の品質ゲート（要件定義書 §4-2・受入 A-6）。
+# 型チェック＋本番ビルドの成功と、依存脆弱性 High/Critical 0件を常設で担保する。
+# lint/test は設定・テスト未整備のため現状は対象外（整備後に追加予定）。
+
+on:
+  pull_request:
+    paths:
+      - "term-board/**"
+      - ".github/workflows/term-board-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "term-board/**"
+      - ".github/workflows/term-board-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-audit:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: term-board
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node (use .nvmrc = 24 LTS)
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: term-board/.nvmrc
+          cache: npm
+          cache-dependency-path: term-board/package-lock.json
+
+      - name: Install (clean, reproducible)
+        run: npm ci
+
+      - name: Type check & build
+        run: npm run build
+
+      - name: Dependency vulnerability scan (fail on High/Critical)
+        run: npm audit --audit-level=high


### PR DESCRIPTION
## 関連 Issue

Closes #294

## 変更の概要
要件定義書 §4-2・受入 **A-6**（npm audit High/Critical 0件）を常設で担保する CI を追加。

`.github/workflows/term-board-ci.yml`:
- トリガー: PR / push to main（paths: `term-board/**`）
- Node は `.nvmrc`(24)・`npm ci`
- **型チェック＋本番ビルド**（`npm run build` = `tsc -b && vite build`）
- **`npm audit --audit-level=high`**（High/Critical で fail）

## 変更の種別
- [x] chore（設定・ツールの変更）

## 動作確認チェックリスト
- [x] ローカルで CI 相当を検証（build: OK / audit: 0 vulnerabilities）
- [x] `.env`・パスワード未コミット

## 補足
- lint/test は eslint設定・テスト未整備のため本PRの範囲外（整備後に別PRで追加）。
- これ以降の term-board のPRは本CIで型/ビルド/脆弱性が自動チェックされます。