### PR TITLE
feat: 解説集ビュー（論点×分類×解説の一覧）を追加

### DIFF
--- a/term-board/src/App.tsx
+++ b/term-board/src/App.tsx
@@ -9,6 +9,7 @@ import { InterviewView } from "./components/InterviewView";
 import { MockInterviewView } from "./components/MockInterviewView";
 import { CardView } from "./components/CardView";
 import { ReviewView } from "./components/ReviewView";
+import { GuideView } from "./components/GuideView";
 import { AuthorView } from "./components/AuthorView";
 import { DictionaryView } from "./components/DictionaryView";
 import { DashboardView } from "./components/DashboardView";
@@ -16,7 +17,7 @@ import { PrepView } from "./components/PrepView";
 import { LearnView } from "./components/LearnView";
 import { HomeView } from "./components/HomeView";
 
-type View = "home" | "quiz" | "card" | "dictionary" | "interview" | "mock" | "author" | "dashboard" | "review" | "prep" | "learn";
+type View = "home" | "quiz" | "card" | "dictionary" | "interview" | "mock" | "guide" | "author" | "dashboard" | "review" | "prep" | "learn";
 
 export default function App() {
   const [view, setView] = useState<View>("home");
@@ -86,6 +87,7 @@ export default function App() {
             <NavTab active={view === "learn"} onClick={() => setView("learn")}>学ぶ</NavTab>
             <NavTab active={view === "interview"} onClick={() => setView("interview")}>面接練習</NavTab>
             <NavTab active={view === "mock"} onClick={() => setView("mock")}>模擬面接</NavTab>
+            <NavTab active={view === "guide"} onClick={() => setView("guide")}>解説集</NavTab>
             <NavTab active={view === "dashboard"} onClick={() => setView("dashboard")}>ダッシュボード</NavTab>
             <NavTab active={view === "review"} onClick={() => setView("review")}>振り返り</NavTab>
             <NavTab active={view === "prep"} onClick={() => setView("prep")}>自己PR</NavTab>
@@ -145,6 +147,8 @@ export default function App() {
         )}
 
         {view === "mock" && <MockInterviewView />}
+
+        {view === "guide" && <GuideView userQuestions={user.content.interviewQuestions} />}
 
         {view === "author" && <AuthorView user={user} />}
       </main>

--- a/term-board/src/components/GuideView.tsx
+++ b/term-board/src/components/GuideView.tsx
@@ -1,0 +1,199 @@
+import { useEffect, useMemo, useState } from "react";
+import type { InterviewQuestion, Term } from "../types";
+import { repository } from "../api";
+import bundledQuestions from "../data/interviewQuestions.json";
+
+type Props = {
+  // ユーザー作問の面接Q&A（F-USER）。
+  userQuestions: InterviewQuestion[];
+};
+
+const bundled = bundledQuestions as InterviewQuestion[];
+
+// 解説集の1行（論点＋分類＋解説）。質問(面接Q&A)・用語(模擬面接)を統一して扱う。
+type Entry = {
+  id: string;
+  ronten: string; // 論点（クリック前に見える見出し）
+  category: string; // 分類
+  answer?: string; // 模範回答／面接での言い方
+  meaning?: string; // 用語の意味
+  template?: string; // 回答の型
+  ngExample?: string; // NG例と改善
+  scene?: string; // 現場では
+  followUps?: { q: string; a: string }[]; // 深掘り
+};
+
+// 分類の表示順（面接Q&A系を先、用語の分野を後に）。未定義は末尾。
+const CATEGORY_ORDER = [
+  "志望動機", "自己PR", "行動面接", "技術質問", "逆質問",
+  "Web基礎", "ネットワーク", "セキュリティ", "データベース",
+  "アーキテクチャ", "インフラ", "フロントエンド", "開発手法", "テスト",
+];
+
+// B6+: 解説集（論点×分類×解説の一覧）。過去問道場の論点一覧に着想。
+export function GuideView({ userQuestions }: Props) {
+  const [terms, setTerms] = useState<Term[]>([]);
+  const [query, setQuery] = useState("");
+  const [category, setCategory] = useState("");
+  const [openId, setOpenId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    repository.getTerms().then((t) => {
+      if (active) setTerms(t);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // 面接Q&A（同梱＋ユーザー作問）と用語を統一エントリ化する。
+  const entries = useMemo<Entry[]>(() => {
+    const qa: Entry[] = [...bundled, ...userQuestions].map((q) => ({
+      id: `qa-${q.id}`,
+      ronten: q.question,
+      category: q.category,
+      answer: q.answer,
+      template: q.template,
+      ngExample: q.ngExample,
+    }));
+    const termEntries: Entry[] = terms.map((t) => ({
+      id: `term-${t.id}`,
+      ronten: `「${t.term}」とは？`,
+      category: t.category,
+      answer: t.interview,
+      meaning: t.meaning,
+      scene: t.scene,
+      followUps: t.followUps,
+    }));
+    return [...qa, ...termEntries];
+  }, [terms, userQuestions]);
+
+  const categories = useMemo(() => {
+    const set = [...new Set(entries.map((e) => e.category))];
+    return set.sort((a, b) => {
+      const ia = CATEGORY_ORDER.indexOf(a);
+      const ib = CATEGORY_ORDER.indexOf(b);
+      return (ia === -1 ? 999 : ia) - (ib === -1 ? 999 : ib);
+    });
+  }, [entries]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return entries.filter((e) => {
+      if (category && e.category !== category) return false;
+      if (q && !`${e.ronten} ${e.answer ?? ""} ${e.meaning ?? ""}`.toLowerCase().includes(q)) return false;
+      return true;
+    });
+  }, [entries, query, category]);
+
+  // 分類ごとにグルーピング（表示順に沿って）。
+  const groups = useMemo(() => {
+    return categories
+      .map((cat) => ({ category: cat, rows: filtered.filter((e) => e.category === cat) }))
+      .filter((g) => g.rows.length > 0);
+  }, [categories, filtered]);
+
+  return (
+    <section className="flex flex-col gap-4">
+      {/* 検索・分類フィルタ */}
+      <div className="flex flex-col gap-3 rounded-2xl bg-white p-4 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
+        <div>
+          <label htmlFor="guide-search" className="sr-only">論点を検索</label>
+          <input
+            id="guide-search"
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="論点・解説で検索"
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-800 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <label htmlFor="guide-cat" className="text-sm font-medium text-slate-600 dark:text-slate-300">分類</label>
+          <select
+            id="guide-cat"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+            className="rounded-lg border border-slate-300 bg-white px-2 py-1.5 text-sm text-slate-800 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+          >
+            <option value="">すべて</option>
+            {categories.map((c) => (
+              <option key={c} value={c}>{c}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <p className="text-sm text-slate-600 dark:text-slate-300">{filtered.length} 件の論点</p>
+
+      {groups.map((g) => (
+        <div key={g.category}>
+          {/* 分類セクション見出し */}
+          <h2 className="mb-2 border-b-2 border-sky-200 pb-1 text-center text-sm font-bold text-sky-700 dark:border-sky-800 dark:text-sky-400">
+            — {g.category} —
+          </h2>
+          <ul className="flex flex-col gap-2">
+            {g.rows.map((e) => {
+              const open = openId === e.id;
+              return (
+                <li key={e.id} className="rounded-xl bg-white shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
+                  <button
+                    type="button"
+                    onClick={() => setOpenId(open ? null : e.id)}
+                    aria-expanded={open}
+                    className="flex w-full items-center gap-3 p-3 text-left focus:outline-none focus:ring-2 focus:ring-sky-400"
+                  >
+                    <span className="min-w-0 flex-1 truncate text-sm font-medium text-slate-900 dark:text-slate-100">{e.ronten}</span>
+                    <span className="shrink-0 rounded-full bg-sky-100 px-2 py-0.5 text-xs font-medium text-sky-800 dark:bg-sky-900 dark:text-sky-200">{e.category}</span>
+                    <span aria-hidden="true" className="shrink-0 text-sm text-slate-400">{open ? "−" : "＋"}</span>
+                  </button>
+                  {open && (
+                    <div className="border-t border-slate-100 px-3 py-3 text-sm leading-relaxed dark:border-slate-700">
+                      {e.meaning && (
+                        <p className="text-slate-700 dark:text-slate-300"><span className="font-semibold text-slate-900 dark:text-slate-100">意味：</span>{e.meaning}</p>
+                      )}
+                      {e.answer && (
+                        <p className="mt-1 text-slate-700 dark:text-slate-300">
+                          <span className="font-semibold text-slate-900 dark:text-slate-100">{e.meaning ? "面接での言い方：" : "模範回答："}</span>{e.answer}
+                        </p>
+                      )}
+                      {e.template && (
+                        <div className="mt-2 rounded-lg bg-sky-50 p-2 ring-1 ring-sky-100 dark:bg-sky-950 dark:ring-sky-900">
+                          <p className="text-slate-700 dark:text-slate-200"><span className="font-semibold text-sky-800 dark:text-sky-300">回答の型：</span>{e.template}</p>
+                        </div>
+                      )}
+                      {e.ngExample && (
+                        <div className="mt-2 rounded-lg bg-rose-50 p-2 ring-1 ring-rose-100 dark:bg-rose-950 dark:ring-rose-900">
+                          <p className="text-slate-700 dark:text-slate-200"><span className="font-semibold text-rose-800 dark:text-rose-300">NG例と改善：</span>{e.ngExample}</p>
+                        </div>
+                      )}
+                      {e.scene && (
+                        <p className="mt-2 text-slate-600 dark:text-slate-400"><span className="font-semibold text-slate-800 dark:text-slate-200">現場では：</span>{e.scene}</p>
+                      )}
+                      {e.followUps && e.followUps.length > 0 && (
+                        <div className="mt-2 rounded-lg bg-amber-50 p-2 ring-1 ring-amber-100 dark:bg-amber-950 dark:ring-amber-900">
+                          <p className="text-xs font-semibold text-amber-800 dark:text-amber-300">深掘り：</p>
+                          <ul className="mt-1 flex flex-col gap-1">
+                            {e.followUps.map((f, i) => (
+                              <li key={i} className="text-slate-700 dark:text-slate-300">
+                                <span className="font-semibold text-slate-800 dark:text-slate-100">Q. {f.q}</span> A. {f.a}
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ))}
+      {filtered.length === 0 && (
+        <p className="text-center text-sm text-slate-600 dark:text-slate-400">該当する論点がありません。</p>
+      )}
+    </section>
+  );
+}

--- a/term-board/src/components/HomeView.tsx
+++ b/term-board/src/components/HomeView.tsx
@@ -1,4 +1,4 @@
-type Target = "quiz" | "card" | "dictionary" | "learn" | "interview" | "mock" | "dashboard" | "review" | "prep" | "author";
+type Target = "quiz" | "card" | "dictionary" | "learn" | "interview" | "mock" | "guide" | "dashboard" | "review" | "prep" | "author";
 
 type Props = { onNavigate: (view: Target) => void };
 
@@ -9,6 +9,7 @@ const MODES: { key: Target; title: string; desc: string }[] = [
   { key: "learn", title: "学ぶ", desc: "学習ロードマップ・職種解説・図解で全体像をつかむ。" },
   { key: "interview", title: "面接練習", desc: "想定質問に声で答え、模範回答・型・NG例で確認。" },
   { key: "mock", title: "模擬面接", desc: "用語の説明を30秒で。模範解答と並べて自己評価する。" },
+  { key: "guide", title: "解説集", desc: "面接の論点を分類別に一覧。解説を開いてまとめて復習。" },
   { key: "dashboard", title: "ダッシュボード", desc: "正答率・苦手・連続学習を可視化。次の一手が分かる。" },
   { key: "review", title: "振り返り", desc: "今日のメモと、日々の学習を時系列で振り返る。" },
   { key: "prep", title: "自己PR", desc: "自己紹介・志望動機を穴埋めで下書き作成。" },


### PR DESCRIPTION
## 概要
ITパスポート過去問道場の『論点一覧』に着想し、面接練習・模擬面接の内容を分類別に一覧表示して解説をまとめて読める『解説集』を新設しました。

## 変更内容
- **GuideView（新規）**：面接Q&A（同梱＋ユーザー作問）と用語（「◯◯とは？」）を統一エントリ化。**分類セクション見出し**（— 志望動機 —, — ネットワーク — …）付きで論点を一覧。各行を開くと 意味／模範回答（面接での言い方）／回答の型／NG例／現場では／深掘り を表示。検索・分類フィルタ付き（180論点）。
- **App.tsx**：`View` に `"guide"` 追加・ナビタブ「解説集」・配線。**HomeView** に入口追加。

> 面接練習（ランダム出題）・模擬面接（用語ベース）で扱う内容を、体系的に見渡して復習できる一覧です。

## 検証
- `npm run build` pass
- Chrome DevTools（preview/mobile）：180論点・14分類セクション・行展開で解説表示・検索/分類フィルタを確認
- Lighthouse（mobile）：Accessibility=100 / Best Practices=100 / SEO=100・ライト/ダーク両対応

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)