### PR TITLE
feat: HIGトークンへ移行（覚えるグループ：暗記カード・用語辞典）

### DIFF
--- a/term-board/e2e/.gitignore
+++ b/term-board/e2e/.gitignore
@@ -3,3 +3,5 @@ playwright-report/
 test-results/
 /blob-report/
 .playwright/
+# ローカルの a11y デバッグ用スクリプト（コミット対象外）
+axe-debug.mjs

--- a/term-board/src/components/CardView.tsx
+++ b/term-board/src/components/CardView.tsx
@@ -114,20 +114,20 @@ export function CardView() {
   };
 
   if (terms.length === 0) {
-    return <p className="text-center text-slate-500 dark:text-slate-400">カードに使える用語がありません。</p>;
+    return <p className="text-center text-label-2">カードに使える用語がありません。</p>;
   }
 
   return (
     <section className="flex flex-col gap-4" aria-live="polite">
       {/* フィルタ */}
-      <div className="flex flex-wrap items-center gap-3 rounded-2xl bg-white p-3 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
+      <div className="hig-card flex flex-wrap items-center gap-3 p-3">
         <div className="flex items-center gap-2">
-          <label htmlFor="card-cat" className="text-sm font-medium text-slate-600 dark:text-slate-300">分野</label>
+          <label htmlFor="card-cat" className="text-sm font-medium text-label-2">分野</label>
           <select
             id="card-cat"
             value={category}
             onChange={(e) => setCategory(e.target.value)}
-            className="rounded-lg border border-slate-300 bg-white px-2 py-1.5 text-sm text-slate-800 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+            className="rounded-control border border-separator bg-surface px-2 py-1.5 text-sm text-label focus:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
           >
             <option value="">全分野</option>
             {categories.map((c) => (
@@ -135,24 +135,24 @@ export function CardView() {
             ))}
           </select>
         </div>
-        <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+        <label className="flex items-center gap-2 text-sm text-label-2">
           <input type="checkbox" checked={onlyWeak} onChange={(e) => setOnlyWeak(e.target.checked)} className="h-4 w-4" />
           苦手だけ（{weakCount}）
         </label>
         {sessionDone > 0 && (
-          <p className="ml-auto text-sm font-medium text-slate-600 dark:text-slate-300">
+          <p className="ml-auto text-sm font-medium text-label-2">
             このセット：覚えた {sessionKnown} ／ {sessionDone}
           </p>
         )}
       </div>
 
       {pool.length === 0 ? (
-        <p className="text-center text-sm text-slate-500 dark:text-slate-400">
+        <p className="text-center text-sm text-label-2">
           {onlyWeak ? "苦手なカードはありません。よくできています！" : "このカードがありません。"}
         </p>
       ) : current ? (
         <>
-          <p className="text-center text-sm text-slate-500 dark:text-slate-400">
+          <p className="text-center text-sm text-label-2">
             思い出してから裏返しましょう（苦手なカードほど多く出ます）
           </p>
 
@@ -161,34 +161,34 @@ export function CardView() {
             type="button"
             onClick={() => setFlipped((f) => !f)}
             aria-pressed={flipped}
-            className="min-h-56 w-full rounded-2xl bg-white p-6 text-left shadow-sm ring-1 ring-slate-200 transition hover:ring-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:bg-slate-800 dark:ring-slate-700 dark:hover:ring-sky-500"
+            className="hig-card min-h-56 w-full p-6 text-left transition hover:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
           >
             <div className="flex items-center gap-2">
-              <span className="text-sm font-medium text-sky-700 dark:text-sky-400">{current.category}</span>
+              <span className="text-sm font-medium text-accent">{current.category}</span>
               {isWeak(current.id) && (
                 <span className="rounded-full bg-rose-100 px-2 py-0.5 text-xs font-medium text-rose-800 dark:bg-rose-900 dark:text-rose-200">復習</span>
               )}
             </div>
             {!flipped ? (
               <div className="mt-6 flex flex-col items-center justify-center gap-2 text-center">
-                <p className="text-3xl font-bold text-slate-900 dark:text-slate-100">{current.term}</p>
-                <p className="text-xs text-slate-500 dark:text-slate-400">タップで意味を見る</p>
+                <p className="text-3xl font-bold text-label">{current.term}</p>
+                <p className="text-xs text-label-2">タップで意味を見る</p>
               </div>
             ) : (
               <div className="mt-3 flex flex-col gap-2">
-                <p className="text-lg font-bold text-slate-900 dark:text-slate-100">{current.term}</p>
+                <p className="text-lg font-bold text-label">{current.term}</p>
                 {current.plainMeaning && (
-                  <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-200">
-                    <span className="font-semibold text-sky-800 dark:text-sky-300">かんたんに：</span>
+                  <p className="text-sm leading-relaxed text-label">
+                    <span className="font-semibold text-accent">かんたんに：</span>
                     {current.plainMeaning}
                   </p>
                 )}
-                <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
-                  <span className="font-semibold text-slate-900 dark:text-slate-100">意味：</span>
+                <p className="text-sm leading-relaxed text-label-2">
+                  <span className="font-semibold text-label">意味：</span>
                   {current.meaning}
                 </p>
-                <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-400">
-                  <span className="font-semibold text-slate-800 dark:text-slate-200">面接での言い方：</span>
+                <p className="text-sm leading-relaxed text-label-2">
+                  <span className="font-semibold text-label">面接での言い方：</span>
                   {current.interview}
                 </p>
               </div>
@@ -201,14 +201,14 @@ export function CardView() {
               <button
                 type="button"
                 onClick={() => assess(true)}
-                className="rounded-xl bg-emerald-700 px-5 py-2.5 font-semibold text-white transition hover:bg-emerald-800 focus:outline-none focus:ring-2 focus:ring-emerald-400"
+                className="rounded-control bg-emerald-700 px-5 py-2.5 font-semibold text-white transition hover:bg-emerald-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 active:scale-[0.98]"
               >
                 ◯ 覚えた
               </button>
               <button
                 type="button"
                 onClick={() => assess(false)}
-                className="rounded-xl bg-slate-200 px-5 py-2.5 font-semibold text-slate-800 transition hover:bg-slate-300 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600"
+                className="rounded-control bg-fill-quaternary px-5 py-2.5 font-semibold text-label transition hover:brightness-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent active:scale-[0.98]"
               >
                 △ まだ
               </button>
@@ -217,7 +217,7 @@ export function CardView() {
             <button
               type="button"
               onClick={() => setFlipped(true)}
-              className="rounded-xl bg-sky-700 px-5 py-3 font-semibold text-white transition hover:bg-sky-800 focus:outline-none focus:ring-2 focus:ring-sky-400"
+              className="hig-btn-primary px-5 py-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
             >
               意味を見る
             </button>

--- a/term-board/src/components/DictionaryView.tsx
+++ b/term-board/src/components/DictionaryView.tsx
@@ -55,7 +55,7 @@ export function DictionaryView({ bookmarks }: Props) {
 
   return (
     <section className="flex flex-col gap-4">
-      <div className="flex flex-col gap-3 rounded-2xl bg-white p-4 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
+      <div className="hig-card flex flex-col gap-3 p-4">
         <div>
           <label htmlFor="dict-search" className="sr-only">用語を検索</label>
           <input
@@ -64,17 +64,17 @@ export function DictionaryView({ bookmarks }: Props) {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="用語・意味で検索"
-            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-800 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+            className="w-full rounded-control border border-separator bg-surface px-3 py-2 text-sm text-label focus:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
           />
         </div>
         <div className="flex flex-wrap items-center gap-3">
           <div className="flex items-center gap-2">
-            <label htmlFor="dict-cat" className="text-sm font-medium text-slate-600 dark:text-slate-300">分野</label>
+            <label htmlFor="dict-cat" className="text-sm font-medium text-label-2">分野</label>
             <select
               id="dict-cat"
               value={category}
               onChange={(e) => setCategory(e.target.value)}
-              className="rounded-lg border border-slate-300 bg-white px-2 py-1.5 text-sm text-slate-800 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+              className="rounded-control border border-separator bg-surface px-2 py-1.5 text-sm text-label focus:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
             >
               <option value="">すべて</option>
               {categories.map((c) => (
@@ -83,74 +83,74 @@ export function DictionaryView({ bookmarks }: Props) {
             </select>
           </div>
           <div className="flex items-center gap-2">
-            <label htmlFor="dict-sort" className="text-sm font-medium text-slate-600 dark:text-slate-300">並び替え</label>
+            <label htmlFor="dict-sort" className="text-sm font-medium text-label-2">並び替え</label>
             <select
               id="dict-sort"
               value={sort}
               onChange={(e) => setSort(e.target.value as "default" | "asc" | "desc")}
-              className="rounded-lg border border-slate-300 bg-white px-2 py-1.5 text-sm text-slate-800 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+              className="rounded-control border border-separator bg-surface px-2 py-1.5 text-sm text-label focus:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
             >
               <option value="default">標準（分野順）</option>
               <option value="asc">あいうえお順</option>
               <option value="desc">あいうえお順（逆）</option>
             </select>
           </div>
-          <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+          <label className="flex items-center gap-2 text-sm text-label-2">
             <input type="checkbox" checked={onlyBookmarked} onChange={(e) => setOnlyBookmarked(e.target.checked)} className="h-4 w-4" />
             ★ブックマークのみ（{bookmarks.count}）
           </label>
         </div>
       </div>
 
-      <p className="text-sm text-slate-600 dark:text-slate-300">{filtered.length} 件</p>
+      <p className="text-sm text-label-2">{filtered.length} 件</p>
 
       <ul className="flex flex-col gap-2">
         {filtered.map((t) => {
           const open = openId === t.id;
           return (
-            <li key={t.id} className="rounded-xl bg-white shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
+            <li key={t.id} className="hig-card">
               <div className="flex items-center gap-2 p-3">
                 <button
                   type="button"
                   onClick={() => setOpenId(open ? null : t.id)}
                   aria-expanded={open}
-                  className="flex min-w-0 flex-1 items-center gap-2 text-left focus:outline-none focus:ring-2 focus:ring-sky-400"
+                  className="flex min-w-0 flex-1 items-center gap-2 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                 >
-                  <span className="truncate font-semibold text-slate-900 dark:text-slate-100">{t.term}</span>
+                  <span className="truncate font-semibold text-label">{t.term}</span>
                   {t.level && (
-                    <span className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${levelClass[t.level] ?? "bg-slate-100 text-slate-700"}`}>
+                    <span className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${levelClass[t.level] ?? "bg-fill-quaternary text-label-2"}`}>
                       {t.level}
                     </span>
                   )}
-                  <span className="shrink-0 text-xs text-slate-500 dark:text-slate-400">{t.category}</span>
+                  <span className="shrink-0 text-xs text-label-2">{t.category}</span>
                 </button>
                 <button
                   type="button"
                   onClick={() => bookmarks.toggle(t.id)}
                   aria-pressed={bookmarks.isBookmarked(t.id)}
                   aria-label={bookmarks.isBookmarked(t.id) ? `${t.term} のブックマークを外す` : `${t.term} をブックマーク`}
-                  className="shrink-0 rounded-lg px-2 py-1 text-lg focus:outline-none focus:ring-2 focus:ring-sky-400"
+                  className="shrink-0 rounded-lg px-2 py-1 text-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                 >
-                  <span className={bookmarks.isBookmarked(t.id) ? "text-amber-500" : "text-slate-400"}>★</span>
+                  <span className={bookmarks.isBookmarked(t.id) ? "text-amber-500" : "text-label-3"}>★</span>
                 </button>
               </div>
               {open && (
-                <div className="border-t border-slate-100 px-3 py-3 text-sm leading-relaxed dark:border-slate-700">
+                <div className="border-t border-separator px-3 py-3 text-sm leading-relaxed">
                   {t.plainMeaning && (
-                    <p className="text-slate-700 dark:text-slate-300"><span className="font-semibold text-sky-800 dark:text-sky-300">かんたんに：</span>{t.plainMeaning}</p>
+                    <p className="text-label-2"><span className="font-semibold text-accent">かんたんに：</span>{t.plainMeaning}</p>
                   )}
-                  <p className="mt-1 text-slate-700 dark:text-slate-300"><span className="font-semibold text-slate-900 dark:text-slate-100">意味：</span>{t.meaning}</p>
+                  <p className="mt-1 text-label-2"><span className="font-semibold text-label">意味：</span>{t.meaning}</p>
                   {t.scene && (
-                    <p className="mt-1 text-slate-600 dark:text-slate-400"><span className="font-semibold text-slate-800 dark:text-slate-200">現場では：</span>{t.scene}</p>
+                    <p className="mt-1 text-label-2"><span className="font-semibold text-label">現場では：</span>{t.scene}</p>
                   )}
-                  <p className="mt-1 text-slate-600 dark:text-slate-400"><span className="font-semibold text-slate-800 dark:text-slate-200">面接での言い方：</span>{t.interview}</p>
+                  <p className="mt-1 text-label-2"><span className="font-semibold text-label">面接での言い方：</span>{t.interview}</p>
                 </div>
               )}
             </li>
           );
         })}
         {filtered.length === 0 && (
-          <li className="text-center text-sm text-slate-600 dark:text-slate-400">該当する用語がありません。</li>
+          <li className="text-center text-sm text-label-2">該当する用語がありません。</li>
         )}
       </ul>
     </section>


### PR DESCRIPTION
## 概要
Apple HIG デザイン土台（#372）の移行第2弾。「覚える」グループ（暗記カード・用語辞典）を新トークンへ。

## 変更
- `CardView` / `DictionaryView`：`bg-white`/`slate-*`/`ring-slate-*`/`sky-*` を `hig-card`・`text-label`/`text-label-2`・`text-accent`・`bg-fill-quaternary`・`border-separator`・`hig-btn-primary` へ置換。入力/セレクトを `rounded-control border-separator bg-surface`、フォーカスを `focus-visible:ring-accent` に統一。レベルチップ（初級/中級/上級）の意味色（emerald/amber/rose）は維持。
- `e2e/.gitignore`：ローカル a11y デバッグスクリプトを除外。

## 検証
- Chrome DevTools で用語辞典を確認（iOS 風・共通クロムと一貫）。
- 本番ビルドに axe critical/serious **0件**。
- `npm run build` green、Vitest **27**、E2E smoke+a11y **7** green。

Closes #373