### PR TITLE
feat: Apple HIG準拠のデザイン土台を導入（iOS/macOS踏襲・第1弾）

### DIFF
--- a/term-board/docs/引き継ぎ書.md
+++ b/term-board/docs/引き継ぎ書.md
@@ -361,6 +361,14 @@ gh run list --repo 80-cloud/hideharu-AI --workflow "term-board-pages.yml" --bran
 
 ## 8. 設計上の注意点（ハマりどころ・実体験ベース）
 
+0. **Apple HIG デザイントークン（#371・iOS/macOS 踏襲の土台）**：`index.css` に定義。
+   - セマンティックカラーを **CSS変数**で持ち、`:root` と `.dark` で値だけ差し替える → `bg-canvas`/`bg-surface`/`text-label`/`text-label-2`/`border-separator`/`bg-accent-fill`/`text-accent`/`bg-fill-quaternary` の Tailwind ユーティリティが **light/dark 自動スイッチ**（個々に `dark:` 不要）。角丸は `rounded-card`(14px)/`rounded-control`(10px)。
+   - コンポーネントクラス：`.hig-card`（面+角丸+ヘアライン罫線）、`.hig-btn-primary`（systemBlue 塗り・白文字でAA）。
+   - ナビは iOS セグメントコントロール（第1段＝`SegmentTab`）＋ピル（第2段＝`PillTab`）。ヘッダーは `sticky` + `bg-bar` + `backdrop-blur-xl`（素材感）。
+   - **移行状況**：済＝共通クロム（App.tsx ヘッダー/ナビ/背景）・HomeView・QuizView・CategoryFilter。**未移行＝他の各ビュー**（CardView/DictionaryView/InterviewView/MockInterviewView/GuideView/ReverseQuestionStock/DashboardView/ReviewView/PrepView/LearnView/AuthorView）。各ビューで `bg-white`/`slate-*`/`ring-slate-*`/`sky-*` を上記トークンへ置換していく（1ビュー=1PR 目安）。
+   - **PCナビの2案比較は別途**：macOS サイドバー案 vs 上部ツールバー案を実装してテストで比較予定（#371 のフォロー）。
+   - 新トークンでも **A11y=100 を維持**（accent #0066cc/dark #0a84ff・label-2 は AA 確保の濃さを選定済み）。新ビュー移行時も light/dark 両方で audit。
+
 1. **ダークはクラス式**：`index.css` に `@custom-variant dark (&:where(.dark, .dark *))`。`dark:` は `<html class="dark">` 配下でのみ効く。
    - ⚠️ **`prefers-color-scheme` 依存にしないこと**。テスト環境がOSダークだと「背景は明るいまま文字だけ暗色」になりコントラスト破綻 → Lighthouse A11y が落ちる（実際に起きた）。新規UIに `dark:` を付けたら必ず light/dark 両方で audit。
 2. **コントラスト（WCAG AA）**：

--- a/term-board/src/App.tsx
+++ b/term-board/src/App.tsx
@@ -81,33 +81,27 @@ export default function App() {
   const activeGroup = NAV_GROUPS.find((g) => g.views.some((v) => v.view === view));
 
   return (
-    <div className="min-h-screen bg-slate-50 text-slate-900 dark:bg-slate-900 dark:text-slate-100">
-      <header className="border-b border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800">
-        <div className="mx-auto flex max-w-2xl flex-col gap-3 px-4 py-4">
+    <div className="min-h-screen bg-canvas text-label">
+      {/* iOS/macOS のナビバー風：上部固定・半透明 + backdrop blur（素材感）。 */}
+      <header className="sticky top-0 z-20 border-b border-separator bg-bar backdrop-blur-xl backdrop-saturate-150">
+        <div className="mx-auto flex max-w-2xl flex-col gap-3 px-4 py-3">
           <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-start justify-between gap-2">
               <div>
-                <h1 className="text-xl font-bold">
+                <h1 className="text-[17px] font-semibold tracking-tight">
                   <button
                     type="button"
                     onClick={() => setView("home")}
                     aria-label="IT用語ボード（ホームへ戻る）"
                     title="ホームへ戻る"
-                    className="rounded transition hover:text-sky-700 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:hover:text-sky-400"
+                    className="rounded transition hover:text-accent focus:outline-none focus:ring-2 focus:ring-accent"
                   >
                     IT用語ボード
                   </button>
                 </h1>
-                <p className="text-xs text-slate-500 dark:text-slate-400">面接で言えるまで、4択で定着させる</p>
+                <p className="text-xs text-label-2">面接で言えるまで、4択で定着させる</p>
               </div>
-              <button
-                type="button"
-                onClick={theme.toggle}
-                aria-label={theme.theme === "dark" ? "ライトモードに切り替え" : "ダークモードに切り替え"}
-                className="rounded-lg px-2 py-1 text-lg ring-1 ring-slate-300 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:ring-slate-600 dark:hover:bg-slate-700 sm:hidden"
-              >
-                {theme.theme === "dark" ? "☀️" : "🌙"}
-              </button>
+              <ThemeToggle theme={theme.theme} onToggle={theme.toggle} className="flex sm:hidden" />
             </div>
             <div className="flex items-center gap-2">
               {view === "quiz" && quiz.status === "ready" && (
@@ -117,44 +111,40 @@ export default function App() {
                   onChange={quiz.setCategory}
                 />
               )}
-              <button
-                type="button"
-                onClick={theme.toggle}
-                aria-label={theme.theme === "dark" ? "ライトモードに切り替え" : "ダークモードに切り替え"}
-                className="hidden rounded-lg px-2 py-1 text-lg ring-1 ring-slate-300 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:ring-slate-600 dark:hover:bg-slate-700 sm:block"
-              >
-                {theme.theme === "dark" ? "☀️" : "🌙"}
-              </button>
+              <ThemeToggle theme={theme.theme} onToggle={theme.toggle} className="hidden sm:flex" />
             </div>
           </div>
 
-          {/* 第1段：グループ（13タブを4グループに集約してモバイルでも2段以内に収める） */}
-          <nav className="flex flex-wrap gap-2" aria-label="カテゴリ切替">
+          {/* 第1段：グループ。iOS のセグメントコントロール（薄い面に白ピルが滑る）。 */}
+          <nav
+            className="flex gap-1 rounded-control bg-fill-quaternary p-1"
+            aria-label="カテゴリ切替"
+          >
             {NAV_GROUPS.map((g) => (
-              <NavTab
+              <SegmentTab
                 key={g.key}
                 active={activeGroup?.key === g.key}
                 onClick={() => setView(g.views[0].view)}
               >
                 {g.label}
-              </NavTab>
+              </SegmentTab>
             ))}
           </nav>
 
-          {/* 第2段：選択中グループのモード（単独グループは第1段で完結するため省略） */}
+          {/* 第2段：選択中グループのモード（単独グループは第1段で完結するため省略）。ピル列。 */}
           {activeGroup && activeGroup.views.length > 1 && (
             <nav
-              className="flex flex-wrap gap-2 border-t border-slate-100 pt-3 dark:border-slate-700"
+              className="flex flex-wrap gap-2"
               aria-label={`${activeGroup.label}のモード切替`}
             >
               {activeGroup.views.map((v) => (
-                <NavTab
+                <PillTab
                   key={v.view}
                   active={view === v.view}
                   onClick={() => setView(v.view)}
                 >
                   {v.label}
-                </NavTab>
+                </PillTab>
               ))}
             </nav>
           )}
@@ -166,18 +156,18 @@ export default function App() {
 
         {view === "quiz" && (
           <>
-            {quiz.status === "loading" && <p className="text-center text-slate-500 dark:text-slate-400">読み込み中…</p>}
+            {quiz.status === "loading" && <p className="text-center text-label-2">読み込み中…</p>}
             {quiz.status === "error" && (
-              <p className="rounded-xl bg-rose-50 p-4 text-center text-rose-700 ring-1 ring-rose-200 dark:bg-rose-950 dark:text-rose-300 dark:ring-rose-900">
+              <p className="rounded-control bg-rose-50 p-4 text-center text-rose-700 ring-1 ring-rose-200 dark:bg-rose-950 dark:text-rose-300 dark:ring-rose-900">
                 用語データを読み込めませんでした。
               </p>
             )}
             {quiz.status === "ready" && (
               <>
-                <div className="mb-5 flex items-center justify-between rounded-xl bg-white px-4 py-3 text-sm shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-                  <span className="text-slate-600 dark:text-slate-300">解答数 <span className="font-bold text-slate-900 dark:text-slate-100">{quiz.answeredCount}</span></span>
-                  <span className="text-slate-600 dark:text-slate-300">正答 <span className="font-bold text-emerald-700 dark:text-emerald-400">{quiz.correctCount}</span></span>
-                  <span className="text-slate-600 dark:text-slate-300">正答率 <span className="font-bold text-sky-700 dark:text-sky-400">{rate}%</span></span>
+                <div className="hig-card mb-5 flex items-center justify-between px-4 py-3 text-sm">
+                  <span className="text-label-2">解答数 <span className="font-bold text-label">{quiz.answeredCount}</span></span>
+                  <span className="text-label-2">正答 <span className="font-bold text-emerald-700 dark:text-emerald-400">{quiz.correctCount}</span></span>
+                  <span className="text-label-2">正答率 <span className="font-bold text-accent">{rate}%</span></span>
                 </div>
                 {quiz.question ? (
                   <QuizView
@@ -223,7 +213,8 @@ export default function App() {
   );
 }
 
-function NavTab({
+// iOS セグメントコントロールの 1 セグメント。選択中は白ピルが浮き上がる。
+function SegmentTab({
   active,
   onClick,
   children,
@@ -237,13 +228,59 @@ function NavTab({
       type="button"
       onClick={onClick}
       aria-current={active ? "page" : undefined}
-      className={`rounded-lg px-3 py-1.5 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-sky-400 ${
-        active
-          ? "bg-sky-700 text-white"
-          : "bg-white text-slate-600 ring-1 ring-slate-300 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-600"
+      className={`flex-1 rounded-[7px] px-2 py-1.5 text-[13px] font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+        active ? "bg-surface text-label shadow-sm" : "text-label-2 hover:text-label"
       }`}
     >
       {children}
+    </button>
+  );
+}
+
+// 第2段のモード切替ピル。選択中は systemBlue 塗り。
+function PillTab({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-current={active ? "page" : undefined}
+      className={`rounded-full px-3.5 py-1.5 text-[13px] font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+        active
+          ? "bg-accent-fill text-white"
+          : "bg-surface text-label-2 ring-1 ring-separator hover:text-label"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+// テーマ切替（iOS/macOS のツールバーボタン風・丸角）。
+function ThemeToggle({
+  theme,
+  onToggle,
+  className = "",
+}: {
+  theme: "light" | "dark";
+  onToggle: () => void;
+  className?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-label={theme === "dark" ? "ライトモードに切り替え" : "ダークモードに切り替え"}
+      className={`h-8 w-8 items-center justify-center rounded-full text-base ring-1 ring-separator transition hover:bg-fill-quaternary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${className}`}
+    >
+      {theme === "dark" ? "☀️" : "🌙"}
     </button>
   );
 }

--- a/term-board/src/components/CategoryFilter.tsx
+++ b/term-board/src/components/CategoryFilter.tsx
@@ -8,14 +8,14 @@ type Props = {
 export function CategoryFilter({ categories, value, onChange }: Props) {
   return (
     <div className="flex items-center gap-2">
-      <label htmlFor="category-select" className="text-sm font-medium text-slate-600 dark:text-slate-300">
+      <label htmlFor="category-select" className="text-sm font-medium text-label-2">
         分野
       </label>
       <select
         id="category-select"
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm text-slate-800 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+        className="rounded-control border border-separator bg-surface px-3 py-1.5 text-sm text-label focus:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
       >
         <option value="">全分野（ランダム）</option>
         {categories.map((c) => (

--- a/term-board/src/components/HomeView.tsx
+++ b/term-board/src/components/HomeView.tsx
@@ -45,8 +45,8 @@ export function HomeView({ onNavigate }: Props) {
   return (
     <section className="flex flex-col gap-6">
       {/* ヒーロー */}
-      <div className="rounded-2xl bg-gradient-to-br from-sky-600 to-sky-800 p-6 text-white shadow-sm">
-        <h2 className="text-2xl font-bold">IT用語を「面接で言える」まで。</h2>
+      <div className="rounded-card bg-gradient-to-br from-sky-700 to-sky-900 p-6 text-white shadow-sm">
+        <h2 className="text-2xl font-bold tracking-tight">IT用語を「面接で言える」まで。</h2>
         <p className="mt-2 text-sm leading-relaxed text-sky-50">
           IT業界へ初めて転職する人のための学習アプリ。4択で覚えて、面接で自分の言葉にする。
           ログイン不要・無料・ブラウザだけで今すぐ。
@@ -55,14 +55,14 @@ export function HomeView({ onNavigate }: Props) {
           <button
             type="button"
             onClick={() => onNavigate("quiz")}
-            className="rounded-xl bg-white px-5 py-2.5 font-semibold text-sky-800 transition hover:bg-sky-50 focus:outline-none focus:ring-2 focus:ring-white"
+            className="rounded-control bg-white px-5 py-2.5 font-semibold text-sky-800 transition hover:bg-sky-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-white active:scale-[0.98]"
           >
             今すぐ4択を始める
           </button>
           <button
             type="button"
             onClick={() => onNavigate("learn")}
-            className="rounded-xl px-5 py-2.5 font-semibold text-white ring-1 ring-white/70 transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white"
+            className="rounded-control px-5 py-2.5 font-semibold text-white ring-1 ring-white/70 transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white active:scale-[0.98]"
           >
             学習ロードマップを見る
           </button>
@@ -70,25 +70,25 @@ export function HomeView({ onNavigate }: Props) {
       </div>
 
       {/* 使い方の流れ */}
-      <div className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-        <h2 className="text-sm font-semibold text-slate-700 dark:text-slate-300">おすすめの進め方</h2>
-        <ol className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-slate-700 dark:text-slate-300">
+      <div className="hig-card p-5">
+        <h2 className="text-sm font-semibold text-label">おすすめの進め方</h2>
+        <ol className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-label">
           <li className="font-medium">① 学ぶ（全体像）</li>
-          <li aria-hidden="true" className="text-slate-400">→</li>
+          <li aria-hidden="true" className="text-label-3">→</li>
           <li className="font-medium">② 4択で定着</li>
-          <li aria-hidden="true" className="text-slate-400">→</li>
+          <li aria-hidden="true" className="text-label-3">→</li>
           <li className="font-medium">③ 面接練習で言える</li>
-          <li aria-hidden="true" className="text-slate-400">→</li>
+          <li aria-hidden="true" className="text-label-3">→</li>
           <li className="font-medium">④ 自己PRを整える</li>
         </ol>
       </div>
 
       {/* モード一覧（ナビと同じ4グループで整理） */}
       <div className="flex flex-col gap-5">
-        <h2 className="text-sm font-semibold text-slate-700 dark:text-slate-300">機能から選ぶ</h2>
+        <h2 className="text-sm font-semibold text-label">機能から選ぶ</h2>
         {MODE_GROUPS.map((group) => (
           <div key={group.label}>
-            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-label-2">
               {group.label}
             </h3>
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
@@ -97,10 +97,10 @@ export function HomeView({ onNavigate }: Props) {
                   key={m.key}
                   type="button"
                   onClick={() => onNavigate(m.key)}
-                  className="rounded-2xl bg-white p-4 text-left shadow-sm ring-1 ring-slate-200 transition hover:ring-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:bg-slate-800 dark:ring-slate-700 dark:hover:ring-sky-500"
+                  className="hig-card p-4 text-left transition hover:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent active:scale-[0.99]"
                 >
-                  <p className="font-bold text-slate-900 dark:text-slate-100">{m.title}</p>
-                  <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">{m.desc}</p>
+                  <p className="font-semibold text-label">{m.title}</p>
+                  <p className="mt-1 text-sm text-label-2">{m.desc}</p>
                 </button>
               ))}
             </div>

--- a/term-board/src/components/QuizView.tsx
+++ b/term-board/src/components/QuizView.tsx
@@ -17,9 +17,9 @@ function optionClass(args: {
   isThisSelected: boolean;
 }): string {
   const base =
-    "flex w-full items-center gap-3 rounded-xl border-2 px-4 py-3 text-left text-base transition focus:outline-none focus:ring-2 focus:ring-sky-400";
+    "flex w-full items-center gap-3 rounded-control border px-4 py-3 text-left text-base transition focus:outline-none focus-visible:ring-2 focus-visible:ring-accent";
   if (!args.answered) {
-    return `${base} border-slate-200 bg-white hover:border-sky-400 hover:bg-sky-50 cursor-pointer dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:border-sky-500 dark:hover:bg-slate-700`;
+    return `${base} border-separator bg-surface text-label hover:border-accent cursor-pointer active:scale-[0.99]`;
   }
   if (args.isThisCorrect) {
     return `${base} border-emerald-500 bg-emerald-50 text-emerald-900 dark:bg-emerald-950 dark:text-emerald-200`;
@@ -68,9 +68,9 @@ export function QuizView({ question, selected, isCorrect, onAnswer, onNext }: Pr
 
   return (
     <section className="flex flex-col gap-5" aria-live="polite">
-      <div className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-        <p className="text-sm font-medium text-sky-700 dark:text-sky-400">{question.term.category}</p>
-        <h2 className="mt-1 text-2xl font-bold text-slate-900 dark:text-slate-100">
+      <div className="hig-card p-6">
+        <p className="text-sm font-medium text-accent">{question.term.category}</p>
+        <h2 className="mt-1 text-2xl font-bold tracking-tight text-label">
           「{question.term.term}」の意味は？
         </h2>
       </div>
@@ -100,7 +100,7 @@ export function QuizView({ question, selected, isCorrect, onAnswer, onNext }: Pr
       </ul>
 
       {answered && (
-        <div className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
+        <div className="hig-card p-6">
           <p
             className={`text-lg font-bold ${
               isCorrect ? "text-emerald-700 dark:text-emerald-400" : "text-rose-700 dark:text-rose-400"
@@ -137,7 +137,7 @@ export function QuizView({ question, selected, isCorrect, onAnswer, onNext }: Pr
             type="button"
             onClick={onNext}
             autoFocus
-            className="mt-4 rounded-xl bg-sky-700 px-5 py-2.5 font-semibold text-white transition hover:bg-sky-800 focus:outline-none focus:ring-2 focus:ring-sky-400"
+            className="hig-btn-primary mt-4 px-5 py-2.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
           >
             次の問題 →
           </button>

--- a/term-board/src/index.css
+++ b/term-board/src/index.css
@@ -3,3 +3,98 @@
 /* B2: ダークを「クラス式」に（.dark 配下でのみ dark: が効く）。
    prefers-color-scheme 依存だと背景と文字が食い違うため、手動トグルで制御する。 */
 @custom-variant dark (&:where(.dark, .dark *));
+
+/* =========================================================================
+   Apple HIG デザイントークン（#371・iOS/macOS 踏襲の土台）
+   - セマンティックなシステムカラーを CSS 変数で定義し、.dark で値だけ差し替える。
+     → `bg-canvas` 等の Tailwind ユーティリティが light/dark で自動スイッチし、
+       個々の要素に dark: を付けずに済む（移行後の保守を軽くする）。
+   - コントラストは WCAG AA（A11y=100 維持）を満たす値を選定済み。
+   ========================================================================= */
+@theme {
+  /* SF 系システムフォント。日本語は Hiragino をフォールバックに置く。 */
+  --font-sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display",
+    "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Yu Gothic", Meiryo, system-ui, sans-serif;
+
+  /* 背景・面（var 参照で .dark 時に自動スイッチ） */
+  --color-canvas: var(--c-canvas); /* ページ背景（systemGroupedBackground） */
+  --color-surface: var(--c-surface); /* カード（secondarySystemGroupedBackground） */
+  --color-surface-2: var(--c-surface-2); /* 入れ子の面・hover */
+  --color-bar: var(--c-bar); /* ナビ/ツールバー（半透明・blur 前提） */
+
+  /* 文字 */
+  --color-label: var(--c-label);
+  --color-label-2: var(--c-label-2); /* secondaryLabel 相当（AA 確保のため濃いめ） */
+  --color-label-3: var(--c-label-3); /* tertiaryLabel（大文字キャプション用） */
+
+  /* 罫線・アクセント */
+  --color-separator: var(--c-separator);
+  --color-accent: var(--c-accent); /* リンク・選択中テキスト */
+  --color-accent-fill: var(--c-accent-fill); /* 塗りボタンの背景（白文字で AA） */
+  --color-fill-quaternary: var(--c-fill-4); /* セグメント等の薄い面 */
+
+  /* 角丸（iOS のカード ~14、コントロール ~10） */
+  --radius-card: 14px;
+  --radius-control: 10px;
+}
+
+:root {
+  --c-canvas: #f2f2f7;
+  --c-surface: #ffffff;
+  --c-surface-2: #f2f2f7;
+  --c-bar: rgba(249, 249, 251, 0.8);
+  --c-label: #1d1d1f;
+  --c-label-2: #5f5f64;
+  --c-label-3: #8a8a8e;
+  --c-separator: rgba(0, 0, 0, 0.1);
+  --c-accent: #0066cc;
+  --c-accent-fill: #0066cc;
+  --c-fill-4: rgba(118, 118, 128, 0.12);
+}
+
+.dark {
+  --c-canvas: #000000;
+  --c-surface: #1c1c1e;
+  --c-surface-2: #2c2c2e;
+  --c-bar: rgba(30, 30, 32, 0.72);
+  --c-label: #f5f5f7;
+  --c-label-2: #a3a3a8;
+  --c-label-3: #8a8a8e;
+  --c-separator: rgba(255, 255, 255, 0.12);
+  --c-accent: #5aa9ff;
+  --c-accent-fill: #0a84ff;
+  --c-fill-4: rgba(118, 118, 128, 0.24);
+}
+
+html {
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  /* iOS の SF テキスト感に寄せる（字面を少し締める）。 */
+  letter-spacing: -0.01em;
+}
+
+@layer components {
+  /* HIG カード：面 + 角丸 + ヘアライン罫線。全画面共通の基本ブロック。 */
+  .hig-card {
+    background-color: var(--color-surface);
+    border-radius: var(--radius-card);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+    border: 1px solid var(--color-separator);
+  }
+
+  /* 塗りボタン（systemBlue・白文字で AA）。iOS の角丸・押し心地に寄せる。 */
+  .hig-btn-primary {
+    background-color: var(--color-accent-fill);
+    color: #ffffff;
+    border-radius: var(--radius-control);
+    font-weight: 600;
+    transition: filter 0.15s ease, transform 0.05s ease;
+  }
+  .hig-btn-primary:hover {
+    filter: brightness(1.06);
+  }
+  .hig-btn-primary:active {
+    transform: scale(0.98);
+  }
+}


### PR DESCRIPTION
## 概要
モバイル=iOS、PC=macOS のUIを踏襲するデザイン刷新の**土台（第1弾）**。引き継ぎ書の方針「土台先行」に沿う。

## 変更
- **`src/index.css`**：Apple HIG デザイントークンを定義。
  - セマンティックなシステムカラーを CSS 変数で持ち、`:root`/`.dark` で値だけ差し替え → `bg-canvas`/`bg-surface`/`text-label`/`text-label-2`/`border-separator`/`bg-accent-fill`/`text-accent`/`bg-fill-quaternary` が **light/dark 自動スイッチ**（個々に `dark:` 不要）。
  - SF 系システムフォント（日本語は Hiragino）、角丸 `rounded-card`(14)/`rounded-control`(10)、`.hig-card`、`.hig-btn-primary`。
- **`src/App.tsx`**：共通クロムを再スタイル。ヘッダー＝`sticky`+`bg-bar`+`backdrop-blur-xl`、第1段ナビ＝iOS セグメントコントロール（`SegmentTab`）、第2段＝ピル（`PillTab`）、テーマトグルを丸ボタン化。
- **`HomeView` / `QuizView` / `CategoryFilter`**：新トークンへ移行し、以降の各ビュー移行の型を提示。

## 検証
- Chrome DevTools で iOS(390px)・macOS(1280px)、light/dark、ホーム/4択/採点後を確認。
- Lighthouse（mobile・dark / desktop・light採点後）：**A11y=100 / Best Practices=100 / SEO=100**。
- 本番ビルドに axe critical/serious **0件**（ヒーローのグラデを from-sky-700 に上げ AA 確保）。
- `npm run build` green、Vitest **27**、E2E smoke+a11y **7** すべて green。

## 後続（別PR）
- 残りの各ビュー（CardView/Dictionary/Interview/Mock/Guide/ReverseQ/Dashboard/Review/Prep/Learn/Author）をトークンへ順次移行（1ビュー=1PR）。
- PCナビの2案（macOS サイドバー / 上部ツールバー）を実装してテストで比較。

Closes #371