### PR TITLE
docs: 引き継ぎ書を作成（次セッション用・全7バッチ完了時点）

### DIFF
--- a/term-board/docs/引き継ぎ書.md
+++ b/term-board/docs/引き継ぎ書.md
@@ -1,0 +1,224 @@
+# term-board 引き継ぎ書（次セッション用）
+
+**最終更新:** 2026-05-28
+**対象:** 次セッションで実装を続ける開発者（および Claude Code）
+**アプリ:** IT用語ボード（term-board）— IT未経験者・初めてIT業界へ転職する人向けの面接対策学習アプリ
+
+---
+
+## 0. 3行サマリ
+
+- **MVP〜拡張は本番公開済み**：https://80-cloud.github.io/hideharu-AI/term-board/ （ログイン不要・無料・GitHub Pages・コスト0円）
+- **B1〜B7 の全バッチ実装完了**（音読・録音は除外）。オープンPRなし・宙ぶらりんゼロ・main 整合済み。
+- **次にやるのは「未実装の予定機能」**：最優先候補は ①面接ログの補完 ②#289 深掘りチェーン ③#290 SRS ④#291 模擬面接（§5参照）。
+
+---
+
+## 1. 何のアプリか
+
+- **目的**：IT用語を「見た瞬間に分かり、面接で自分の言葉で言える」まで運ぶ。過去問道場の4択学習サイクルを**面接対策**へ拡張。
+- **対象ユーザー**：IT業界へ**初めて転職する人・実務未経験者**（ポートフォリオ・現場経験を持たない前提）。要件定義書 §1-3。
+- **設計思想**：サーバー・DB・認証を持たない**静的SPA**（不要を持たず床割れリスクを避ける）。共有はサーバー無しのピア共有（共有コード）。将来は `api/` 層の差し替えでフルスタック化可能（要件定義書 §1-5・§8）。
+
+---
+
+## 2. 技術スタック・場所
+
+| 項目 | 内容 |
+|---|---|
+| フォルダ | `/Users/macmini/dev/Cursor/term-board/` |
+| リポジトリ | `80-cloud/hideharu-AI`（モノレポ。他に task-board / review-board / sns-board 等） |
+| フロント | React 19 + Vite 6 + TypeScript + Tailwind CSS v4 |
+| 永続化 | localStorage のみ（`api/` 層で隔離） |
+| ホスティング | GitHub Pages（静的）。`main` の `term-board/**` 変更で自動デプロイ |
+| Node | **24 LTS**（`.nvmrc`）。nvm は Homebrew で導入済み |
+| 公開URL | https://80-cloud.github.io/hideharu-AI/term-board/ |
+| dev ポート | **5176**（固定・他アプリと分離） |
+
+### ローカル起動
+
+```bash
+cd /Users/macmini/dev/Cursor/term-board
+nvm use          # .nvmrc により Node 24（※ ~/.zshrc に nvm 読込設定は追記済み）
+npm install
+npm run dev      # http://localhost:5176/
+npm run build    # tsc -b && vite build（CIと同じ）
+npm run preview  # 本番ビルドを base 付き(/hideharu-AI/term-board/)で確認 → :4173
+```
+
+> **重要**：bash から npm を使うときは毎回 `export NVM_DIR="$HOME/.nvm"; \. "/opt/homebrew/opt/nvm/nvm.sh"; nvm use 24` を読み込むこと（非対話シェルでは .zshrc が効かない場合がある）。
+
+---
+
+## 3. ディレクトリ構成（src/）
+
+```
+src/
+├── api/                         # データ取得・保存の隔離層（差し替え点）
+│   ├── termRepository.ts        # インタフェース（全メソッド定義）
+│   ├── localStorageTermRepository.ts  # MVP実装（localStorage・破損ガード）
+│   └── index.ts                 # repository を1箇所でエクスポート（Phase4はここを差し替え）
+├── hooks/
+│   ├── useQuiz.ts               # 4択ロジック（reloadKeyで作問を即反映・解答時に学習日記録）
+│   ├── useUserContent.ts        # 作問CRUD＋共有コード（F-USER）
+│   ├── useBookmarks.ts          # ブックマーク集合（B1）
+│   ├── useTheme.ts              # ダーク/ライト（B2・クラス式）
+│   └── useProfileDraft.ts       # 自己PR下書き（B5・自動保存）
+├── components/
+│   ├── HomeView.tsx             # B7 トップページ（初期表示・各モード入口）
+│   ├── QuizView.tsx             # 4択の出題・採点・解説（かんたん→意味→面接→現場）
+│   ├── CategoryFilter.tsx       # 分野フィルタ
+│   ├── DictionaryView.tsx       # B1 用語辞典（検索/分野/レベル/★/詳細）
+│   ├── LearnView.tsx            # B6 学ぶ（ロードマップ/職種/図解）
+│   ├── InterviewView.tsx        # 面接練習（同梱質問＋頻出タグ＋テンプレ＋NG例＋ユーザー作問）
+│   ├── DashboardView.tsx        # B3 ダッシュボード（正答率/苦手/おすすめ/ストリーク）
+│   ├── PrepView.tsx             # B5 自己紹介・志望動機
+│   └── AuthorView.tsx           # マイ問題（作問・共有 F-USER）
+├── data/
+│   ├── terms.json               # 用語12件（level/plainMeaning/scene つき）
+│   ├── interviewQuestions.json  # 同梱の頻出面接質問6件（tags/template/ngExample）
+│   ├── roadmap.json             # 学習ロードマップ6ステップ
+│   └── jobRoles.json            # 職種5種
+├── utils/
+│   ├── shuffle.ts               # Fisher–Yates・pickRandom
+│   └── share.ts                 # 共有コード encode/decode・newId（F-USER）
+├── types.ts                     # Term / Progress / InterviewQuestion / UserContent / ProfileDraft
+├── App.tsx                      # ナビ（ホーム/4択/辞典/学ぶ/面接練習/ダッシュボード/自己PR/マイ問題）
+└── main.tsx / index.css         # エントリ・Tailwind(@custom-variant dark)
+```
+
+### localStorage キー一覧
+- `term-board:progress:v1` — 用語ごとの正誤（F-PROG-01）
+- `term-board:userContent:v1` — ユーザー作問（F-USER）
+- `term-board:bookmarks:v1` — ブックマーク（B1）
+- `term-board:studyDays:v1` — 学習した日（B3 ストリーク）
+- `term-board:profile:v1` — 自己PR下書き（B5）
+- `term-board:theme:v1` — テーマ（B2）
+
+---
+
+## 4. 実装済み機能（本番公開中）
+
+| 区分 | 機能 | PR |
+|---|---|---|
+| Phase1 | 4択出題/即採点/正解位置ランダム化/分野フィルタ/解答記録 | #282 |
+| 未経験者土台 | F-TERM-05 平易説明（かんたんに言うと） | #287 |
+| コア差別化 | F-TERM-04 実務シーン（現場では） | #288 |
+| ユーザー作問 | F-USER 作問＋共有コード、F-INTV-01 面接練習 | #302 |
+| 公開 | GitHub Pages 自動デプロイ・OGP（Discord共有） | #286 |
+| 品質 | A-5 達成（A11y=100）、CI（build+npm audit）常設 | #292/#294 |
+| **B1** | 用語辞典（辞典/カテゴリ/検索/ブックマーク/レベル） | #305 |
+| **B2** | ダークモード（クラス式トグル） | #307 |
+| **B3** | ダッシュボード（分野別正答率/苦手抽出/おすすめ/ストリーク） | #309 |
+| **B4** | 面接コンテンツ（想定質問集/頻出タグ/回答テンプレ/NG例） | #311 |
+| **B5** | 自己PR（自己紹介作成/志望動機整理） | #313 |
+| **B6** | 学ぶ（学習ロードマップ/業界職種解説/図解） | #315 |
+| **B7** | トップページ（ホーム・各モード入口） | #317 |
+
+> 全画面で Lighthouse（モバイル）**Accessibility=100 / Best Practices=100 / SEO=100**、Performance良好（LCP≈92ms）、`npm audit` High/Critical **0件**、ライト/ダーク両対応を維持。
+
+---
+
+## 5. 未実装＝次にやること（優先度つき）
+
+### ★ 最優先候補
+
+1. **面接ログの補完（当初リストの取りこぼし）**
+   - 現状：`studyDays` は**クイズ解答時のみ**記録。面接練習（InterviewView）は履歴を残さない。
+   - やること：面接練習で「言えた/言えなかった」自己評価（F-INTV-02）＋練習履歴を記録し、ダッシュボードに反映。
+   - 関連：`api/` に面接ログ用ストア追加 or LearningLog（要件定義書 §8-3 の `LearningSession`）を実装。
+
+2. **#289 F-INTV-03 深掘り「なぜ?」チェーン**（Issue起票済み）
+   - `Term.followUps?: {q;a}[]` は型に未追加。terms.json に追い質問を足し、QuizView/InterviewViewで段階開示。
+
+3. **#290 F-QUIZ-05 間隔反復（SRS）**（Issue起票済み）
+   - `useQuiz` の出題選択を Progress 入力の優先度方式に（Leitner等）。苦手・未出題を優先。
+
+4. **#291 F-INTV-04 模擬面接モード**（Issue起票済み）
+   - 質問→（入力/口頭）→模範と差分→自己評価。タイマー任意。
+
+### その他の予定（要件定義書・機能一覧.md の 📋予定）
+- F-CARD-01 暗記カード、F-PROG-04 進捗リセット/エクスポート
+- F-LOG-03 学習メモ / F-LOG-04 振り返り一覧 / F-LOG-05 ログのエクスポート/インポート
+- F-INTV-05 構造採点ルーブリック / F-INTV-06 説明相手レベル切替 / F-INTV-07 逆質問ストック
+- F-QUIZ-06 混同ペア分析 / F-PROG-06 知識マップ / F-BHV-01 行動面接STAR
+- （Phase4・将来）F-AUTH 認証 / F-PROG-05 サーバー保存 / F-TERM-03 用語サーバー管理
+
+> 各機能の詳細仕様は `docs/要件定義書.md`（§13 含む）と `docs/機能一覧.md`（ステータス列）を参照。
+
+### 内容面のTODO
+- **用語データの拡充**（現状12件のみ）。出典確定と内容正確性レビュー（受入 A-7・R-01）。
+- 用語に `followUps`/`reverseQuestions`/`related`/`confusedWith` を段階的に付与（差別化機能の前提データ）。
+
+---
+
+## 6. 開発ルール（CLAUDE.md 準拠・厳守）
+
+1. **main直push禁止**。必ず Issue → ブランチ → PR → Squash merge。
+2. ブランチ名：`feature/#番号-説明` / `fix/#番号-説明` / `docs/#番号-説明` / `chore/#番号-説明`。
+3. コミット・PR は**日本語・Conventional Commits**（feat: / fix: / docs: / chore: …）。PR は `Closes #番号`。
+4. ラベル必須（enhancement/bug/documentation/chore）。
+5. PRマージ後は `git checkout main && git pull` で整合。
+6. **CI**：term-board の PR は `term-board-ci.yml`（型チェック＋ビルド＋`npm audit --audit-level=high`）と `claude-review` が走る。両方 pass を確認してマージ。
+7. **デプロイ**：main の `term-board/**` 変更で `term-board-pages.yml` が自動デプロイ（公開中なのでマージ＝本番反映）。
+8. **機能一覧.md は生きた文書**：機能を実装したら、その実装PRで該当行のステータスを ✅ に更新する。
+
+### 1機能の標準フロー（このセッションで確立した型）
+```
+① gh issue create（enhancement）
+② git checkout -b feature/#番号-説明
+③ 実装（types→api→hooks→components→App配線）
+④ npm run build（型/ビルド）
+⑤ npm run preview → Chrome DevTools で実ブラウザ検証＋Lighthouse(モバイル)でA11y=100確認
+⑥ 機能一覧.md のステータス更新
+⑦ commit（日本語）→ push → gh pr create（Closes #番号）
+⑧ CI(build-and-audit/claude-review)pass を待つ → Squash merge --delete-branch
+⑨ git checkout main && git pull → 必要なら本番URLで反映確認
+```
+
+---
+
+## 7. 設計上の注意点（ハマりどころ）
+
+- **ダークモードはクラス式**（`index.css` の `@custom-variant dark (&:where(.dark, .dark *))`）。`dark:` クラスは `.dark` 配下でのみ効く。**`prefers-color-scheme` 依存にしないこと**（テスト環境がダークだと背景と文字が食い違いコントラスト破綻 → A11y落ちる）。新規UIに `dark:` を足すときは light/dark 両方で Lighthouse 確認。
+- **コントラスト（WCAG AA）**：`text-slate-500` は slate-50 背景上で borderline。本文は `slate-600`（light）/`slate-300`（dark）を基本に。白文字ボタンは `bg-sky-700` 以上（`sky-600` は白文字4.0で**不足**）。
+- **作問4択をクイズに即反映**：`useQuiz(reloadKey)` に `user.content.quizTerms.length` を渡している（App.tsx）。出題データを変える機能は reloadKey を更新する。
+- **graceful degradation**：localStorage 読込は全て try/catch で空フォールバック。出題は止めない（受入 A-4）。新ストア追加時も踏襲。
+- **`api/` 隔離を崩さない**：コンポーネントから直接 localStorage を触らない。必ず `repository`（`api/index.ts`）経由。
+- **perl で className 一括置換は危険**：`\S+` が閉じ引用符を巻き込みJSXを壊した事故あり。負の先読みを使うか、対象を限定するか、Edit を使う。
+
+---
+
+## 8. ドキュメント一覧（docs/）
+
+- `要件定義書.md`（v0.4・§13 面接対策機能の詳細・§14 ユーザー作問）— 仕様の正本
+- `機能一覧.md` — 機能ID×実装ステータス（**生きた一覧**）
+- `データモデル.md` — Term/Progress/InterviewQuestion/UserContent/ProfileDraft（ER図の代替）
+- `技術スタック.md` — 採用技術と不採用理由
+- `画面設計書.md` — 画面一覧・状態遷移（※B1〜B7のモード追加分は未追記。要更新）
+- `テスト計画書.md` — 方針（ピラミッド）。**自動テスト未導入**（現状は実ブラウザ検証＋CIのbuild/audit）
+- `引き継ぎ書.md` — 本書
+
+### ドキュメントの未更新点（次セッションで直すと良い）
+- **画面設計書.md** が S-01/S-03/S-06 までしか反映されておらず、B1〜B7 で増えた画面（用語辞典/学ぶ/ダッシュボード/自己PR/ホーム）が未記載。
+- **テスト計画書**：Vitest（ユニット）/Playwright（E2E）が未導入のまま。shuffle・useQuiz・repository破損ガードのユニットテストが価値高。
+
+---
+
+## 9. 現在の状態（クリーン）
+
+- オープンな term-board PR：**なし**
+- 宙ぶらりんの作業：**なし**
+- main：B7（#317）まで反映・本番公開済み
+- 手動タスク：なし（nvm/zshrc は設定済み）
+
+---
+
+## 10. 次セッションの推奨スタート
+
+1. `cd /Users/macmini/dev/Cursor/term-board && git checkout main && git pull`（最新確認）
+2. やる機能を1つ選ぶ（§5 の最優先候補から）→ Issue 作成 → §6 の標準フローで実装
+3. 迷ったら `docs/機能一覧.md` の 📋予定 を上から、または要件定義書 §13 を参照
+
+> 推奨順：**面接ログ補完（自己評価F-INTV-02含む）→ #289 深掘り → #290 SRS → #291 模擬面接**。
+> いずれも `Term`/`InterviewQuestion` への任意フィールド追加＋表示で段階導入でき、`api/` 隔離のまま育つ。

--- a/term-board/docs/引き継ぎ書.md
+++ b/term-board/docs/引き継ぎ書.md
@@ -1,224 +1,336 @@
-# term-board 引き継ぎ書（次セッション用）
+# term-board 引き継ぎ書（次セッション用・詳細版）
 
 **最終更新:** 2026-05-28
-**対象:** 次セッションで実装を続ける開発者（および Claude Code）
+**対象:** 次セッションで実装を続ける開発者／ Claude Code
 **アプリ:** IT用語ボード（term-board）— IT未経験者・初めてIT業界へ転職する人向けの面接対策学習アプリ
+**本番URL:** https://80-cloud.github.io/hideharu-AI/term-board/ （ログイン不要・無料・GitHub Pages・コスト0円）
 
 ---
 
 ## 0. 3行サマリ
 
-- **MVP〜拡張は本番公開済み**：https://80-cloud.github.io/hideharu-AI/term-board/ （ログイン不要・無料・GitHub Pages・コスト0円）
-- **B1〜B7 の全バッチ実装完了**（音読・録音は除外）。オープンPRなし・宙ぶらりんゼロ・main 整合済み。
-- **次にやるのは「未実装の予定機能」**：最優先候補は ①面接ログの補完 ②#289 深掘りチェーン ③#290 SRS ④#291 模擬面接（§5参照）。
+- **B1〜B7 の全バッチ実装完了・本番公開済み**。オープンPRなし・宙ぶらりんゼロ・main 整合済み。
+- アプリは**サーバー無しの静的SPA**（React+Vite+TS+Tailwind v4、永続化は localStorage、`api/` 層で隔離）。
+- **次にやる最優先**：①面接ログ補完（自己評価 F-INTV-02 含む）→ ②#289 深掘りチェーン → ③#290 SRS → ④#291 模擬面接（詳細は §6）。
 
 ---
 
-## 1. 何のアプリか
+## 1. アプリの目的と設計思想
 
 - **目的**：IT用語を「見た瞬間に分かり、面接で自分の言葉で言える」まで運ぶ。過去問道場の4択学習サイクルを**面接対策**へ拡張。
-- **対象ユーザー**：IT業界へ**初めて転職する人・実務未経験者**（ポートフォリオ・現場経験を持たない前提）。要件定義書 §1-3。
-- **設計思想**：サーバー・DB・認証を持たない**静的SPA**（不要を持たず床割れリスクを避ける）。共有はサーバー無しのピア共有（共有コード）。将来は `api/` 層の差し替えでフルスタック化可能（要件定義書 §1-5・§8）。
+- **対象**：IT業界へ**初めて転職する人・実務未経験者**（ポートフォリオ・現場経験なし前提）。要件定義書 §1-3。
+  - → 設計に効く前提：**専門用語を専門用語で説明しない（平易ファースト）／用語は"現場での使われ方"に紐付け／怖くない・続くUX**。
+- **設計思想（重要）**：認証・サーバー・DBを**意図的に持たない**（不要を持つと床割れリスクが増える・要件定義書 §1-5）。
+  - 共有はサーバー無しの**ピア共有**（共有コードをDiscord等に貼る）。
+  - 将来フルスタック化は `api/` 層の実装差し替え1箇所でできる設計（§3-2 / 要件定義書 §8-4）。
 
 ---
 
-## 2. 技術スタック・場所
+## 2. 環境・起動
 
-| 項目 | 内容 |
+| 項目 | 値 |
 |---|---|
 | フォルダ | `/Users/macmini/dev/Cursor/term-board/` |
-| リポジトリ | `80-cloud/hideharu-AI`（モノレポ。他に task-board / review-board / sns-board 等） |
-| フロント | React 19 + Vite 6 + TypeScript + Tailwind CSS v4 |
-| 永続化 | localStorage のみ（`api/` 層で隔離） |
-| ホスティング | GitHub Pages（静的）。`main` の `term-board/**` 変更で自動デプロイ |
-| Node | **24 LTS**（`.nvmrc`）。nvm は Homebrew で導入済み |
-| 公開URL | https://80-cloud.github.io/hideharu-AI/term-board/ |
-| dev ポート | **5176**（固定・他アプリと分離） |
+| リポジトリ | `80-cloud/hideharu-AI`（モノレポ。task-board/review-board/sns-board 等と同居） |
+| フロント | React 19 / Vite 6 / TypeScript 5.7 / Tailwind CSS v4（@tailwindcss/vite） |
+| 永続化 | localStorage のみ |
+| ホスティング | GitHub Pages（`main` の `term-board/**` 変更で自動デプロイ） |
+| Node | **24 LTS**（`.nvmrc`）。nvm は Homebrew 導入済み・`~/.zshrc` に読込設定済み |
+| dev ポート | **5176**（固定。`vite.config.ts` の `strictPort`） |
+| Pages base | `/hideharu-AI/term-board/`（`vite.config.ts`） |
 
-### ローカル起動
-
+### bash から npm を使うときの定型（非対話シェルで nvm を読む）
 ```bash
+export NVM_DIR="$HOME/.nvm"; \. "/opt/homebrew/opt/nvm/nvm.sh"; nvm use 24
 cd /Users/macmini/dev/Cursor/term-board
-nvm use          # .nvmrc により Node 24（※ ~/.zshrc に nvm 読込設定は追記済み）
-npm install
-npm run dev      # http://localhost:5176/
-npm run build    # tsc -b && vite build（CIと同じ）
-npm run preview  # 本番ビルドを base 付き(/hideharu-AI/term-board/)で確認 → :4173
 ```
 
-> **重要**：bash から npm を使うときは毎回 `export NVM_DIR="$HOME/.nvm"; \. "/opt/homebrew/opt/nvm/nvm.sh"; nvm use 24` を読み込むこと（非対話シェルでは .zshrc が効かない場合がある）。
+### コマンド
+```bash
+npm install
+npm run dev      # http://localhost:5176/
+npm run build    # tsc -b && vite build（CIと同一・型エラーも検出）
+npm run preview  # 本番ビルドを base 付きで配信 → http://localhost:4173/hideharu-AI/term-board/
+npm audit --audit-level=high   # High/Critical 0 を維持（CIでも実行）
+```
+
+> Lighthouse は **preview（本番ビルド）に対して** Chrome DevTools の lighthouse_audit を mobile で実行。ダークモードは light/dark **両方**で確認すること（§8）。
 
 ---
 
-## 3. ディレクトリ構成（src/）
+## 3. アーキテクチャ
+
+### 3-1. ディレクトリ（src/）
 
 ```
 src/
-├── api/                         # データ取得・保存の隔離層（差し替え点）
-│   ├── termRepository.ts        # インタフェース（全メソッド定義）
-│   ├── localStorageTermRepository.ts  # MVP実装（localStorage・破損ガード）
-│   └── index.ts                 # repository を1箇所でエクスポート（Phase4はここを差し替え）
+├── api/
+│   ├── termRepository.ts            # インタフェース（下記 3-3）
+│   ├── localStorageTermRepository.ts# MVP実装（全メソッド・破損ガードつき）
+│   └── index.ts                     # export const repository = localStorageTermRepository
+│                                     #   ← Phase4 はここを http 実装に差し替えるだけ
 ├── hooks/
-│   ├── useQuiz.ts               # 4択ロジック（reloadKeyで作問を即反映・解答時に学習日記録）
-│   ├── useUserContent.ts        # 作問CRUD＋共有コード（F-USER）
-│   ├── useBookmarks.ts          # ブックマーク集合（B1）
-│   ├── useTheme.ts              # ダーク/ライト（B2・クラス式）
-│   └── useProfileDraft.ts       # 自己PR下書き（B5・自動保存）
+│   ├── useQuiz.ts        # 4択ロジック。useQuiz(reloadKey) で作問を即反映。解答時に studyDay 記録
+│   ├── useUserContent.ts # 作問CRUD＋exportCode/importCode（F-USER）
+│   ├── useBookmarks.ts   # Set<string> 管理（B1）
+│   ├── useTheme.ts       # "light"|"dark" トグル（B2・<html class="dark">）
+│   └── useProfileDraft.ts# 自己PR下書き（B5・自動保存）
 ├── components/
-│   ├── HomeView.tsx             # B7 トップページ（初期表示・各モード入口）
-│   ├── QuizView.tsx             # 4択の出題・採点・解説（かんたん→意味→面接→現場）
-│   ├── CategoryFilter.tsx       # 分野フィルタ
-│   ├── DictionaryView.tsx       # B1 用語辞典（検索/分野/レベル/★/詳細）
-│   ├── LearnView.tsx            # B6 学ぶ（ロードマップ/職種/図解）
-│   ├── InterviewView.tsx        # 面接練習（同梱質問＋頻出タグ＋テンプレ＋NG例＋ユーザー作問）
-│   ├── DashboardView.tsx        # B3 ダッシュボード（正答率/苦手/おすすめ/ストリーク）
-│   ├── PrepView.tsx             # B5 自己紹介・志望動機
-│   └── AuthorView.tsx           # マイ問題（作問・共有 F-USER）
+│   ├── HomeView.tsx       # B7 トップ（props: onNavigate）。初期表示
+│   ├── QuizView.tsx       # 4択出題・採点・解説（かんたん→意味→面接→現場）
+│   ├── CategoryFilter.tsx # 分野select（quiz画面のヘッダーにのみ表示）
+│   ├── DictionaryView.tsx # B1 辞典（props: bookmarks）
+│   ├── LearnView.tsx      # B6 学ぶ（roadmap/jobRoles/図解。内部サブタブ）
+│   ├── InterviewView.tsx  # 面接練習（props: userQuestions）。同梱質問＋タグ＋テンプレ＋NG例
+│   ├── DashboardView.tsx  # B3（props: bookmarks）。Progress集計
+│   ├── PrepView.tsx       # B5 自己PR（内部サブタブ：自己紹介/志望動機）
+│   └── AuthorView.tsx     # マイ問題（props: user=UseUserContent。内部サブタブ：面接Q&A/4択/共有）
 ├── data/
-│   ├── terms.json               # 用語12件（level/plainMeaning/scene つき）
-│   ├── interviewQuestions.json  # 同梱の頻出面接質問6件（tags/template/ngExample）
+│   ├── terms.json               # 用語12件
+│   ├── interviewQuestions.json  # 同梱の頻出面接質問6件
 │   ├── roadmap.json             # 学習ロードマップ6ステップ
 │   └── jobRoles.json            # 職種5種
 ├── utils/
-│   ├── shuffle.ts               # Fisher–Yates・pickRandom
-│   └── share.ts                 # 共有コード encode/decode・newId（F-USER）
-├── types.ts                     # Term / Progress / InterviewQuestion / UserContent / ProfileDraft
-├── App.tsx                      # ナビ（ホーム/4択/辞典/学ぶ/面接練習/ダッシュボード/自己PR/マイ問題）
-└── main.tsx / index.css         # エントリ・Tailwind(@custom-variant dark)
+│   ├── shuffle.ts  # shuffle<T>(arr) / pickRandom<T>(arr)
+│   └── share.ts    # encodeShareCode / decodeShareCode / newId
+├── types.ts        # 下記 3-2
+├── App.tsx         # View型のユニオン・ナビ・各ビューの出し分け
+├── main.tsx        # createRoot
+└── index.css       # @import "tailwindcss"; @custom-variant dark (...)
 ```
 
-### localStorage キー一覧
-- `term-board:progress:v1` — 用語ごとの正誤（F-PROG-01）
-- `term-board:userContent:v1` — ユーザー作問（F-USER）
-- `term-board:bookmarks:v1` — ブックマーク（B1）
-- `term-board:studyDays:v1` — 学習した日（B3 ストリーク）
-- `term-board:profile:v1` — 自己PR下書き（B5）
-- `term-board:theme:v1` — テーマ（B2）
+### 3-2. 型定義（src/types.ts・現物）
 
----
+```ts
+export type Term = {
+  id: string; category: string; term: string;
+  meaning: string; distractors: string[]; interview: string;
+  plainMeaning?: string;            // F-TERM-05 かんたん説明
+  scene?: string;                   // F-TERM-04 現場での使われ方
+  source?: "builtin" | "user";      // 出所
+  level?: "初級" | "中級" | "上級";  // B1 レベル
+};
 
-## 4. 実装済み機能（本番公開中）
+export type InterviewQuestion = {
+  id: string; category: string; question: string; answer: string;
+  memo?: string; source?: "builtin" | "user";
+  tags?: string[];      // B4 頻出タグ（"頻出"/"未経験定番"/"STAR"）
+  template?: string;    // B4 回答の型
+  ngExample?: string;   // B4 NG例＋改善
+};
 
-| 区分 | 機能 | PR |
+export type UserContent = { quizTerms: Term[]; interviewQuestions: InterviewQuestion[] };
+
+export type ProfileDraft = {
+  selfIntro:  { name; background; learning; work; closing };   // 各 string
+  motivation: { trigger; companyReason; action; future };      // 各 string
+};
+
+export type Progress = { [termId: string]: { correct: number; wrong: number; lastAnsweredAt: string } };
+```
+
+> 拡張フィールドは**すべて任意**。新機能はだいたい「型に任意フィールド追加 → data/JSON に値追加 → 表示」の3手で段階導入できる。
+
+### 3-3. api/ 層インタフェース（src/api/termRepository.ts・現物）
+
+```ts
+export interface TermRepository {
+  getTerms(): Promise<Term[]>;                 // builtin＋userのquizTermsを統合（source付与）
+  getProgress(): Promise<Progress>;
+  saveProgress(p: Progress): Promise<void>;
+  getUserContent(): Promise<UserContent>;       // F-USER
+  saveUserContent(c: UserContent): Promise<void>;
+  getBookmarks(): Promise<string[]>;            // B1
+  saveBookmarks(ids: string[]): Promise<void>;
+  getStudyDays(): Promise<string[]>;            // B3（YYYY-MM-DD）
+  recordStudyDay(day: string): Promise<void>;
+  getProfileDraft(): Promise<ProfileDraft | null>; // B5
+  saveProfileDraft(p: ProfileDraft): Promise<void>;
+}
+```
+
+- **使い方**：`import { repository } from "../api";` して `repository.xxx()`。**コンポーネントから直接 localStorage を触らない**（必ず repository 経由）。
+- localStorage 実装は全 get で try/catch → 空フォールバック（graceful degradation・受入 A-4）。新ストア追加時も踏襲。
+
+### 3-4. localStorage キー
+| キー | 内容 | 書く場所 |
 |---|---|---|
-| Phase1 | 4択出題/即採点/正解位置ランダム化/分野フィルタ/解答記録 | #282 |
-| 未経験者土台 | F-TERM-05 平易説明（かんたんに言うと） | #287 |
-| コア差別化 | F-TERM-04 実務シーン（現場では） | #288 |
-| ユーザー作問 | F-USER 作問＋共有コード、F-INTV-01 面接練習 | #302 |
-| 公開 | GitHub Pages 自動デプロイ・OGP（Discord共有） | #286 |
-| 品質 | A-5 達成（A11y=100）、CI（build+npm audit）常設 | #292/#294 |
-| **B1** | 用語辞典（辞典/カテゴリ/検索/ブックマーク/レベル） | #305 |
-| **B2** | ダークモード（クラス式トグル） | #307 |
-| **B3** | ダッシュボード（分野別正答率/苦手抽出/おすすめ/ストリーク） | #309 |
-| **B4** | 面接コンテンツ（想定質問集/頻出タグ/回答テンプレ/NG例） | #311 |
-| **B5** | 自己PR（自己紹介作成/志望動機整理） | #313 |
-| **B6** | 学ぶ（学習ロードマップ/業界職種解説/図解） | #315 |
-| **B7** | トップページ（ホーム・各モード入口） | #317 |
+| `term-board:progress:v1` | 用語ごと正誤 | useQuiz.answer |
+| `term-board:userContent:v1` | ユーザー作問 | useUserContent |
+| `term-board:bookmarks:v1` | ★用語ID配列 | useBookmarks |
+| `term-board:studyDays:v1` | 学習日（YYYY-MM-DD） | useQuiz.answer |
+| `term-board:profile:v1` | 自己PR下書き | useProfileDraft |
+| `term-board:theme:v1` | "light"/"dark" | useTheme |
 
-> 全画面で Lighthouse（モバイル）**Accessibility=100 / Best Practices=100 / SEO=100**、Performance良好（LCP≈92ms）、`npm audit` High/Critical **0件**、ライト/ダーク両対応を維持。
+### 3-5. ナビゲーション（App.tsx）
+- `type View = "home"|"quiz"|"dictionary"|"interview"|"author"|"dashboard"|"prep"|"learn"`
+- `useState<View>("home")` が初期表示。ヘッダーの `<NavTab>` で切替。
+- 共有state：`useUserContent()`（作問）/`useBookmarks()`/`useTheme()` を App で持ち、必要なビューへ props で渡す。
+- `useQuiz(user.content.quizTerms.length)` … 作問4択を即出題に反映するため reloadKey に件数を渡している。
 
----
-
-## 5. 未実装＝次にやること（優先度つき）
-
-### ★ 最優先候補
-
-1. **面接ログの補完（当初リストの取りこぼし）**
-   - 現状：`studyDays` は**クイズ解答時のみ**記録。面接練習（InterviewView）は履歴を残さない。
-   - やること：面接練習で「言えた/言えなかった」自己評価（F-INTV-02）＋練習履歴を記録し、ダッシュボードに反映。
-   - 関連：`api/` に面接ログ用ストア追加 or LearningLog（要件定義書 §8-3 の `LearningSession`）を実装。
-
-2. **#289 F-INTV-03 深掘り「なぜ?」チェーン**（Issue起票済み）
-   - `Term.followUps?: {q;a}[]` は型に未追加。terms.json に追い質問を足し、QuizView/InterviewViewで段階開示。
-
-3. **#290 F-QUIZ-05 間隔反復（SRS）**（Issue起票済み）
-   - `useQuiz` の出題選択を Progress 入力の優先度方式に（Leitner等）。苦手・未出題を優先。
-
-4. **#291 F-INTV-04 模擬面接モード**（Issue起票済み）
-   - 質問→（入力/口頭）→模範と差分→自己評価。タイマー任意。
-
-### その他の予定（要件定義書・機能一覧.md の 📋予定）
-- F-CARD-01 暗記カード、F-PROG-04 進捗リセット/エクスポート
-- F-LOG-03 学習メモ / F-LOG-04 振り返り一覧 / F-LOG-05 ログのエクスポート/インポート
-- F-INTV-05 構造採点ルーブリック / F-INTV-06 説明相手レベル切替 / F-INTV-07 逆質問ストック
-- F-QUIZ-06 混同ペア分析 / F-PROG-06 知識マップ / F-BHV-01 行動面接STAR
-- （Phase4・将来）F-AUTH 認証 / F-PROG-05 サーバー保存 / F-TERM-03 用語サーバー管理
-
-> 各機能の詳細仕様は `docs/要件定義書.md`（§13 含む）と `docs/機能一覧.md`（ステータス列）を参照。
-
-### 内容面のTODO
-- **用語データの拡充**（現状12件のみ）。出典確定と内容正確性レビュー（受入 A-7・R-01）。
-- 用語に `followUps`/`reverseQuestions`/`related`/`confusedWith` を段階的に付与（差別化機能の前提データ）。
-
----
-
-## 6. 開発ルール（CLAUDE.md 準拠・厳守）
-
-1. **main直push禁止**。必ず Issue → ブランチ → PR → Squash merge。
-2. ブランチ名：`feature/#番号-説明` / `fix/#番号-説明` / `docs/#番号-説明` / `chore/#番号-説明`。
-3. コミット・PR は**日本語・Conventional Commits**（feat: / fix: / docs: / chore: …）。PR は `Closes #番号`。
-4. ラベル必須（enhancement/bug/documentation/chore）。
-5. PRマージ後は `git checkout main && git pull` で整合。
-6. **CI**：term-board の PR は `term-board-ci.yml`（型チェック＋ビルド＋`npm audit --audit-level=high`）と `claude-review` が走る。両方 pass を確認してマージ。
-7. **デプロイ**：main の `term-board/**` 変更で `term-board-pages.yml` が自動デプロイ（公開中なのでマージ＝本番反映）。
-8. **機能一覧.md は生きた文書**：機能を実装したら、その実装PRで該当行のステータスを ✅ に更新する。
-
-### 1機能の標準フロー（このセッションで確立した型）
+### 3-6. データJSONのスキーマ例
+`terms.json`（1件）:
+```json
+{ "id": "tcp-ip", "category": "ネットワーク", "level": "中級",
+  "term": "TCP/IP", "meaning": "…", "plainMeaning": "…", "scene": "…",
+  "distractors": ["…","…","…"], "interview": "…" }
 ```
-① gh issue create（enhancement）
-② git checkout -b feature/#番号-説明
-③ 実装（types→api→hooks→components→App配線）
-④ npm run build（型/ビルド）
-⑤ npm run preview → Chrome DevTools で実ブラウザ検証＋Lighthouse(モバイル)でA11y=100確認
-⑥ 機能一覧.md のステータス更新
-⑦ commit（日本語）→ push → gh pr create（Closes #番号）
-⑧ CI(build-and-audit/claude-review)pass を待つ → Squash merge --delete-branch
-⑨ git checkout main && git pull → 必要なら本番URLで反映確認
+`interviewQuestions.json`（1件）:
+```json
+{ "id": "iv-why-it", "category": "志望動機", "question": "なぜIT業界を志望？",
+  "answer": "…", "tags": ["頻出","未経験定番"], "template": "…", "ngExample": "NG：… → 改善：…" }
 ```
 
 ---
 
-## 7. 設計上の注意点（ハマりどころ）
+## 4. 実装済み機能（本番公開中・PR番号）
 
-- **ダークモードはクラス式**（`index.css` の `@custom-variant dark (&:where(.dark, .dark *))`）。`dark:` クラスは `.dark` 配下でのみ効く。**`prefers-color-scheme` 依存にしないこと**（テスト環境がダークだと背景と文字が食い違いコントラスト破綻 → A11y落ちる）。新規UIに `dark:` を足すときは light/dark 両方で Lighthouse 確認。
-- **コントラスト（WCAG AA）**：`text-slate-500` は slate-50 背景上で borderline。本文は `slate-600`（light）/`slate-300`（dark）を基本に。白文字ボタンは `bg-sky-700` 以上（`sky-600` は白文字4.0で**不足**）。
-- **作問4択をクイズに即反映**：`useQuiz(reloadKey)` に `user.content.quizTerms.length` を渡している（App.tsx）。出題データを変える機能は reloadKey を更新する。
-- **graceful degradation**：localStorage 読込は全て try/catch で空フォールバック。出題は止めない（受入 A-4）。新ストア追加時も踏襲。
-- **`api/` 隔離を崩さない**：コンポーネントから直接 localStorage を触らない。必ず `repository`（`api/index.ts`）経由。
-- **perl で className 一括置換は危険**：`\S+` が閉じ引用符を巻き込みJSXを壊した事故あり。負の先読みを使うか、対象を限定するか、Edit を使う。
+| 区分 | 機能ID | 内容 | PR |
+|---|---|---|---|
+| Phase1 | F-TERM-01/02, F-QUIZ-01〜04, F-PROG-01 | 4択・即採点・ランダム化・分野・記録 | #282 |
+| 未経験者土台 | F-TERM-05 | 平易説明「かんたんに言うと」 | #287 |
+| コア差別化 | F-TERM-04 | 実務シーン「現場では」 | #288 |
+| 作問・共有 | F-USER-01/02, F-INTV-01 | マイ問題・共有コード・面接練習 | #302 |
+| 公開/品質 | — | Pages自動デプロイ・OGP・CI・A11y=100 | #286/#292/#294 |
+| B1 | F-DICT-01〜05 | 用語辞典・カテゴリ・検索・★・レベル | #305 |
+| B2 | F-UI-01 | ダークモード | #307 |
+| B3 | F-PROG-02/03, F-LOG-01/02, F-RECO-01 | ダッシュボード・苦手・おすすめ・ストリーク | #309 |
+| B4 | F-INTV-08〜11 | 想定質問集・頻出タグ・回答テンプレ・NG例 | #311 |
+| B5 | F-PREP-01/02 | 自己紹介作成・志望動機整理 | #313 |
+| B6 | F-LEARN-01〜03 | 学習ロードマップ・業界職種・図解 | #315 |
+| B7 | F-UI-02 | トップページ（ホーム） | #317 |
 
----
-
-## 8. ドキュメント一覧（docs/）
-
-- `要件定義書.md`（v0.4・§13 面接対策機能の詳細・§14 ユーザー作問）— 仕様の正本
-- `機能一覧.md` — 機能ID×実装ステータス（**生きた一覧**）
-- `データモデル.md` — Term/Progress/InterviewQuestion/UserContent/ProfileDraft（ER図の代替）
-- `技術スタック.md` — 採用技術と不採用理由
-- `画面設計書.md` — 画面一覧・状態遷移（※B1〜B7のモード追加分は未追記。要更新）
-- `テスト計画書.md` — 方針（ピラミッド）。**自動テスト未導入**（現状は実ブラウザ検証＋CIのbuild/audit）
-- `引き継ぎ書.md` — 本書
-
-### ドキュメントの未更新点（次セッションで直すと良い）
-- **画面設計書.md** が S-01/S-03/S-06 までしか反映されておらず、B1〜B7 で増えた画面（用語辞典/学ぶ/ダッシュボード/自己PR/ホーム）が未記載。
-- **テスト計画書**：Vitest（ユニット）/Playwright（E2E）が未導入のまま。shuffle・useQuiz・repository破損ガードのユニットテストが価値高。
+> 全画面で Lighthouse（モバイル）**Accessibility=100 / Best Practices=100 / SEO=100**、Performance良好（LCP≈92ms / CLS 0）、`npm audit` 0件、ライト/ダーク両対応。
 
 ---
 
-## 9. 現在の状態（クリーン）
+## 5. 当初リクエスト機能の対応状況（取りこぼし確認）
 
-- オープンな term-board PR：**なし**
-- 宙ぶらりんの作業：**なし**
-- main：B7（#317）まで反映・本番公開済み
-- 手動タスク：なし（nvm/zshrc は設定済み）
+ユーザー要望リストはほぼ全て実装済み。例外：
+- **音読・録音** … ユーザー指示で**除外**。
+- **面接ログ** … **部分的**。`studyDays` はクイズ解答時のみ記録。面接練習の履歴・自己評価は未記録 → §6-1 で補完。
 
 ---
 
-## 10. 次セッションの推奨スタート
+## 6. 未実装＝次にやること（実装プラン込み）
 
-1. `cd /Users/macmini/dev/Cursor/term-board && git checkout main && git pull`（最新確認）
-2. やる機能を1つ選ぶ（§5 の最優先候補から）→ Issue 作成 → §6 の標準フローで実装
-3. 迷ったら `docs/機能一覧.md` の 📋予定 を上から、または要件定義書 §13 を参照
+### 6-1.【最優先】面接ログ補完 ＋ 自己採点（F-INTV-02）
+- **狙い**：面接練習の「言えた/言えなかった」を自己申告し、履歴をダッシュボードに反映（当初リスト「面接ログ」の本来分）。
+- **実装案**：
+  1. `types.ts` に `LearningSession`（要件定義書 §8-3：`{id, startedAt, mode:"quiz"|"card"|"interview", asked, correct}`）を追加。
+  2. `api/` に `getLearningLog()/saveLearningLog()`（localStorage `term-board:learningLog:v1`）。
+  3. `InterviewView` の回答開示後に「言えた/言えなかった」ボタン → セッション記録＋ `recordStudyDay`。
+  4. `DashboardView` に面接練習回数・言えた率を追加。
+- **受入**：面接練習が studyDays/ストリークにも効く・ダッシュボードに面接実績が出る。
 
-> 推奨順：**面接ログ補完（自己評価F-INTV-02含む）→ #289 深掘り → #290 SRS → #291 模擬面接**。
-> いずれも `Term`/`InterviewQuestion` への任意フィールド追加＋表示で段階導入でき、`api/` 隔離のまま育つ。
+### 6-2. #289 F-INTV-03 深掘り「なぜ?」チェーン（Issue起票済）
+- `Term` に `followUps?: { q: string; a: string }[]` を追加 → `terms.json` に追い質問 → QuizView 正解後に段階開示（「UDPとの違いは?」等）。
+
+### 6-3. #290 F-QUIZ-05 間隔反復（SRS）（Issue起票済）
+- `useQuiz` の出題選択を Progress 入力の優先度方式へ（誤答・未出題を優先、正答連続で間隔を伸ばす＝Leitner簡易）。現状の `pickRandom(pool)` を重み付き選択に。
+
+### 6-4. #291 F-INTV-04 模擬面接モード（Issue起票済）
+- 質問→（任意入力/口頭）→模範と差分→自己評価。任意でタイマー。InterviewView の発展 or 新ビュー。
+
+### 6-5. その他（要件定義書・機能一覧.md の 📋予定）
+- F-CARD-01 暗記カード／F-PROG-04 進捗リセット・エクスポート／F-LOG-03 学習メモ・F-LOG-04 振り返り一覧・F-LOG-05 ログ入出力
+- F-INTV-05 構造採点ルーブリック／F-INTV-06 説明相手レベル切替／F-INTV-07 逆質問ストック
+- F-QUIZ-06 混同ペア分析／F-PROG-06 知識マップ／F-BHV-01 行動面接STAR
+- （Phase4・将来）F-AUTH 認証／F-PROG-05 サーバー保存／F-TERM-03 用語サーバー管理
+
+### 6-6. 内容・ドキュメントのTODO
+- **用語データ拡充**（現状12件のみ）：出典確定＋内容正確性レビュー（受入 A-7・R-01）。`followUps`/`related`/`confusedWith` の付与は差別化機能の前提。
+- **画面設計書.md** が B1〜B7 のモード追加を未反映 → 更新推奨。
+- **テスト計画書**：Vitest（shuffle/useQuiz/repository破損ガード）＋Playwright（主要導線）が未導入。
+
+---
+
+## 7. 開発フロー（CLAUDE.md 厳守）
+
+### ルール
+1. **main直push禁止**。Issue → ブランチ → PR → **Squash merge**。
+2. ブランチ：`feature/#番号-説明`（fix/docs/chore も同様）。
+3. コミット・PR は**日本語・Conventional Commits**。PR本文に `Closes #番号`。ラベル必須。
+4. PRマージ後は `git checkout main && git pull`。
+5. **CI**：`term-board-ci.yml`（型/ビルド＋npm audit）と `claude-review` の両方 pass を確認してマージ。
+6. **マージ＝本番反映**（`term-board/**` 変更で Pages 自動デプロイ）。
+7. **機能一覧.md は生きた文書**：実装PRで該当行を ✅ に更新。
+
+### 1機能の標準フロー（このセッションで確立）
+```
+① gh issue create --repo 80-cloud/hideharu-AI --label enhancement --title "feat: …" --body "…"
+② git checkout main && git pull && git checkout -b feature/#NNN-説明
+③ 実装：types.ts → api/ → hooks/ → components/ → App.tsx 配線
+④ npm run build               # 型/ビルド（CIと同じ）
+⑤ npm run preview → Chrome DevTools navigate → 操作確認 → lighthouse_audit(mobile) で A11y=100
+   ※ ダーク追加時は light/dark 両方で確認
+⑥ docs/機能一覧.md のステータスを ✅ に更新
+⑦ git add → commit（日本語・Co-Authored-By: Claude）→ push → gh pr create（Closes #NNN・label）
+⑧ CI pass を待つ → gh pr merge --squash --delete-branch
+⑨ git checkout main && git pull →（必要なら）本番URLで反映確認
+```
+
+### よく使うコマンド
+```bash
+# Issue/PR/マージ
+gh issue create --repo 80-cloud/hideharu-AI --label enhancement --title "…" --body "…"
+gh pr create   --repo 80-cloud/hideharu-AI --base main --head <branch> --label enhancement --title "…" --body "…"
+gh pr checks <PR> --repo 80-cloud/hideharu-AI
+gh pr merge  <PR> --repo 80-cloud/hideharu-AI --squash --delete-branch
+# Pages デプロイ状況
+gh run list --repo 80-cloud/hideharu-AI --workflow "term-board-pages.yml" --branch main --limit 1
+```
+
+---
+
+## 8. 設計上の注意点（ハマりどころ・実体験ベース）
+
+1. **ダークはクラス式**：`index.css` に `@custom-variant dark (&:where(.dark, .dark *))`。`dark:` は `<html class="dark">` 配下でのみ効く。
+   - ⚠️ **`prefers-color-scheme` 依存にしないこと**。テスト環境がOSダークだと「背景は明るいまま文字だけ暗色」になりコントラスト破綻 → Lighthouse A11y が落ちる（実際に起きた）。新規UIに `dark:` を付けたら必ず light/dark 両方で audit。
+2. **コントラスト（WCAG AA）**：
+   - `text-slate-500` は slate-50 背景上で borderline。本文は **`slate-600`(light)/`slate-300`(dark)** を基本に。
+   - 白文字ボタンは **`bg-sky-700` 以上**（`bg-sky-600` は白文字 4.0 で**不足**＝過去に2回失敗）。
+   - 小さい色付きラベルは `sky-700`/`sky-800`。
+3. **作問のクイズ即反映**：`useQuiz(reloadKey)` の reloadKey を更新する（App は `user.content.quizTerms.length`）。出題データを変える機能は reloadKey を意識。
+4. **api/ 隔離を崩さない**：localStorage 直アクセス禁止。`repository` 経由。新データは termRepository.ts に get/save を足し、localStorage実装に try/catch つきで実装。
+5. **graceful degradation**：全 get は失敗時 空/null フォールバック。出題は止めない。
+6. **className 一括置換の事故**：`perl -pe 's/ dark:\S+//g'` が**閉じ引用符まで巻き込みJSXを破壊**した。負の先読み（`(?! dark)`）や対象限定、または Edit ツールを使う。一括置換後は必ず `npm run build` で確認。
+7. **見出し階層**：ページに h1（アプリ名）しかない所へ h3 を置くと Lighthouse `heading-order` で減点。セクション見出しは **h2** を使う（過去に発生）。
+8. **noUnusedLocals 有効**：未使用の定数・変数はビルドエラー。消すこと。
+
+---
+
+## 9. ドキュメント（docs/）
+
+| ファイル | 役割 | 状態 |
+|---|---|---|
+| `要件定義書.md`（v0.4） | 仕様の正本（§13 面接対策詳細・§14 ユーザー作問） | 最新 |
+| `機能一覧.md` | 機能ID×実装ステータス（生きた一覧） | 最新 |
+| `データモデル.md` | 型/構造（ER図の代替） | 最新 |
+| `技術スタック.md` | 採用技術・不採用理由 | 最新 |
+| `画面設計書.md` | 画面・遷移 | **要更新**（B1〜B7未反映） |
+| `テスト計画書.md` | 方針（自動テスト未導入） | 要拡充 |
+| `引き継ぎ書.md` | 本書 | 本書 |
+
+---
+
+## 10. 現在の状態（クリーン）
+
+- オープンな term-board PR：本書PR（#319）以外なし。
+- 宙ぶらりんの作業・手動タスク：なし（nvm/zshrc 設定済み）。
+- main：B7（#317）まで反映・本番公開済み。
+
+---
+
+## 11. 次セッションの開始手順
+
+```bash
+export NVM_DIR="$HOME/.nvm"; \. "/opt/homebrew/opt/nvm/nvm.sh"; nvm use 24
+cd /Users/macmini/dev/Cursor/term-board && git checkout main && git pull
+npm install   # 念のため
+```
+1. §6 から実装する機能を1つ選ぶ（推奨：**6-1 面接ログ補完 → #289 → #290 → #291**）。
+2. §7 の標準フローで Issue→ブランチ→実装→検証→PR→マージ。
+3. 仕様は `docs/要件定義書.md`（§13）と `docs/機能一覧.md`（📋予定）を参照。
+
+> 設計の一貫性：新機能は「型に任意フィールド追加 → data/hook → component → App配線」で段階導入し、`api/` 隔離・WCAG AA・ライト/ダーク両対応・Lighthouse A11y=100 を維持する。


### PR DESCRIPTION
## 関連 Issue

Closes #318

## 変更の概要
次セッションで実装を続けるための詳細な引き継ぎ書 `docs/引き継ぎ書.md` を作成。

- アプリ概要・対象（IT未経験者）・設計思想（静的SPA）
- 技術スタック・ローカル起動・ディレクトリ構成・localStorageキー
- 実装済み機能（B1〜B7・PR番号つき）
- **未実装＝次にやること**（優先度：面接ログ補完→#289深掘り→#290 SRS→#291模擬面接）
- 開発ルール（CLAUDE.md準拠）＋1機能の標準フロー
- ハマりどころ（クラス式ダーク・コントラスト・reloadKey・api隔離・perl事故）
- ドキュメント未更新点（画面設計書・テスト計画書）

## 変更の種別
- [x] docs（ドキュメントのみ）

## 動作確認チェックリスト
- [x] 現状（本番公開・全7バッチ・オープンPRなし）を正確に反映
- [x] コード変更なし