### PR TITLE
feat: ヘッダーのアプリ名クリックでホームへ戻れるようにする

### DIFF
--- a/term-board/src/App.tsx
+++ b/term-board/src/App.tsx
@@ -37,7 +37,17 @@ export default function App() {
           <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-start justify-between gap-2">
               <div>
-                <h1 className="text-xl font-bold">IT用語ボード</h1>
+                <h1 className="text-xl font-bold">
+                  <button
+                    type="button"
+                    onClick={() => setView("home")}
+                    aria-label="IT用語ボード（ホームへ戻る）"
+                    title="ホームへ戻る"
+                    className="rounded transition hover:text-sky-700 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:hover:text-sky-400"
+                  >
+                    IT用語ボード
+                  </button>
+                </h1>
                 <p className="text-xs text-slate-500 dark:text-slate-400">面接で言えるまで、4択で定着させる</p>
               </div>
               <button


### PR DESCRIPTION
## 概要
ヘッダーの「IT用語ボード」をクリックするとホーム画面に戻れるようにしました（Webの一般的な慣習）。

## 変更内容
- App.tsx：h1 内のアプリ名をボタン化し、`onClick` で `view` を `home` に切り替え。
- アクセシビリティ：`aria-label="IT用語ボード（ホームへ戻る）"` と `title="ホームへ戻る"`。表示文字を含めることで WCAG 2.5.3（Label in Name）を満たす。h1 は維持。

## 検証
- `npm run build` pass
- Chrome DevTools（preview/mobile）：用語辞典・4択など別画面からタイトルクリックでホーム復帰を確認
- Lighthouse（mobile）：Accessibility=100 / Best Practices=100 / SEO=100（監査 Failed 0・label-content-name-mismatch 解消）

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)