### PR TITLE
feat: 逆質問ストックを独立タブ（マイ問題の横）に移動

### DIFF
--- a/term-board/src/App.tsx
+++ b/term-board/src/App.tsx
@@ -10,6 +10,7 @@ import { MockInterviewView } from "./components/MockInterviewView";
 import { CardView } from "./components/CardView";
 import { ReviewView } from "./components/ReviewView";
 import { GuideView } from "./components/GuideView";
+import { ReverseQuestionStock } from "./components/ReverseQuestionStock";
 import { AuthorView } from "./components/AuthorView";
 import { DictionaryView } from "./components/DictionaryView";
 import { DashboardView } from "./components/DashboardView";
@@ -17,7 +18,7 @@ import { PrepView } from "./components/PrepView";
 import { LearnView } from "./components/LearnView";
 import { HomeView } from "./components/HomeView";
 
-type View = "home" | "quiz" | "card" | "dictionary" | "interview" | "mock" | "guide" | "author" | "dashboard" | "review" | "prep" | "learn";
+type View = "home" | "quiz" | "card" | "dictionary" | "interview" | "mock" | "guide" | "author" | "reverseq" | "dashboard" | "review" | "prep" | "learn";
 
 export default function App() {
   const [view, setView] = useState<View>("home");
@@ -92,6 +93,7 @@ export default function App() {
             <NavTab active={view === "review"} onClick={() => setView("review")}>振り返り</NavTab>
             <NavTab active={view === "prep"} onClick={() => setView("prep")}>自己PR</NavTab>
             <NavTab active={view === "author"} onClick={() => setView("author")}>マイ問題</NavTab>
+            <NavTab active={view === "reverseq"} onClick={() => setView("reverseq")}>逆質問</NavTab>
           </nav>
         </div>
       </header>
@@ -151,6 +153,8 @@ export default function App() {
         {view === "guide" && <GuideView userQuestions={user.content.interviewQuestions} />}
 
         {view === "author" && <AuthorView user={user} />}
+
+        {view === "reverseq" && <ReverseQuestionStock />}
       </main>
     </div>
   );

--- a/term-board/src/components/HomeView.tsx
+++ b/term-board/src/components/HomeView.tsx
@@ -1,4 +1,4 @@
-type Target = "quiz" | "card" | "dictionary" | "learn" | "interview" | "mock" | "guide" | "dashboard" | "review" | "prep" | "author";
+type Target = "quiz" | "card" | "dictionary" | "learn" | "interview" | "mock" | "guide" | "dashboard" | "review" | "prep" | "author" | "reverseq";
 
 type Props = { onNavigate: (view: Target) => void };
 
@@ -14,6 +14,7 @@ const MODES: { key: Target; title: string; desc: string }[] = [
   { key: "review", title: "振り返り", desc: "今日のメモと、日々の学習を時系列で振り返る。" },
   { key: "prep", title: "自己PR", desc: "自己紹介・志望動機を穴埋めで下書き作成。" },
   { key: "author", title: "マイ問題", desc: "自分で問題を作り、共有コードで配布・取り込み。" },
+  { key: "reverseq", title: "逆質問", desc: "「最後に質問は？」に備えて逆質問を貯める。いつでも編集。" },
 ];
 
 // B7: トップページ（アプリ紹介・各モードへの入口）。

--- a/term-board/src/components/InterviewView.tsx
+++ b/term-board/src/components/InterviewView.tsx
@@ -3,7 +3,6 @@ import type { InterviewQuestion, LearningSession } from "../types";
 import { repository } from "../api";
 import { pickRandom } from "../utils/shuffle";
 import { newId } from "../utils/share";
-import { ReverseQuestionStock } from "./ReverseQuestionStock";
 import bundledQuestions from "../data/interviewQuestions.json";
 
 type Props = {
@@ -92,7 +91,6 @@ export function InterviewView({ userQuestions }: Props) {
   if (!current) return null;
 
   return (
-    <div className="flex flex-col gap-6">
     <section className="flex flex-col gap-5" aria-live="polite">
       <div className="flex flex-wrap items-center justify-center gap-3">
         <p className="text-sm text-slate-500 dark:text-slate-400">
@@ -199,8 +197,5 @@ export function InterviewView({ userQuestions }: Props) {
         </div>
       )}
     </section>
-      {/* 逆質問ストックは練習の邪魔にならないよう、模範回答を見た後にだけ表示する。 */}
-      {revealed && <ReverseQuestionStock />}
-    </div>
   );
 }


### PR DESCRIPTION
## 概要
逆質問ストックを面接練習内ではなく独立モードにし、ナビの「マイ問題」の横に配置していつでも閲覧・編集できるようにしました。

## 変更内容
- **InterviewView**：`ReverseQuestionStock` を除去（面接練習は質問の練習に専念）。
- **App.tsx**：`View` に `"reverseq"` 追加・ナビタブ「逆質問」をマイ問題の横に配置・描画を配線。
- **HomeView**：逆質問の入口を追加。

## 差別化の確認
逆質問は他モードと重複しません（「最後に質問は？」に備える自分専用の逆質問リストという独自機能）。今回は移動のため新たな重複は発生していません。

## 検証
- `npm run build` pass
- Chrome DevTools（preview/mobile）：「逆質問」タブで表示・候補追加可、面接練習からは除去（残存なし）を確認
- Lighthouse（mobile）：Accessibility=100 / Best Practices=100 / SEO=100

Closes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)