### PR TITLE
ci: term-board にセキュリティCI（gitleaks / CodeQL）を導入

### DIFF
--- a/.github/workflows/term-board-codeql.yml
+++ b/.github/workflows/term-board-codeql.yml
@@ -1,0 +1,52 @@
+name: term-board CodeQL (SAST)
+
+# ============================================================
+# CodeQL による静的アプリケーションセキュリティテスト（SAST）。
+# term-board は JavaScript/TypeScript のみ（Javaなし）なので 1 言語で解析する。
+# 公開リポジトリのため CodeQL は無料。paths は term-board に限定し、
+# monorepo の他アプリ（review-board / task-board 等）には走らせない。
+# review-board-codeql.yml を雛形に backend(Java) を削除したもの。
+# ============================================================
+
+on:
+  pull_request:
+    paths:
+      - 'term-board/src/**'
+      - '.github/workflows/term-board-codeql.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'term-board/src/**'
+      - '.github/workflows/term-board-codeql.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: tb-codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write   # CodeQL の結果を Security タブに上げる
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          build-mode: none
+          # 解析対象を term-board のソースに限定（他アプリ・テストを取り込まない）。
+          config: |
+            paths:
+              - term-board/src
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"

--- a/.github/workflows/term-board-gitleaks.yml
+++ b/.github/workflows/term-board-gitleaks.yml
@@ -1,0 +1,68 @@
+name: term-board Secret Scan (gitleaks / S軸)
+
+# ============================================================
+# 機密情報の server-side スキャン（最後の防衛線）。
+# review-board-gitleaks.yml を term-board スコープで複製したもの。
+#
+# 目的: GitHub Web 編集 / `git commit --no-verify` 等、ローカル hook を
+#       バイパスする経路を塞ぐ。task-board の平文パスワード Public コミット
+#       事故（不可逆）と同型の再発防止（S軸の核）。
+#
+# 方式: バージョン固定の gitleaks で term-board ツリーを走査。設定は
+#       リポジトリルートの .gitleaks.toml を review-board と共用する。
+# ============================================================
+
+on:
+  pull_request:
+    paths:
+      - 'term-board/**'
+      - '.gitleaks.toml'
+      - '.github/workflows/term-board-gitleaks.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'term-board/**'
+      - '.gitleaks.toml'
+      - '.github/workflows/term-board-gitleaks.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: tb-gitleaks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  secret-scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    env:
+      GITLEAKS_VERSION: 8.30.1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: gitleaks をインストール（バージョン固定）
+        run: |
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /tmp gitleaks
+          sudo install /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: term-board を機密情報スキャン
+        run: |
+          # 検知時は gitleaks が exit 1 → step が fail。設定は repo ルートの .gitleaks.toml。
+          gitleaks dir term-board \
+            --config .gitleaks.toml \
+            --report-path gitleaks-report.json \
+            --report-format json \
+            --redact \
+            --verbose
+
+      - name: 検出レポートを artifact 化（失敗時のみ）
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tb-gitleaks-report
+          path: gitleaks-report.json
+          retention-days: 7

--- a/term-board/docs/引き継ぎ書.md
+++ b/term-board/docs/引き継ぎ書.md
@@ -306,6 +306,7 @@ export interface TermRepository {
     - scripts：`e2e:smoke` / `e2e:a11y`（review-board の package.json を踏襲）。
   - CI：`term-board-e2e.yml` を新規（review-board-e2e.yml を雛形に、backend起動を削りフロントのみ）。
 - **③-c セキュリティCI（流用でそのまま効く）**
+  - ✅ 実装済（#369）：`term-board-gitleaks.yml`（`gitleaks dir term-board`・ルートの `.gitleaks.toml` 共用）と `term-board-codeql.yml`（`javascript-typescript` のみ・`paths: term-board/src`）を追加。どちらも PR/main push の `term-board/**`（CodeQLは `term-board/src/**`）で発火。ローカル gitleaks は「no leaks found」。
   - **gitleaks（秘密情報スキャン）**：`review-board-gitleaks.yml` を雛形に `term-board-gitleaks.yml` を作成。
     `paths` を `term-board/**` に。ルートの `.gitleaks.toml` を共用。
   - **CodeQL（SAST・JS/TS）**：`review-board-codeql.yml` を雛形に `term-board-codeql.yml`。


### PR DESCRIPTION
## 概要
引き継ぎ書 §6-7 ③-c。review-board の既存セキュリティCIを term-board スコープで複製。

## 変更
- `.github/workflows/term-board-gitleaks.yml`：`gitleaks dir term-board`（バージョン固定 8.30.1）。設定はルートの `.gitleaks.toml` を review-board と共用。`term-board/**` の PR/push で発火。Web編集・`--no-verify` バイパスを塞ぐ最後の防衛線。
- `.github/workflows/term-board-codeql.yml`：CodeQL SAST。term-board は JS/TS のみ（Javaなし）なので `javascript-typescript` 1言語、`paths: term-board/src` に限定。`term-board/src/**` の PR/push で発火。公開リポジトリゆえ無料。

## 検証
- ローカル `gitleaks dir term-board --config .gitleaks.toml`：**no leaks found**
- ワークフローは既存の review-board-gitleaks / review-board-codeql を踏襲

Closes #369