### PR TITLE
docs: 次の作業計画（①ナビ整理 ②用語監査 ③テスト/セキュリティ）を引き継ぎ書に追加

### DIFF
--- a/term-board/docs/引き継ぎ書.md
+++ b/term-board/docs/引き継ぎ書.md
@@ -9,9 +9,9 @@
 
 ## 0. 3行サマリ
 
-- **B1〜B7 の全バッチ実装完了・本番公開済み**。オープンPRなし・宙ぶらりんゼロ・main 整合済み。
+- **主要13モード実装・本番公開済み**（4択/暗記カード/用語辞典/学ぶ/面接練習/模擬面接/解説集/ダッシュボード/振り返り/自己PR/マイ問題/逆質問）。用語**176語**。オープンPRなし・main整合済み。
 - アプリは**サーバー無しの静的SPA**（React+Vite+TS+Tailwind v4、永続化は localStorage、`api/` 層で隔離）。
-- **次にやる最優先**：①面接ログ補完（自己評価 F-INTV-02 含む）→ ②#289 深掘りチェーン → ③#290 SRS → ④#291 模擬面接（詳細は §6）。
+- **次にやる最優先（§6-7）**：①ナビのグループ化（モバイルUX）→ ②用語データの正確性レビュー（176語）→ ③自動テスト＋セキュリティCI導入（**review-board の Playwright+axe / gitleaks / CodeQL を流用**）。
 
 ---
 
@@ -239,9 +239,77 @@ export interface TermRepository {
 - （Phase4・将来）F-AUTH 認証／F-PROG-05 サーバー保存／F-TERM-03 用語サーバー管理
 
 ### 6-6. 内容・ドキュメントのTODO
-- **用語データ拡充**（現状12件のみ）：出典確定＋内容正確性レビュー（受入 A-7・R-01）。`followUps`/`related`/`confusedWith` の付与は差別化機能の前提。
-- **画面設計書.md** が B1〜B7 のモード追加を未反映 → 更新推奨。
-- **テスト計画書**：Vitest（shuffle/useQuiz/repository破損ガード）＋Playwright（主要導線）が未導入。
+- **用語データ拡充**：完了（176語。下記 §6-7-② で正確性レビューを実施）。`followUps`/`related`/`confusedWith` の付与は差別化機能の前提。
+- **画面設計書.md** が増えたモード（暗記カード/模擬面接/解説集/振り返り/逆質問 ほか）を未反映 → 更新推奨。
+- **テスト計画書**：Vitest（shuffle/srsWeight/repository破損ガード）＋Playwright（主要導線）が未導入 → §6-7-③ で導入。
+
+---
+
+## 6-7. 次の作業計画（最優先・①→②→③の順で実行）
+
+> 機能（13モード）が出揃ったため、ここからは**体験・品質・安全性**の底上げを優先する。
+> ①→②→③の順に1機能=1PR（CLAUDE.md §2フロー）で進める。③のテスト/セキュリティは
+> **review-board の既存資産を流用**する（車輪の再発明をしない）。
+
+### ① ナビゲーションのグループ化（モバイルUX・最優先）
+- **背景**：ナビが**13タブ**になり、スマホ（〜390px）で3〜4段に折り返してコンテンツを圧迫。
+  機能追加より体感改善の効果が大きい。
+- **方針**：トップレベルのタブを**4グループに集約**する。案：
+  - **覚える**：4択クイズ / 暗記カード / 用語辞典
+  - **面接対策**：面接練習 / 模擬面接 / 解説集 / 逆質問
+  - **学ぶ・記録**：学ぶ / ダッシュボード / 振り返り / 自己PR
+  - **マイ問題**（単独）／ ホーム（アプリ名クリックで戻る・実装済 #341）
+- **実装案**：`App.tsx` の `View` ユニオンは維持し、ナビだけ2段構成にする。
+  - 第1段＝グループ（`NavGroup` 状態）、第2段＝そのグループ内のモード。または
+  - グループ見出し＋折りたたみ（details/summary）でモバイルは省スペース、PCは横並び。
+  - `HomeView` の「機能から選ぶ」もグループ見出しで整理すると一貫する。
+- **受入**：スマホでナビが**2段以内**に収まる／全モードへ到達可能／キーボード操作可・A11y=100維持。
+- **対象**：`src/App.tsx`（ナビ部）、必要なら `src/components/HomeView.tsx`。
+
+### ② 用語データの正確性レビュー＋出典確定（176語）
+- **背景**：12→176語へ拡充済み。AI生成を含むため**内容監査**の価値が上がっている（受入 A-7・R-01）。
+- **方針**：
+  1. 全176語を分野ごとにレビュー：定義の正確性／`distractors`が「明確に誤り」か（正解と紛れない）／
+     `plainMeaning`が噛み砕きつつ嘘がないか／`level`の妥当性。
+  2. 出典の確認（IPA ITパスポート/基本情報シラバス、MDN、各公式Docs等）。怪しい記述は修正。
+  3. 重複・表記ゆれの点検（例：似た用語の意味が被っていないか）。
+  4. （任意）差別化機能の素地として `related`/`confusedWith` を主要語に付与。
+- **進め方**：`src/data/terms.json` を分野単位（9分野）でレビューし、分野ごとに小さなPRに分割すると安全。
+- **受入**：明確な誤りゼロ／4択の誤答が正解と紛れない／build・A11y維持。
+
+### ③ 自動テスト＋セキュリティCIの導入（review-board 資産を流用）
+> 流用元はすべて `/Users/macmini/dev/Cursor/review-board` と monorepo の `.github/workflows/`。
+> term-board は**サーバー無しの静的SPA**なので、認証/バックエンド前提の部分は不要で**より簡単**。
+
+- **③-a 単体テスト（Vitest）**
+  - 導入：`vitest` を devDependency に追加、`package.json` に `"test": "vitest run"`。
+  - 最初のテスト（費用対効果が高い順）：
+    - `utils/shuffle.ts`：`pickWeighted` の分布・`shuffle` が要素を保つ・`pickRandom`。
+    - `utils/srs.ts`：`srsWeight`（未出題=6／誤答超過で増／正答で減・下限1）。
+    - `api/localStorageTermRepository.ts`：破損JSON・型不一致で空フォールバック（受入A-4）、
+      `importAll`の不正データ拒否、`exportAll/importAll`往復、`resetProgress`が作問を残す。
+  - CI：`term-board-ci.yml` に `npm run test` ステップを追加。
+- **③-b E2E＋アクセシビリティ（Playwright＋@axe-core/playwright）**
+  - **流用元**：`review-board/e2e/`（`playwright.config.js` / `tests/a11y.spec.js` / `package.json`）。
+  - term-board 版 `term-board/e2e/` を作成し簡素化：
+    - `baseURL` は `http://localhost:5176`（dev固定ポート）。auth/LoginPage は**不要**。
+    - `smoke.spec.js`：ホーム表示→各モードへ遷移→4択を1問解く、等の主要導線。
+    - `a11y.spec.js`：`@axe-core/playwright` で主要ビュー（ホーム/4択/辞典/面接練習/学ぶ）の
+      critical 違反ゼロを assert（既存の手動 Lighthouse A11y=100 を自動化）。
+    - scripts：`e2e:smoke` / `e2e:a11y`（review-board の package.json を踏襲）。
+  - CI：`term-board-e2e.yml` を新規（review-board-e2e.yml を雛形に、backend起動を削りフロントのみ）。
+- **③-c セキュリティCI（流用でそのまま効く）**
+  - **gitleaks（秘密情報スキャン）**：`review-board-gitleaks.yml` を雛形に `term-board-gitleaks.yml` を作成。
+    `paths` を `term-board/**` に。ルートの `.gitleaks.toml` を共用。
+  - **CodeQL（SAST・JS/TS）**：`review-board-codeql.yml` を雛形に `term-board-codeql.yml`。
+    言語は `javascript-typescript` のみ（Javaなし）。`paths` を `term-board/**` に。公開リポジトリゆえ無料。
+  - **dependency-scan / SBOM**：余力があれば `review-board-dependency-scan.yml` / `review-board-sbom.yml`
+    を同様に term-board スコープで複製。
+  - 既存の `term-board-ci.yml`（型/ビルド＋`npm audit` High/Critical 0）は維持。
+- **受入**：`npm run test` が green／Playwright smoke・a11y が green／gitleaks・CodeQL が PR で走り pass。
+
+> **補足（slack-board）**：slack-board には `performance-tests/`（soak.js）等があるが、term-board は
+> サーバー無しのため負荷試験は対象外。テスト/セキュリティの流用元は **review-board が最適**。
 
 ---
 


### PR DESCRIPTION
## 概要
優先3項目を ①→②→③ の順で実行するための計画を引き継ぎ書 §6-7 に追記しました。③のテスト/セキュリティは **review-board の既存資産を流用**する方針です（調査済み）。

## 追記内容（§6-7）
- **① ナビのグループ化**：13タブ→4グループ集約案・実装案・受入（スマホ2段以内/A11y維持）。
- **② 用語の正確性レビュー**：176語の定義/誤答/level/出典確認、分野単位の小PL分割。
- **③ 自動テスト＋セキュリティCI（流用元明記）**：
  - Vitest（shuffle/srsWeight/repository破損ガード）
  - Playwright + @axe-core/playwright（`review-board/e2e/` を雛形に、auth/backend を削った term-board/e2e/）
  - gitleaks / CodeQL（`review-board-gitleaks.yml` / `review-board-codeql.yml` を term-board スコープで複製）
  - slack-board は負荷試験中心のため本アプリ（サーバー無し）には不適と補足。

§0 サマリも現状（13モード・176語・サーバー無し）に更新。

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)