### PR TITLE
feat: 用語辞典に並び替え（あいうえお順）を追加

### DIFF
--- a/term-board/src/components/DictionaryView.tsx
+++ b/term-board/src/components/DictionaryView.tsx
@@ -17,6 +17,7 @@ export function DictionaryView({ bookmarks }: Props) {
   const [query, setQuery] = useState("");
   const [category, setCategory] = useState("");
   const [onlyBookmarked, setOnlyBookmarked] = useState(false);
+  const [sort, setSort] = useState<"default" | "asc" | "desc">("default");
   const [openId, setOpenId] = useState<string | null>(null);
 
   useEffect(() => {
@@ -36,7 +37,7 @@ export function DictionaryView({ bookmarks }: Props) {
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
-    return terms.filter((t) => {
+    const list = terms.filter((t) => {
       if (category && t.category !== category) return false;
       if (onlyBookmarked && !bookmarks.isBookmarked(t.id)) return false;
       if (q && !`${t.term} ${t.meaning} ${t.plainMeaning ?? ""}`.toLowerCase().includes(q)) {
@@ -44,7 +45,13 @@ export function DictionaryView({ bookmarks }: Props) {
       }
       return true;
     });
-  }, [terms, query, category, onlyBookmarked, bookmarks]);
+    if (sort !== "default") {
+      // あいうえお順（日本語照合）。英字・カタカナ・漢字も自然な順に並ぶ。
+      const sorted = [...list].sort((a, b) => a.term.localeCompare(b.term, "ja"));
+      return sort === "desc" ? sorted.reverse() : sorted;
+    }
+    return list;
+  }, [terms, query, category, onlyBookmarked, bookmarks, sort]);
 
   return (
     <section className="flex flex-col gap-4">
@@ -73,6 +80,19 @@ export function DictionaryView({ bookmarks }: Props) {
               {categories.map((c) => (
                 <option key={c} value={c}>{c}</option>
               ))}
+            </select>
+          </div>
+          <div className="flex items-center gap-2">
+            <label htmlFor="dict-sort" className="text-sm font-medium text-slate-600 dark:text-slate-300">並び替え</label>
+            <select
+              id="dict-sort"
+              value={sort}
+              onChange={(e) => setSort(e.target.value as "default" | "asc" | "desc")}
+              className="rounded-lg border border-slate-300 bg-white px-2 py-1.5 text-sm text-slate-800 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+            >
+              <option value="default">標準（分野順）</option>
+              <option value="asc">あいうえお順</option>
+              <option value="desc">あいうえお順（逆）</option>
             </select>
           </div>
           <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">


### PR DESCRIPTION
## 概要
用語辞典に並び替え機能を追加しました。標準（分野順）に加え、あいうえお順の昇順・降順で並べ替えられます。

## 変更内容
- **DictionaryView**：並び替えセレクト（標準（分野順）/ あいうえお順 / あいうえお順（逆））を追加。
- 日本語照合 `localeCompare(b.term, "ja")` で用語名を整列。英字・カタカナ・漢字も自然な順に並ぶ。検索・分野・★フィルタと併用可。

## 検証
- `npm run build` pass
- Chrome DevTools（preview/mobile）：あいうえお順で並び順が変化することを確認（3層構造→ALB→API…）
- Lighthouse（mobile）：Accessibility=100 / Best Practices=100 / SEO=100

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)