### PR TITLE
fix: 逆質問ストックを模範解答の後にのみ表示する

### DIFF
--- a/term-board/src/components/InterviewView.tsx
+++ b/term-board/src/components/InterviewView.tsx
@@ -199,7 +199,8 @@ export function InterviewView({ userQuestions }: Props) {
         </div>
       )}
     </section>
-      <ReverseQuestionStock />
+      {/* 逆質問ストックは練習の邪魔にならないよう、模範回答を見た後にだけ表示する。 */}
+      {revealed && <ReverseQuestionStock />}
     </div>
   );
 }


### PR DESCRIPTION
## 概要
面接練習で逆質問ストックが常時表示され、質問に答える練習中に邪魔に感じるという指摘を受け、模範回答を開いた後（最後）にのみ表示するよう変更しました。

## 変更内容
- **InterviewView**：`ReverseQuestionStock` を `revealed`（模範回答表示後）のときだけ描画。

## 検証
- `npm run build` pass
- Chrome DevTools（preview）：質問表示中は逆質問ストック非表示 → 模範回答を見た後に表示、を確認

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)