### PR TITLE
feat: 暗記カードを差別化（SRS間隔反復＋苦手/分野フィルタ）

### DIFF
--- a/term-board/src/api/localStorageTermRepository.ts
+++ b/term-board/src/api/localStorageTermRepository.ts
@@ -4,6 +4,7 @@ import termsData from "../data/terms.json";
 
 // MVP 実装: 用語は同梱 JSON、進捗・ユーザー作問は localStorage（要件定義書 §2 C-1/C-2・§8-4）。
 const PROGRESS_KEY = "term-board:progress:v1";
+const CARD_PROGRESS_KEY = "term-board:cardProgress:v1";
 const USER_CONTENT_KEY = "term-board:userContent:v1";
 const BOOKMARKS_KEY = "term-board:bookmarks:v1";
 const STUDY_DAYS_KEY = "term-board:studyDays:v1";
@@ -22,6 +23,7 @@ const LEARNING_LOG_MAX = 1000;
 // F-LOG-05: エクスポート/インポート対象のキー（テーマは UI 設定なので除外）。
 const EXPORT_KEYS = [
   PROGRESS_KEY,
+  CARD_PROGRESS_KEY,
   USER_CONTENT_KEY,
   BOOKMARKS_KEY,
   STUDY_DAYS_KEY,
@@ -36,9 +38,9 @@ const EMPTY_USER_CONTENT: UserContent = { quizTerms: [], interviewQuestions: [] 
 
 // 要件定義書 §4-1 / A-4: localStorage の破損・容量超過・未対応でも
 // 「進捗のみ初期化して用語出題は継続する」graceful degradation を守る。
-function readProgress(): Progress {
+function readProgressFrom(key: string): Progress {
   try {
-    const raw = localStorage.getItem(PROGRESS_KEY);
+    const raw = localStorage.getItem(key);
     if (!raw) return {};
     const parsed: unknown = JSON.parse(raw);
     // スキーマ不一致（配列・null・プリミティブ）は壊れているとみなして破棄する。
@@ -80,7 +82,7 @@ export const localStorageTermRepository: TermRepository = {
   },
 
   async getProgress(): Promise<Progress> {
-    return readProgress();
+    return readProgressFrom(PROGRESS_KEY);
   },
 
   async saveProgress(p: Progress): Promise<void> {
@@ -89,6 +91,18 @@ export const localStorageTermRepository: TermRepository = {
     } catch {
       // 容量超過・プライベートモード等で保存できなくても学習は継続させる（silent にはしない）。
       console.warn("[term-board] 進捗の保存に失敗しました。学習は継続します。");
+    }
+  },
+
+  async getCardProgress(): Promise<Progress> {
+    return readProgressFrom(CARD_PROGRESS_KEY);
+  },
+
+  async saveCardProgress(p: Progress): Promise<void> {
+    try {
+      localStorage.setItem(CARD_PROGRESS_KEY, JSON.stringify(p));
+    } catch {
+      console.warn("[term-board] 暗記カードの習熟度の保存に失敗しました。学習は継続します。");
     }
   },
 

--- a/term-board/src/api/termRepository.ts
+++ b/term-board/src/api/termRepository.ts
@@ -9,6 +9,11 @@ export interface TermRepository {
   getProgress(): Promise<Progress>;
   saveProgress(p: Progress): Promise<void>;
 
+  // F-CARD-01: 暗記カード専用の習熟度（覚えた/まだ）。4択の Progress とは別管理で
+  // 正答率を汚さず、カードの SRS（間隔反復）出題に使う。
+  getCardProgress(): Promise<Progress>;
+  saveCardProgress(p: Progress): Promise<void>;
+
   // F-USER: ユーザー作問データ（4択用語・面接Q&A）。
   getUserContent(): Promise<UserContent>;
   saveUserContent(c: UserContent): Promise<void>;

--- a/term-board/src/components/CardView.tsx
+++ b/term-board/src/components/CardView.tsx
@@ -1,42 +1,100 @@
-import { useEffect, useState } from "react";
-import type { Term, LearningSession } from "../types";
+import { useEffect, useMemo, useState } from "react";
+import type { Term, Progress, LearningSession } from "../types";
 import { repository } from "../api";
-import { pickRandom } from "../utils/shuffle";
+import { pickWeighted } from "../utils/shuffle";
+import { srsWeight } from "../utils/srs";
 import { newId } from "../utils/share";
 
-// F-CARD-01: 暗記カード（要件定義書 §13）。
+// F-CARD-01: 暗記カード（能動的想起 × 間隔反復）。
 // 表=用語、裏=意味/かんたん説明/面接での言い方。クリックで裏返す。
-// 「覚えた/まだ」自己評価は学習ログ（mode:card）へ記録し studyDays にも効かせる。
+// 「覚えた/まだ」をカード専用の習熟度に記録し、SRS(srsWeight)で苦手・未学習カードを
+// 優先出題する。4択(再認)・辞典(参照)と差別化した「思い出して答える」学習。
 
 export function CardView() {
   const [terms, setTerms] = useState<Term[]>([]);
+  const [cardProgress, setCardProgress] = useState<Progress>({});
   const [current, setCurrent] = useState<Term | null>(null);
   const [flipped, setFlipped] = useState(false);
   const [sessionDone, setSessionDone] = useState(0);
   const [sessionKnown, setSessionKnown] = useState(0);
+  const [category, setCategory] = useState("");
+  const [onlyWeak, setOnlyWeak] = useState(false);
 
   useEffect(() => {
     let active = true;
-    repository.getTerms().then((t) => {
+    Promise.all([repository.getTerms(), repository.getCardProgress()]).then(([t, cp]) => {
       if (!active) return;
       setTerms(t);
-      if (t.length > 0) setCurrent(pickRandom(t));
+      setCardProgress(cp);
     });
     return () => {
       active = false;
     };
   }, []);
 
-  const nextCard = (prev: Term | null) => {
-    let picked = pickRandom(terms);
-    if (terms.length > 1 && prev) {
-      while (picked.id === prev.id) picked = pickRandom(terms);
+  const categories = useMemo(() => [...new Set(terms.map((t) => t.category))].sort(), [terms]);
+
+  // 苦手＝「まだ」が「覚えた」を上回るカード。
+  const isWeak = (id: string, prog: Progress = cardProgress) => {
+    const p = prog[id];
+    return !!p && p.wrong > p.correct;
+  };
+
+  const weakCount = useMemo(
+    () => terms.filter((t) => isWeak(t.id)).length,
+    [terms, cardProgress],
+  );
+
+  const pool = useMemo(
+    () =>
+      terms.filter((t) => {
+        if (category && t.category !== category) return false;
+        if (onlyWeak && !isWeak(t.id)) return false;
+        return true;
+      }),
+    [terms, category, onlyWeak, cardProgress],
+  );
+
+  // SRS 重み付きで次のカードを選ぶ（直前と同じは避ける）。
+  const pickFrom = (list: Term[], prog: Progress, prev: Term | null): Term | null => {
+    if (list.length === 0) return null;
+    let picked = pickWeighted(list, (t) => srsWeight(prog[t.id]));
+    if (list.length > 1 && prev) {
+      while (picked.id === prev.id) picked = pickWeighted(list, (t) => srsWeight(prog[t.id]));
     }
     return picked;
   };
 
-  // 「覚えた/まだ」を学習ログへ記録し、次のカードへ。
+  // pool が用意できたら／フィルタ変更で current が pool 外になったら出題し直す。
+  useEffect(() => {
+    if (pool.length === 0) {
+      setCurrent(null);
+      return;
+    }
+    if (current === null || !pool.some((t) => t.id === current.id)) {
+      setFlipped(false);
+      setCurrent(pickFrom(pool, cardProgress, null));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pool]);
+
+  // 「覚えた/まだ」を記録し、次のカードへ。
   const assess = (known: boolean) => {
+    if (!current) return;
+    const id = current.id;
+    // カード専用の習熟度を更新（SRS の入力）。
+    const cur = cardProgress[id] ?? { correct: 0, wrong: 0, lastAnsweredAt: "" };
+    const nextProgress: Progress = {
+      ...cardProgress,
+      [id]: {
+        correct: cur.correct + (known ? 1 : 0),
+        wrong: cur.wrong + (known ? 0 : 1),
+        lastAnsweredAt: new Date().toISOString(),
+      },
+    };
+    setCardProgress(nextProgress);
+    void repository.saveCardProgress(nextProgress);
+    // 学習ログ・学習日（ダッシュボード／振り返り／ストリーク用）。
     const session: LearningSession = {
       id: newId(),
       startedAt: new Date().toISOString(),
@@ -48,86 +106,124 @@ export function CardView() {
     void repository.recordStudyDay(new Date().toLocaleDateString("sv-SE"));
     setSessionDone((n) => n + 1);
     if (known) setSessionKnown((n) => n + 1);
+
+    // 次のカード（更新後の習熟度・フィルタを反映）。
+    const nextPool = onlyWeak ? pool.filter((t) => isWeak(t.id, nextProgress) || t.id === id) : pool;
     setFlipped(false);
-    setCurrent((prev) => (terms.length > 0 ? nextCard(prev) : null));
+    setCurrent(pickFrom(nextPool.length > 0 ? nextPool : pool, nextProgress, current));
   };
 
-  if (terms.length === 0 || !current) {
+  if (terms.length === 0) {
     return <p className="text-center text-slate-500 dark:text-slate-400">カードに使える用語がありません。</p>;
   }
 
   return (
-    <section className="flex flex-col gap-5" aria-live="polite">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <p className="text-sm text-slate-500 dark:text-slate-400">カードをタップして意味を確認しましょう。</p>
+    <section className="flex flex-col gap-4" aria-live="polite">
+      {/* フィルタ */}
+      <div className="flex flex-wrap items-center gap-3 rounded-2xl bg-white p-3 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
+        <div className="flex items-center gap-2">
+          <label htmlFor="card-cat" className="text-sm font-medium text-slate-600 dark:text-slate-300">分野</label>
+          <select
+            id="card-cat"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+            className="rounded-lg border border-slate-300 bg-white px-2 py-1.5 text-sm text-slate-800 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+          >
+            <option value="">全分野</option>
+            {categories.map((c) => (
+              <option key={c} value={c}>{c}</option>
+            ))}
+          </select>
+        </div>
+        <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+          <input type="checkbox" checked={onlyWeak} onChange={(e) => setOnlyWeak(e.target.checked)} className="h-4 w-4" />
+          苦手だけ（{weakCount}）
+        </label>
         {sessionDone > 0 && (
-          <p className="text-sm font-medium text-slate-600 dark:text-slate-300">
+          <p className="ml-auto text-sm font-medium text-slate-600 dark:text-slate-300">
             このセット：覚えた {sessionKnown} ／ {sessionDone}
           </p>
         )}
       </div>
 
-      {/* カード本体（クリックで裏返す） */}
-      <button
-        type="button"
-        onClick={() => setFlipped((f) => !f)}
-        aria-pressed={flipped}
-        className="min-h-56 w-full rounded-2xl bg-white p-6 text-left shadow-sm ring-1 ring-slate-200 transition hover:ring-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:bg-slate-800 dark:ring-slate-700 dark:hover:ring-sky-500"
-      >
-        <p className="text-sm font-medium text-sky-700 dark:text-sky-400">{current.category}</p>
-        {!flipped ? (
-          <div className="mt-6 flex flex-col items-center justify-center gap-2 text-center">
-            <p className="text-3xl font-bold text-slate-900 dark:text-slate-100">{current.term}</p>
-            <p className="text-xs text-slate-500 dark:text-slate-400">タップで意味を見る</p>
-          </div>
-        ) : (
-          <div className="mt-3 flex flex-col gap-2">
-            <p className="text-lg font-bold text-slate-900 dark:text-slate-100">{current.term}</p>
-            {current.plainMeaning && (
-              <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-200">
-                <span className="font-semibold text-sky-800 dark:text-sky-300">かんたんに：</span>
-                {current.plainMeaning}
-              </p>
-            )}
-            <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
-              <span className="font-semibold text-slate-900 dark:text-slate-100">意味：</span>
-              {current.meaning}
-            </p>
-            <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-400">
-              <span className="font-semibold text-slate-800 dark:text-slate-200">面接での言い方：</span>
-              {current.interview}
-            </p>
-          </div>
-        )}
-      </button>
+      {pool.length === 0 ? (
+        <p className="text-center text-sm text-slate-500 dark:text-slate-400">
+          {onlyWeak ? "苦手なカードはありません。よくできています！" : "このカードがありません。"}
+        </p>
+      ) : current ? (
+        <>
+          <p className="text-center text-sm text-slate-500 dark:text-slate-400">
+            思い出してから裏返しましょう（苦手なカードほど多く出ます）
+          </p>
 
-      {/* 自己評価（裏面のときだけ） */}
-      {flipped ? (
-        <div className="flex flex-wrap gap-2">
+          {/* カード本体（クリックで裏返す） */}
           <button
             type="button"
-            onClick={() => assess(true)}
-            className="rounded-xl bg-emerald-700 px-5 py-2.5 font-semibold text-white transition hover:bg-emerald-800 focus:outline-none focus:ring-2 focus:ring-emerald-400"
+            onClick={() => setFlipped((f) => !f)}
+            aria-pressed={flipped}
+            className="min-h-56 w-full rounded-2xl bg-white p-6 text-left shadow-sm ring-1 ring-slate-200 transition hover:ring-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:bg-slate-800 dark:ring-slate-700 dark:hover:ring-sky-500"
           >
-            ◯ 覚えた
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium text-sky-700 dark:text-sky-400">{current.category}</span>
+              {isWeak(current.id) && (
+                <span className="rounded-full bg-rose-100 px-2 py-0.5 text-xs font-medium text-rose-800 dark:bg-rose-900 dark:text-rose-200">復習</span>
+              )}
+            </div>
+            {!flipped ? (
+              <div className="mt-6 flex flex-col items-center justify-center gap-2 text-center">
+                <p className="text-3xl font-bold text-slate-900 dark:text-slate-100">{current.term}</p>
+                <p className="text-xs text-slate-500 dark:text-slate-400">タップで意味を見る</p>
+              </div>
+            ) : (
+              <div className="mt-3 flex flex-col gap-2">
+                <p className="text-lg font-bold text-slate-900 dark:text-slate-100">{current.term}</p>
+                {current.plainMeaning && (
+                  <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-200">
+                    <span className="font-semibold text-sky-800 dark:text-sky-300">かんたんに：</span>
+                    {current.plainMeaning}
+                  </p>
+                )}
+                <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+                  <span className="font-semibold text-slate-900 dark:text-slate-100">意味：</span>
+                  {current.meaning}
+                </p>
+                <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-400">
+                  <span className="font-semibold text-slate-800 dark:text-slate-200">面接での言い方：</span>
+                  {current.interview}
+                </p>
+              </div>
+            )}
           </button>
-          <button
-            type="button"
-            onClick={() => assess(false)}
-            className="rounded-xl bg-slate-200 px-5 py-2.5 font-semibold text-slate-800 transition hover:bg-slate-300 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600"
-          >
-            △ まだ
-          </button>
-        </div>
-      ) : (
-        <button
-          type="button"
-          onClick={() => setFlipped(true)}
-          className="rounded-xl bg-sky-700 px-5 py-3 font-semibold text-white transition hover:bg-sky-800 focus:outline-none focus:ring-2 focus:ring-sky-400"
-        >
-          意味を見る
-        </button>
-      )}
+
+          {/* 自己評価（裏面のときだけ） */}
+          {flipped ? (
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => assess(true)}
+                className="rounded-xl bg-emerald-700 px-5 py-2.5 font-semibold text-white transition hover:bg-emerald-800 focus:outline-none focus:ring-2 focus:ring-emerald-400"
+              >
+                ◯ 覚えた
+              </button>
+              <button
+                type="button"
+                onClick={() => assess(false)}
+                className="rounded-xl bg-slate-200 px-5 py-2.5 font-semibold text-slate-800 transition hover:bg-slate-300 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600"
+              >
+                △ まだ
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setFlipped(true)}
+              className="rounded-xl bg-sky-700 px-5 py-3 font-semibold text-white transition hover:bg-sky-800 focus:outline-none focus:ring-2 focus:ring-sky-400"
+            >
+              意味を見る
+            </button>
+          )}
+        </>
+      ) : null}
     </section>
   );
 }

--- a/term-board/src/hooks/useQuiz.ts
+++ b/term-board/src/hooks/useQuiz.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Term, Progress } from "../types";
 import { repository } from "../api";
 import { shuffle, pickWeighted } from "../utils/shuffle";
+import { srsWeight } from "../utils/srs";
 
 // 1問分の出題データ。options は正解 meaning と distractors を混ぜてシャッフル済み（F-QUIZ-03）。
 export type Question = {
@@ -16,16 +17,6 @@ export type QuizStatus = "loading" | "ready" | "error";
 function buildQuestion(term: Term): Question {
   const options = shuffle([term.meaning, ...term.distractors]);
   return { term, options, answer: term.meaning };
-}
-
-// F-QUIZ-05: SRS（間隔反復）の出題優先度。Leitner 方式の簡易版。
-// 未出題を最優先、誤答が多いほど高く、正答を積むほど低く（間隔が伸びる）。
-// 重みが大きいほど選ばれやすい（pickWeighted）。
-function srsWeight(p?: Progress[string]): number {
-  if (!p) return 6; // 未出題を最優先
-  const net = p.correct - p.wrong; // 定着度（正答超過＝定着）
-  // net 0 → 5、誤答超過で増、正答を積むほど減（下限1で必ず再登場の余地を残す）。
-  return Math.max(1, 5 - net);
 }
 
 export type UseQuiz = {

--- a/term-board/src/utils/srs.ts
+++ b/term-board/src/utils/srs.ts
@@ -1,0 +1,10 @@
+// F-QUIZ-05: SRS（間隔反復）の出題優先度。Leitner 方式の簡易版。
+// 4択クイズ・暗記カードで共有する。重みが大きいほど選ばれやすい（pickWeighted）。
+// 未出題を最優先、誤答（まだ）が多いほど高く、正答（覚えた）を積むほど低く（間隔が伸びる）。
+type Stat = { correct: number; wrong: number };
+
+export function srsWeight(p?: Stat): number {
+  if (!p) return 6; // 未出題を最優先
+  const net = p.correct - p.wrong; // 定着度（正答超過＝定着）
+  return Math.max(1, 5 - net); // net 0→5、誤答超過で増、正答で減（下限1で必ず再登場の余地）
+}


### PR DESCRIPTION
## 概要
「暗記カードが辞典・4択と内容重複し存在意義が弱い」という指摘を受け、暗記カードを **能動的想起 × 間隔反復(SRS)** の独自モードに強化しました。4択(再認)・辞典(参照)と明確に差別化します。

## 変更内容
- **utils/srs（新規）**：`srsWeight` を共通化し、4択クイズと暗記カードで共有。
- **api/**：`getCardProgress` / `saveCardProgress` を追加。
  - カード専用ストア `term-board:cardProgress:v1`。**4択の正答率・解答数は汚さない**（別管理）。エクスポート/インポート対象にも追加。
- **CardView**：
  - 「覚えた/まだ」をカード習熟度に記録し、**SRS で苦手・未学習カードを優先出題**。
  - **分野フィルタ** ＋ **「苦手だけ」フィルタ**（苦手枚数を表示）。
  - 現在カードが苦手なら **「復習」バッジ**。
  - 学習ログ(`mode:card`)・`studyDays`（ストリーク/振り返り）への記録は従来どおり維持。

## 検証
- `npm run build` pass
- Chrome DevTools（preview/mobile）：「まだ」記録→苦手(0→1)・復習バッジ・苦手だけフィルタで該当カードが優先出題されることを確認
- 4択のダッシュボード正答率/解答数に影響しないこと（別ストア）を設計で担保
- Lighthouse（mobile）：Accessibility=100 / Best Practices=100 / SEO=100

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)