### PR TITLE
test: Playwright E2E + アクセシビリティ自動テストを導入

### DIFF
--- a/.github/workflows/term-board-e2e.yml
+++ b/.github/workflows/term-board-e2e.yml
@@ -1,0 +1,74 @@
+name: term-board E2E (Playwright)
+
+# term-board は「サーバー無しの静的SPA」。backend/DB/MinIO は不要で、
+# Playwright が Vite dev を起動して smoke + a11y を回すだけ（review-board-e2e を簡素化）。
+# PR では chromium-desktop で smoke と a11y の両方を自動実行する。
+
+on:
+  pull_request:
+    paths:
+      - 'term-board/**'
+      - '.github/workflows/term-board-e2e.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: tb-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: smoke + a11y
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node (use .nvmrc = 24 LTS)
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: term-board/.nvmrc
+          cache: npm
+          cache-dependency-path: term-board/package-lock.json
+
+      - name: Install app deps (Vite は Playwright が起動)
+        working-directory: term-board
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: tb-playwright-${{ runner.os }}-${{ hashFiles('term-board/e2e/package.json') }}
+
+      - name: Install E2E deps + chromium
+        working-directory: term-board/e2e
+        run: |
+          npm install
+          npx playwright install --with-deps chromium
+
+      - name: Run E2E (smoke + a11y)
+        working-directory: term-board/e2e
+        env:
+          CI: 'true'
+        run: npm run e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tb-playwright-report-${{ github.run_id }}
+          path: term-board/e2e/playwright-report/
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Upload traces (failures only)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tb-playwright-traces-${{ github.run_id }}
+          path: term-board/e2e/test-results/
+          retention-days: 14
+          if-no-files-found: ignore

--- a/term-board/docs/引き継ぎ書.md
+++ b/term-board/docs/引き継ぎ書.md
@@ -294,7 +294,9 @@ export interface TermRepository {
     - `api/localStorageTermRepository.ts`：破損JSON・型不一致で空フォールバック（受入A-4）、
       `importAll`の不正データ拒否、`exportAll/importAll`往復、`resetProgress`が作問を残す。
   - CI：`term-board-ci.yml` に `npm run test` ステップを追加。
-- **③-b E2E＋アクセシビリティ（Playwright＋@axe-core/playwright）**
+- **③-b E2E＋アクセシビリティ（Playwright＋@axe-core/playwright）** ✅ 実装済（#367）
+  > `term-board/e2e/` を作成（review-board を簡素化・backend/DB/認証なし）。`baseURL`=dev固定5176、webServer は `npm run dev`。`smoke.spec.js`（ホーム→4グループ・各モード到達→4択1問）と `a11y.spec.js`（主要5ビューの critical 違反ゼロ）で**7テスト green**。CI `term-board-e2e.yml` を新規（PRで chromium-desktop の smoke+a11y 自動実行）。
+  > 旧メモ↓
   - **流用元**：`review-board/e2e/`（`playwright.config.js` / `tests/a11y.spec.js` / `package.json`）。
   - term-board 版 `term-board/e2e/` を作成し簡素化：
     - `baseURL` は `http://localhost:5176`（dev固定ポート）。auth/LoginPage は**不要**。

--- a/term-board/e2e/.gitignore
+++ b/term-board/e2e/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+playwright-report/
+test-results/
+/blob-report/
+.playwright/

--- a/term-board/e2e/package-lock.json
+++ b/term-board/e2e/package-lock.json
@@ -1,0 +1,102 @@
+{
+  "name": "term-board-e2e",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "term-board-e2e",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@axe-core/playwright": "^4.10.0",
+        "@playwright/test": "^1.48.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/term-board/e2e/package.json
+++ b/term-board/e2e/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "term-board-e2e",
+  "version": "0.1.0",
+  "private": true,
+  "description": "term-board の E2E（Playwright）。サーバー無しの静的SPAなので Vite dev のみを起動し、smoke と a11y を PR で自動実行する。",
+  "scripts": {
+    "install:browsers": "playwright install --with-deps chromium",
+    "e2e": "playwright test --project=chromium-desktop",
+    "e2e:smoke": "playwright test --project=chromium-desktop --grep @smoke",
+    "e2e:a11y": "playwright test --project=chromium-desktop --grep @a11y",
+    "e2e:mobile": "playwright test --project=mobile-chrome",
+    "e2e:report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@axe-core/playwright": "^4.10.0",
+    "@playwright/test": "^1.48.0"
+  }
+}

--- a/term-board/e2e/playwright.config.js
+++ b/term-board/e2e/playwright.config.js
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// term-board E2E 設定。
+// - サーバー無しの静的SPA（React+Vite）。backend/DB は無く、Vite dev だけを起動する。
+// - dev は base パス（/hideharu-AI/term-board/）で配信され、root(/) は 302 で base へ誘導される。
+//   baseURL は origin のみとし、各テストは goto('/') でリダイレクトを追従する。
+// - smoke / a11y はどちらも chromium-desktop で PR 自動実行（外部依存が無く安定）。
+const ORIGIN = process.env.E2E_BASE_URL || 'http://localhost:5176';
+const APP_URL = `${ORIGIN}/hideharu-AI/term-board/`;
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: [['html', { open: 'never' }], ['list']],
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+
+  use: {
+    baseURL: ORIGIN,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    { name: 'chromium-desktop', use: { ...devices['Desktop Chrome'] } },
+    { name: 'mobile-chrome', use: { ...devices['Pixel 5'] } },
+  ],
+
+  webServer: {
+    command: 'npm run dev',
+    cwd: '..',
+    url: APP_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/term-board/e2e/tests/a11y.spec.js
+++ b/term-board/e2e/tests/a11y.spec.js
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+// @a11y：WCAG 監査。手動 Lighthouse A11y=100 を自動化し、主要ビューの
+// critical 違反ゼロを保証する（serious 以下は可視化のためログのみ）。
+const WCAG = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
+
+async function scan(page) {
+  const results = await new AxeBuilder({ page }).withTags(WCAG).analyze();
+  const critical = results.violations.filter((v) => v.impact === 'critical');
+  const serious = results.violations.filter((v) => v.impact === 'serious');
+  if (serious.length) {
+    console.log('a11y serious violations:', serious.map((v) => `${v.id} (${v.nodes.length})`).join(', '));
+  }
+  return { critical };
+}
+
+// グループnav経由で各モードへ遷移する小ヘルパー。
+async function openMode(page, group, mode) {
+  await page.getByRole('button', { name: group, exact: true }).click();
+  if (mode) await page.getByRole('button', { name: mode, exact: true }).click();
+}
+
+test.describe('accessibility @a11y', () => {
+  test('ホームに critical な a11y 違反が無い', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: /面接で言える/ })).toBeVisible();
+    const { critical } = await scan(page);
+    expect(critical, critical.map((v) => v.id).join(', ')).toEqual([]);
+  });
+
+  test('4択クイズに critical な a11y 違反が無い', async ({ page }) => {
+    await page.goto('/');
+    await openMode(page, '覚える', '4択クイズ');
+    await expect(page.getByRole('heading', { name: /の意味は/ })).toBeVisible();
+    const { critical } = await scan(page);
+    expect(critical, critical.map((v) => v.id).join(', ')).toEqual([]);
+  });
+
+  test('用語辞典に critical な a11y 違反が無い', async ({ page }) => {
+    await page.goto('/');
+    await openMode(page, '覚える', '用語辞典');
+    const { critical } = await scan(page);
+    expect(critical, critical.map((v) => v.id).join(', ')).toEqual([]);
+  });
+
+  test('面接練習に critical な a11y 違反が無い', async ({ page }) => {
+    await page.goto('/');
+    await openMode(page, '面接対策', '面接練習');
+    await expect(page.getByRole('button', { name: /模範回答を見る/ })).toBeVisible();
+    const { critical } = await scan(page);
+    expect(critical, critical.map((v) => v.id).join(', ')).toEqual([]);
+  });
+
+  test('学ぶに critical な a11y 違反が無い', async ({ page }) => {
+    await page.goto('/');
+    await openMode(page, '学ぶ・記録', '学ぶ');
+    const { critical } = await scan(page);
+    expect(critical, critical.map((v) => v.id).join(', ')).toEqual([]);
+  });
+});

--- a/term-board/e2e/tests/smoke.spec.js
+++ b/term-board/e2e/tests/smoke.spec.js
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+
+// @smoke：PR で自動実行する主要導線。
+// 認証もサーバーも無いので、ホーム表示→4グループへの到達→4択を1問解く、を担保する。
+test.describe('smoke @smoke', () => {
+  test('ホームが表示され、4グループ・各モードへ到達できる', async ({ page }) => {
+    await page.goto('/');
+
+    // ヒーロー見出し（h2）＝ホーム到達。
+    await expect(page.getByRole('heading', { name: /面接で言える/ })).toBeVisible();
+
+    // グループ「覚える」→ 第2段にモードが現れ、4択クイズへ遷移する。
+    await page.getByRole('button', { name: '覚える', exact: true }).click();
+    await expect(page.getByRole('button', { name: '4択クイズ', exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: '用語辞典', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /の意味は/ })).toBeVisible();
+
+    // グループ「面接対策」→ 面接練習が初期表示（模範回答ボタン）。
+    await page.getByRole('button', { name: '面接対策', exact: true }).click();
+    await expect(page.getByRole('button', { name: '模擬面接', exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: /模範回答を見る/ })).toBeVisible();
+
+    // グループ「学ぶ・記録」→ 第2段にダッシュボード等。
+    await page.getByRole('button', { name: '学ぶ・記録', exact: true }).click();
+    await expect(page.getByRole('button', { name: 'ダッシュボード', exact: true })).toBeVisible();
+
+    // グループ「マイ問題」（単独）へ。
+    await page.getByRole('button', { name: 'マイ問題', exact: true }).click();
+
+    // アプリ名クリックでホームへ戻る。
+    await page.getByRole('button', { name: /ホームへ戻る/ }).click();
+    await expect(page.getByRole('heading', { name: /面接で言える/ })).toBeVisible();
+  });
+
+  test('4択クイズを1問解ける（採点と解説が出る）', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: '覚える', exact: true }).click();
+
+    await expect(page.getByRole('heading', { name: /の意味は/ })).toBeVisible();
+
+    // 出題セクション（aria-live="polite"）内の選択肢ボタンの先頭を回答。
+    const options = page.locator('section[aria-live="polite"] ul button');
+    await expect(options.first()).toBeVisible();
+    await options.first().click();
+
+    // 採点結果と「次の問題」が現れる。
+    await expect(page.getByText(/正解！|不正解/)).toBeVisible();
+    await expect(page.getByRole('button', { name: /次の問題/ })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## 概要
引き継ぎ書 §6-7 ③-b。手動 Lighthouse A11y=100 の自動化と主要導線の回帰防止。term-board はサーバー無しの静的SPAなので review-board の e2e を大幅に簡素化（backend/DB/MinIO/認証すべて不要）。

## 変更
- `term-board/e2e/`：Playwright 一式（`package.json` / `playwright.config.js` / `.gitignore` / `tests/`）。
  - `playwright.config.js`：`baseURL`=dev固定 `http://localhost:5176`、webServer は `npm run dev`（base パス配信・root は302で追従）。chromium-desktop と mobile-chrome の projects。
  - `tests/smoke.spec.js`（@smoke）：ホーム表示→4グループ「覚える/面接対策/学ぶ・記録/マイ問題」と各モードへ到達→4択を1問解いて採点・解説が出る。
  - `tests/a11y.spec.js`（@a11y）：`@axe-core/playwright` で主要5ビュー（ホーム/4択/用語辞典/面接練習/学ぶ）の critical 違反ゼロを assert。
- `.github/workflows/term-board-e2e.yml`：PR で chromium-desktop の smoke + a11y を自動実行（review-board-e2e を雛形に backend 起動を削除）。

## 検証（ローカル）
- `npm run e2e`（chromium-desktop）：**7 passed**（smoke 2 + a11y 5）

Closes #367