### PR TITLE
fix: 解説集と用語辞典の内容重複を解消（解説集は面接論点に限定）

### DIFF
--- a/term-board/src/components/GuideView.tsx
+++ b/term-board/src/components/GuideView.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
-import type { InterviewQuestion, Term } from "../types";
-import { repository } from "../api";
+import { useMemo, useState } from "react";
+import type { InterviewQuestion } from "../types";
 import bundledQuestions from "../data/interviewQuestions.json";
 
 type Props = {
@@ -10,92 +9,50 @@ type Props = {
 
 const bundled = bundledQuestions as InterviewQuestion[];
 
-// 解説集の1行（論点＋分類＋解説）。質問(面接Q&A)・用語(模擬面接)を統一して扱う。
-type Entry = {
-  id: string;
-  ronten: string; // 論点（クリック前に見える見出し）
-  category: string; // 分類
-  answer?: string; // 模範回答／面接での言い方
-  meaning?: string; // 用語の意味
-  template?: string; // 回答の型
-  ngExample?: string; // NG例と改善
-  scene?: string; // 現場では
-  followUps?: { q: string; a: string }[]; // 深掘り
-};
+// 分類（面接の論点カテゴリ）の表示順。未定義は末尾。
+const CATEGORY_ORDER = ["志望動機", "自己PR", "行動面接", "技術質問", "逆質問"];
 
-// 分類の表示順（面接Q&A系を先、用語の分野を後に）。未定義は末尾。
-const CATEGORY_ORDER = [
-  "志望動機", "自己PR", "行動面接", "技術質問", "逆質問",
-  "Web基礎", "ネットワーク", "セキュリティ", "データベース",
-  "アーキテクチャ", "インフラ", "フロントエンド", "開発手法", "テスト",
-];
-
-// B6+: 解説集（論点×分類×解説の一覧）。過去問道場の論点一覧に着想。
+// 解説集：面接で訊かれる「論点（質問）×分類×模範解答」の一覧。
+// 用語の語彙は「用語辞典」が担うため、ここでは扱わない（役割分離）。
 export function GuideView({ userQuestions }: Props) {
-  const [terms, setTerms] = useState<Term[]>([]);
   const [query, setQuery] = useState("");
   const [category, setCategory] = useState("");
   const [openId, setOpenId] = useState<string | null>(null);
 
-  useEffect(() => {
-    let active = true;
-    repository.getTerms().then((t) => {
-      if (active) setTerms(t);
-    });
-    return () => {
-      active = false;
-    };
-  }, []);
-
-  // 面接Q&A（同梱＋ユーザー作問）と用語を統一エントリ化する。
-  const entries = useMemo<Entry[]>(() => {
-    const qa: Entry[] = [...bundled, ...userQuestions].map((q) => ({
-      id: `qa-${q.id}`,
-      ronten: q.question,
-      category: q.category,
-      answer: q.answer,
-      template: q.template,
-      ngExample: q.ngExample,
-    }));
-    const termEntries: Entry[] = terms.map((t) => ({
-      id: `term-${t.id}`,
-      ronten: `「${t.term}」とは？`,
-      category: t.category,
-      answer: t.interview,
-      meaning: t.meaning,
-      scene: t.scene,
-      followUps: t.followUps,
-    }));
-    return [...qa, ...termEntries];
-  }, [terms, userQuestions]);
+  const all = useMemo<InterviewQuestion[]>(() => [...bundled, ...userQuestions], [userQuestions]);
 
   const categories = useMemo(() => {
-    const set = [...new Set(entries.map((e) => e.category))];
+    const set = [...new Set(all.map((q) => q.category))];
     return set.sort((a, b) => {
       const ia = CATEGORY_ORDER.indexOf(a);
       const ib = CATEGORY_ORDER.indexOf(b);
       return (ia === -1 ? 999 : ia) - (ib === -1 ? 999 : ib);
     });
-  }, [entries]);
+  }, [all]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
-    return entries.filter((e) => {
+    return all.filter((e) => {
       if (category && e.category !== category) return false;
-      if (q && !`${e.ronten} ${e.answer ?? ""} ${e.meaning ?? ""}`.toLowerCase().includes(q)) return false;
+      if (q && !`${e.question} ${e.answer} ${e.template ?? ""} ${e.ngExample ?? ""}`.toLowerCase().includes(q)) return false;
       return true;
     });
-  }, [entries, query, category]);
+  }, [all, query, category]);
 
-  // 分類ごとにグルーピング（表示順に沿って）。
-  const groups = useMemo(() => {
-    return categories
-      .map((cat) => ({ category: cat, rows: filtered.filter((e) => e.category === cat) }))
-      .filter((g) => g.rows.length > 0);
-  }, [categories, filtered]);
+  const groups = useMemo(
+    () =>
+      categories
+        .map((cat) => ({ category: cat, rows: filtered.filter((e) => e.category === cat) }))
+        .filter((g) => g.rows.length > 0),
+    [categories, filtered],
+  );
 
   return (
     <section className="flex flex-col gap-4">
+      <p className="rounded-xl bg-sky-50 p-3 text-sm text-slate-700 ring-1 ring-sky-100 dark:bg-sky-950 dark:text-slate-200 dark:ring-sky-900">
+        面接で訊かれる<strong className="font-semibold">論点（質問）</strong>の模範解答集です。用語の意味を引きたいときは「用語辞典」をご利用ください。
+      </p>
+
       {/* 検索・分類フィルタ */}
       <div className="flex flex-col gap-3 rounded-2xl bg-white p-4 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
         <div>
@@ -105,7 +62,7 @@ export function GuideView({ userQuestions }: Props) {
             type="search"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="論点・解説で検索"
+            placeholder="質問・模範解答で検索"
             className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-800 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
           />
         </div>
@@ -129,7 +86,6 @@ export function GuideView({ userQuestions }: Props) {
 
       {groups.map((g) => (
         <div key={g.category}>
-          {/* 分類セクション見出し */}
           <h2 className="mb-2 border-b-2 border-sky-200 pb-1 text-center text-sm font-bold text-sky-700 dark:border-sky-800 dark:text-sky-400">
             — {g.category} —
           </h2>
@@ -144,20 +100,13 @@ export function GuideView({ userQuestions }: Props) {
                     aria-expanded={open}
                     className="flex w-full items-center gap-3 p-3 text-left focus:outline-none focus:ring-2 focus:ring-sky-400"
                   >
-                    <span className="min-w-0 flex-1 truncate text-sm font-medium text-slate-900 dark:text-slate-100">{e.ronten}</span>
+                    <span className="min-w-0 flex-1 text-sm font-medium text-slate-900 dark:text-slate-100">{e.question}</span>
                     <span className="shrink-0 rounded-full bg-sky-100 px-2 py-0.5 text-xs font-medium text-sky-800 dark:bg-sky-900 dark:text-sky-200">{e.category}</span>
                     <span aria-hidden="true" className="shrink-0 text-sm text-slate-400">{open ? "−" : "＋"}</span>
                   </button>
                   {open && (
                     <div className="border-t border-slate-100 px-3 py-3 text-sm leading-relaxed dark:border-slate-700">
-                      {e.meaning && (
-                        <p className="text-slate-700 dark:text-slate-300"><span className="font-semibold text-slate-900 dark:text-slate-100">意味：</span>{e.meaning}</p>
-                      )}
-                      {e.answer && (
-                        <p className="mt-1 text-slate-700 dark:text-slate-300">
-                          <span className="font-semibold text-slate-900 dark:text-slate-100">{e.meaning ? "面接での言い方：" : "模範回答："}</span>{e.answer}
-                        </p>
-                      )}
+                      <p className="text-slate-700 dark:text-slate-300"><span className="font-semibold text-slate-900 dark:text-slate-100">模範回答：</span>{e.answer}</p>
                       {e.template && (
                         <div className="mt-2 rounded-lg bg-sky-50 p-2 ring-1 ring-sky-100 dark:bg-sky-950 dark:ring-sky-900">
                           <p className="text-slate-700 dark:text-slate-200"><span className="font-semibold text-sky-800 dark:text-sky-300">回答の型：</span>{e.template}</p>
@@ -168,19 +117,11 @@ export function GuideView({ userQuestions }: Props) {
                           <p className="text-slate-700 dark:text-slate-200"><span className="font-semibold text-rose-800 dark:text-rose-300">NG例と改善：</span>{e.ngExample}</p>
                         </div>
                       )}
-                      {e.scene && (
-                        <p className="mt-2 text-slate-600 dark:text-slate-400"><span className="font-semibold text-slate-800 dark:text-slate-200">現場では：</span>{e.scene}</p>
-                      )}
-                      {e.followUps && e.followUps.length > 0 && (
-                        <div className="mt-2 rounded-lg bg-amber-50 p-2 ring-1 ring-amber-100 dark:bg-amber-950 dark:ring-amber-900">
-                          <p className="text-xs font-semibold text-amber-800 dark:text-amber-300">深掘り：</p>
-                          <ul className="mt-1 flex flex-col gap-1">
-                            {e.followUps.map((f, i) => (
-                              <li key={i} className="text-slate-700 dark:text-slate-300">
-                                <span className="font-semibold text-slate-800 dark:text-slate-100">Q. {f.q}</span> A. {f.a}
-                              </li>
-                            ))}
-                          </ul>
+                      {e.tags && e.tags.length > 0 && (
+                        <div className="mt-2 flex flex-wrap gap-1.5">
+                          {e.tags.map((tg) => (
+                            <span key={tg} className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600 dark:bg-slate-700 dark:text-slate-300">{tg}</span>
+                          ))}
                         </div>
                       )}
                     </div>

--- a/term-board/src/components/HomeView.tsx
+++ b/term-board/src/components/HomeView.tsx
@@ -5,11 +5,11 @@ type Props = { onNavigate: (view: Target) => void };
 const MODES: { key: Target; title: string; desc: string }[] = [
   { key: "quiz", title: "4択クイズ", desc: "用語の意味を4択で。即採点＋解説で定着させる。" },
   { key: "card", title: "暗記カード", desc: "表に用語、裏に意味。タップで裏返してサクッと暗記。" },
-  { key: "dictionary", title: "用語辞典", desc: "用語を検索・分野・レベルで探し、ブックマーク。" },
+  { key: "dictionary", title: "用語辞典", desc: "IT用語の意味を引く・覚える。検索・分野・レベル・あいうえお順。" },
   { key: "learn", title: "学ぶ", desc: "学習ロードマップ・職種解説・図解で全体像をつかむ。" },
   { key: "interview", title: "面接練習", desc: "想定質問に声で答え、模範回答・型・NG例で確認。" },
   { key: "mock", title: "模擬面接", desc: "用語の説明を30秒で。模範解答と並べて自己評価する。" },
-  { key: "guide", title: "解説集", desc: "面接の論点を分類別に一覧。解説を開いてまとめて復習。" },
+  { key: "guide", title: "解説集", desc: "面接で訊かれる質問（論点）と模範解答を分類別に一覧。" },
   { key: "dashboard", title: "ダッシュボード", desc: "正答率・苦手・連続学習を可視化。次の一手が分かる。" },
   { key: "review", title: "振り返り", desc: "今日のメモと、日々の学習を時系列で振り返る。" },
   { key: "prep", title: "自己PR", desc: "自己紹介・志望動機を穴埋めで下書き作成。" },


### PR DESCRIPTION
## 概要
ご指摘の重複を解消します。解説集に用語160件を「◯◯とは？」として載せていたため、用語辞典（語彙）と内容が重複していました。役割を明確に分離します。

## 役割分担（修正後）
- **用語辞典**：IT用語の**意味を引く・覚える**（160用語・かんたん/意味/現場/面接での言い方・検索/分野/レベル/あいうえお順）
- **解説集**：面接で訊かれる**論点（質問）×分類×模範解答**（志望動機・自己PR・行動面接・技術質問・逆質問の18論点。模範回答・回答の型・NG例）

## 変更内容
- **GuideView**：用語エントリを除外し、面接Q&A（同梱＋ユーザー作問）のみに。冒頭に「語彙は用語辞典へ」の案内文を追加。
- **HomeView**：用語辞典・解説集の説明文を差別化。

## 検証
- `npm run build` pass
- Chrome DevTools（preview/mobile）：解説集=18論点・5分類（用語の意味列なし）、用語辞典=160用語のまま、と分離を確認
- Lighthouse（mobile）：Accessibility=100 / Best Practices=100 / SEO=100

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)