### PR TITLE
feat: HIGトークンへ移行（面接対策グループ：面接練習・模擬面接・解説集・逆質問）

### DIFF
--- a/term-board/src/components/GuideView.tsx
+++ b/term-board/src/components/GuideView.tsx
@@ -49,12 +49,12 @@ export function GuideView({ userQuestions }: Props) {
 
   return (
     <section className="flex flex-col gap-4">
-      <p className="rounded-xl bg-sky-50 p-3 text-sm text-slate-700 ring-1 ring-sky-100 dark:bg-sky-950 dark:text-slate-200 dark:ring-sky-900">
+      <p className="rounded-control bg-sky-50 p-3 text-sm text-label ring-1 ring-sky-100 dark:bg-sky-950 dark:ring-sky-900">
         面接で訊かれる<strong className="font-semibold">論点（質問）</strong>の模範解答集です。用語の意味を引きたいときは「用語辞典」をご利用ください。
       </p>
 
       {/* 検索・分類フィルタ */}
-      <div className="flex flex-col gap-3 rounded-2xl bg-white p-4 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
+      <div className="hig-card flex flex-col gap-3 p-4">
         <div>
           <label htmlFor="guide-search" className="sr-only">論点を検索</label>
           <input
@@ -63,16 +63,16 @@ export function GuideView({ userQuestions }: Props) {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="質問・模範解答で検索"
-            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-800 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+            className="w-full rounded-control border border-separator bg-surface px-3 py-2 text-sm text-label focus:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
           />
         </div>
         <div className="flex items-center gap-2">
-          <label htmlFor="guide-cat" className="text-sm font-medium text-slate-600 dark:text-slate-300">分類</label>
+          <label htmlFor="guide-cat" className="text-sm font-medium text-label-2">分類</label>
           <select
             id="guide-cat"
             value={category}
             onChange={(e) => setCategory(e.target.value)}
-            className="rounded-lg border border-slate-300 bg-white px-2 py-1.5 text-sm text-slate-800 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+            className="rounded-control border border-separator bg-surface px-2 py-1.5 text-sm text-label focus:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
           >
             <option value="">すべて</option>
             {categories.map((c) => (
@@ -82,45 +82,45 @@ export function GuideView({ userQuestions }: Props) {
         </div>
       </div>
 
-      <p className="text-sm text-slate-600 dark:text-slate-300">{filtered.length} 件の論点</p>
+      <p className="text-sm text-label-2">{filtered.length} 件の論点</p>
 
       {groups.map((g) => (
         <div key={g.category}>
-          <h2 className="mb-2 border-b-2 border-sky-200 pb-1 text-center text-sm font-bold text-sky-700 dark:border-sky-800 dark:text-sky-400">
+          <h2 className="mb-2 border-b border-separator pb-1 text-center text-sm font-bold text-accent">
             — {g.category} —
           </h2>
           <ul className="flex flex-col gap-2">
             {g.rows.map((e) => {
               const open = openId === e.id;
               return (
-                <li key={e.id} className="rounded-xl bg-white shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
+                <li key={e.id} className="hig-card">
                   <button
                     type="button"
                     onClick={() => setOpenId(open ? null : e.id)}
                     aria-expanded={open}
-                    className="flex w-full items-center gap-3 p-3 text-left focus:outline-none focus:ring-2 focus:ring-sky-400"
+                    className="flex w-full items-center gap-3 p-3 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                   >
-                    <span className="min-w-0 flex-1 text-sm font-medium text-slate-900 dark:text-slate-100">{e.question}</span>
+                    <span className="min-w-0 flex-1 text-sm font-medium text-label">{e.question}</span>
                     <span className="shrink-0 rounded-full bg-sky-100 px-2 py-0.5 text-xs font-medium text-sky-800 dark:bg-sky-900 dark:text-sky-200">{e.category}</span>
-                    <span aria-hidden="true" className="shrink-0 text-sm text-slate-400">{open ? "−" : "＋"}</span>
+                    <span aria-hidden="true" className="shrink-0 text-sm text-label-3">{open ? "−" : "＋"}</span>
                   </button>
                   {open && (
-                    <div className="border-t border-slate-100 px-3 py-3 text-sm leading-relaxed dark:border-slate-700">
-                      <p className="text-slate-700 dark:text-slate-300"><span className="font-semibold text-slate-900 dark:text-slate-100">模範回答：</span>{e.answer}</p>
+                    <div className="border-t border-separator px-3 py-3 text-sm leading-relaxed">
+                      <p className="text-label-2"><span className="font-semibold text-label">模範回答：</span>{e.answer}</p>
                       {e.template && (
-                        <div className="mt-2 rounded-lg bg-sky-50 p-2 ring-1 ring-sky-100 dark:bg-sky-950 dark:ring-sky-900">
-                          <p className="text-slate-700 dark:text-slate-200"><span className="font-semibold text-sky-800 dark:text-sky-300">回答の型：</span>{e.template}</p>
+                        <div className="mt-2 rounded-control bg-sky-50 p-2 ring-1 ring-sky-100 dark:bg-sky-950 dark:ring-sky-900">
+                          <p className="text-label"><span className="font-semibold text-accent">回答の型：</span>{e.template}</p>
                         </div>
                       )}
                       {e.ngExample && (
-                        <div className="mt-2 rounded-lg bg-rose-50 p-2 ring-1 ring-rose-100 dark:bg-rose-950 dark:ring-rose-900">
-                          <p className="text-slate-700 dark:text-slate-200"><span className="font-semibold text-rose-800 dark:text-rose-300">NG例と改善：</span>{e.ngExample}</p>
+                        <div className="mt-2 rounded-control bg-rose-50 p-2 ring-1 ring-rose-100 dark:bg-rose-950 dark:ring-rose-900">
+                          <p className="text-label"><span className="font-semibold text-rose-700 dark:text-rose-300">NG例と改善：</span>{e.ngExample}</p>
                         </div>
                       )}
                       {e.tags && e.tags.length > 0 && (
                         <div className="mt-2 flex flex-wrap gap-1.5">
                           {e.tags.map((tg) => (
-                            <span key={tg} className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600 dark:bg-slate-700 dark:text-slate-300">{tg}</span>
+                            <span key={tg} className="rounded-full bg-fill-quaternary px-2 py-0.5 text-xs font-medium text-label-2">{tg}</span>
                           ))}
                         </div>
                       )}
@@ -133,7 +133,7 @@ export function GuideView({ userQuestions }: Props) {
         </div>
       ))}
       {filtered.length === 0 && (
-        <p className="text-center text-sm text-slate-600 dark:text-slate-400">該当する論点がありません。</p>
+        <p className="text-center text-sm text-label-2">該当する論点がありません。</p>
       )}
     </section>
   );

--- a/term-board/src/components/InterviewView.tsx
+++ b/term-board/src/components/InterviewView.tsx
@@ -82,7 +82,7 @@ export function InterviewView({ userQuestions }: Props) {
 
   if (pool.length === 0) {
     return (
-      <p className="text-center text-slate-500 dark:text-slate-400">
+      <p className="text-center text-label-2">
         面接の質問がありません。「マイ問題」で追加できます。
       </p>
     );
@@ -93,22 +93,22 @@ export function InterviewView({ userQuestions }: Props) {
   return (
     <section className="flex flex-col gap-5" aria-live="polite">
       <div className="flex flex-wrap items-center justify-center gap-3">
-        <p className="text-sm text-slate-500 dark:text-slate-400">
+        <p className="text-sm text-label-2">
           声に出して答えてから「模範回答を見る」
         </p>
         {sessionAsked > 0 && (
-          <p className="text-sm font-medium text-slate-600 dark:text-slate-300" aria-live="polite">
+          <p className="text-sm font-medium text-label-2" aria-live="polite">
             この練習：言えた {sessionSaid} ／ {sessionAsked}
           </p>
         )}
         {tags.length > 0 && (
           <div className="flex items-center gap-2">
-            <label htmlFor="iv-tag" className="text-sm font-medium text-slate-600 dark:text-slate-300">タグ</label>
+            <label htmlFor="iv-tag" className="text-sm font-medium text-label-2">タグ</label>
             <select
               id="iv-tag"
               value={tag}
               onChange={(e) => setTag(e.target.value)}
-              className="rounded-lg border border-slate-300 bg-white px-2 py-1.5 text-sm text-slate-800 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+              className="rounded-control border border-separator bg-surface px-2 py-1.5 text-sm text-label focus:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
             >
               <option value="">すべて</option>
               {tags.map((tg) => (
@@ -119,9 +119,9 @@ export function InterviewView({ userQuestions }: Props) {
         )}
       </div>
 
-      <div className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
+      <div className="hig-card p-6">
         <div className="flex flex-wrap items-center gap-2">
-          <span className="text-sm font-medium text-sky-700 dark:text-sky-400">{current.category}</span>
+          <span className="text-sm font-medium text-accent">{current.category}</span>
           {current.source === "user" && (
             <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900 dark:text-amber-200">
               みんなの問題
@@ -133,47 +133,47 @@ export function InterviewView({ userQuestions }: Props) {
             </span>
           ))}
         </div>
-        <h2 className="mt-1 text-2xl font-bold text-slate-900 dark:text-slate-100">{current.question}</h2>
+        <h2 className="mt-1 text-2xl font-bold text-label">{current.question}</h2>
       </div>
 
       {!revealed ? (
         <button
           type="button"
           onClick={() => setRevealed(true)}
-          className="rounded-xl bg-sky-700 px-5 py-3 font-semibold text-white transition hover:bg-sky-800 focus:outline-none focus:ring-2 focus:ring-sky-400"
+          className="hig-btn-primary px-5 py-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         >
           模範回答を見る
         </button>
       ) : (
-        <div className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-          <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
-            <span className="font-semibold text-slate-900 dark:text-slate-100">模範回答：</span>
+        <div className="hig-card p-6">
+          <p className="text-sm leading-relaxed text-label-2">
+            <span className="font-semibold text-label">模範回答：</span>
             {current.answer}
           </p>
           {current.template && (
-            <div className="mt-3 rounded-xl bg-sky-50 p-3 ring-1 ring-sky-100 dark:bg-sky-950 dark:ring-sky-900">
-              <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-200">
-                <span className="font-semibold text-sky-800 dark:text-sky-300">回答の型：</span>
+            <div className="mt-3 rounded-control bg-sky-50 p-3 ring-1 ring-sky-100 dark:bg-sky-950 dark:ring-sky-900">
+              <p className="text-sm leading-relaxed text-label">
+                <span className="font-semibold text-accent">回答の型：</span>
                 {current.template}
               </p>
             </div>
           )}
           {current.ngExample && (
-            <div className="mt-2 rounded-xl bg-rose-50 p-3 ring-1 ring-rose-100 dark:bg-rose-950 dark:ring-rose-900">
-              <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-200">
-                <span className="font-semibold text-rose-800 dark:text-rose-300">NG例と改善：</span>
+            <div className="mt-2 rounded-control bg-rose-50 p-3 ring-1 ring-rose-100 dark:bg-rose-950 dark:ring-rose-900">
+              <p className="text-sm leading-relaxed text-label">
+                <span className="font-semibold text-rose-700 dark:text-rose-300">NG例と改善：</span>
                 {current.ngExample}
               </p>
             </div>
           )}
           {current.memo && (
-            <p className="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
-              <span className="font-semibold text-slate-800 dark:text-slate-200">メモ：</span>
+            <p className="mt-2 text-sm leading-relaxed text-label-2">
+              <span className="font-semibold text-label">メモ：</span>
               {current.memo}
             </p>
           )}
           <div className="mt-4 flex flex-col gap-2">
-            <p className="text-sm font-medium text-slate-600 dark:text-slate-300">
+            <p className="text-sm font-medium text-label-2">
               自分の言葉で言えましたか？
             </p>
             <div className="flex flex-wrap gap-2">
@@ -181,14 +181,14 @@ export function InterviewView({ userQuestions }: Props) {
                 type="button"
                 onClick={() => selfAssess(true)}
                 autoFocus
-                className="rounded-xl bg-emerald-700 px-5 py-2.5 font-semibold text-white transition hover:bg-emerald-800 focus:outline-none focus:ring-2 focus:ring-emerald-400"
+                className="rounded-control bg-emerald-700 px-5 py-2.5 font-semibold text-white transition hover:bg-emerald-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 active:scale-[0.98]"
               >
                 ◯ 言えた
               </button>
               <button
                 type="button"
                 onClick={() => selfAssess(false)}
-                className="rounded-xl bg-slate-200 px-5 py-2.5 font-semibold text-slate-800 transition hover:bg-slate-300 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600"
+                className="rounded-control bg-fill-quaternary px-5 py-2.5 font-semibold text-label transition hover:brightness-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent active:scale-[0.98]"
               >
                 △ 言えなかった
               </button>

--- a/term-board/src/components/MockInterviewView.tsx
+++ b/term-board/src/components/MockInterviewView.tsx
@@ -108,7 +108,7 @@ export function MockInterviewView() {
 
   if (terms.length === 0 || !current) {
     return (
-      <p className="text-center text-slate-500 dark:text-slate-400">
+      <p className="text-center text-label-2">
         模擬面接に使える用語がありません。
       </p>
     );
@@ -117,20 +117,20 @@ export function MockInterviewView() {
   return (
     <section className="flex flex-col gap-5" aria-live="polite">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <p className="text-sm text-slate-500 dark:text-slate-400">
+        <p className="text-sm text-label-2">
           面接官になったつもりで、結論から声に出して説明しましょう。
         </p>
         {sessionAsked > 0 && (
-          <p className="text-sm font-medium text-slate-600 dark:text-slate-300">
+          <p className="text-sm font-medium text-label-2">
             この模擬面接：言えた {sessionSaid} ／ {sessionAsked}
           </p>
         )}
       </div>
 
       {/* 質問 */}
-      <div className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-        <p className="text-sm font-medium text-sky-700 dark:text-sky-400">{current.category}</p>
-        <h2 className="mt-1 text-2xl font-bold text-slate-900 dark:text-slate-100">
+      <div className="hig-card p-6">
+        <p className="text-sm font-medium text-accent">{current.category}</p>
+        <h2 className="mt-1 text-2xl font-bold text-label">
           「{current.term}」について、面接官に説明してください。
         </h2>
       </div>
@@ -140,14 +140,14 @@ export function MockInterviewView() {
         <button
           type="button"
           onClick={startTimer}
-          className="rounded-xl bg-slate-200 px-4 py-2 text-sm font-semibold text-slate-800 transition hover:bg-slate-300 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600"
+          className="rounded-control bg-fill-quaternary px-4 py-2 text-sm font-semibold text-label transition hover:brightness-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         >
           ⏱ 30秒で結論（タイマー開始）
         </button>
         {timerLabel && (
           <span
             className={`text-sm font-bold ${
-              remaining === 0 ? "text-rose-700 dark:text-rose-400" : "text-slate-700 dark:text-slate-200"
+              remaining === 0 ? "text-rose-700 dark:text-rose-400" : "text-label"
             }`}
             role="status"
           >
@@ -158,7 +158,7 @@ export function MockInterviewView() {
 
       {/* 任意入力（声に出す代わりにメモしてもよい） */}
       <div>
-        <label htmlFor="mock-answer" className="text-sm font-medium text-slate-600 dark:text-slate-300">
+        <label htmlFor="mock-answer" className="text-sm font-medium text-label-2">
           自分の答え（任意・声に出す代わりにメモしても）
         </label>
         <textarea
@@ -167,7 +167,7 @@ export function MockInterviewView() {
           onChange={(e) => setInput(e.target.value)}
           rows={3}
           placeholder="結論 →（理由・具体）の順で…"
-          className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+          className="mt-1 w-full rounded-control border border-separator bg-surface px-3 py-2 text-sm text-label focus:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         />
       </div>
 
@@ -175,24 +175,24 @@ export function MockInterviewView() {
         <button
           type="button"
           onClick={reveal}
-          className="rounded-xl bg-sky-700 px-5 py-3 font-semibold text-white transition hover:bg-sky-800 focus:outline-none focus:ring-2 focus:ring-sky-400"
+          className="hig-btn-primary px-5 py-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         >
           模範解答と比べる
         </button>
       ) : (
-        <div className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-          <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
-            <span className="font-semibold text-slate-900 dark:text-slate-100">模範解答：</span>
+        <div className="hig-card p-6">
+          <p className="text-sm leading-relaxed text-label-2">
+            <span className="font-semibold text-label">模範解答：</span>
             {current.interview}
           </p>
-          <p className="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
-            <span className="font-semibold text-slate-800 dark:text-slate-200">正しい意味：</span>
+          <p className="mt-2 text-sm leading-relaxed text-label-2">
+            <span className="font-semibold text-label">正しい意味：</span>
             {current.meaning}
           </p>
           {input.trim() && (
-            <div className="mt-3 rounded-xl bg-slate-50 p-3 ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-700">
-              <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-200">
-                <span className="font-semibold text-slate-800 dark:text-slate-100">あなたの答え：</span>
+            <div className="mt-3 rounded-control bg-surface-2 p-3">
+              <p className="text-sm leading-relaxed text-label">
+                <span className="font-semibold text-label">あなたの答え：</span>
                 {input}
               </p>
             </div>
@@ -202,8 +202,8 @@ export function MockInterviewView() {
               <p className="text-sm font-semibold text-amber-800 dark:text-amber-300">深掘りも想定しておきましょう</p>
               <ul className="mt-1 flex flex-col gap-2">
                 {current.followUps.map((f, i) => (
-                  <li key={i} className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
-                    <span className="font-semibold text-slate-800 dark:text-slate-100">Q. {f.q}</span>
+                  <li key={i} className="text-sm leading-relaxed text-label-2">
+                    <span className="font-semibold text-label">Q. {f.q}</span>
                     <br />
                     A. {f.a}
                   </li>
@@ -213,8 +213,8 @@ export function MockInterviewView() {
           )}
 
           <div className="mt-4 flex flex-col gap-2">
-            <p className="text-sm font-medium text-slate-600 dark:text-slate-300">
-              自己採点（3観点）<span className="ml-2 font-bold text-sky-700 dark:text-sky-400">{rubricScore} / 3</span>
+            <p className="text-sm font-medium text-label-2">
+              自己採点（3観点）<span className="ml-2 font-bold text-accent">{rubricScore} / 3</span>
             </p>
             <fieldset className="flex flex-col gap-1.5">
               <legend className="sr-only">構造採点ルーブリック</legend>
@@ -223,12 +223,12 @@ export function MockInterviewView() {
                 ["reason", "理由を説明した"],
                 ["concrete", "具体例・現場のイメージを出した"],
               ] as const).map(([key, label]) => (
-                <label key={key} className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+                <label key={key} className="flex items-center gap-2 text-sm text-label">
                   <input
                     type="checkbox"
                     checked={rubric[key]}
                     onChange={(e) => setRubric((r) => ({ ...r, [key]: e.target.checked }))}
-                    className="h-4 w-4 rounded border-slate-400 text-sky-700 focus:ring-2 focus:ring-sky-400 dark:border-slate-500"
+                    className="h-4 w-4 rounded border-separator text-accent focus-visible:ring-2 focus-visible:ring-accent"
                   />
                   {label}
                 </label>
@@ -238,7 +238,7 @@ export function MockInterviewView() {
               type="button"
               onClick={submitAssessment}
               autoFocus
-              className="mt-1 self-start rounded-xl bg-sky-700 px-5 py-2.5 font-semibold text-white transition hover:bg-sky-800 focus:outline-none focus:ring-2 focus:ring-sky-400"
+              className="hig-btn-primary mt-1 self-start px-5 py-2.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
             >
               記録して次へ →
             </button>

--- a/term-board/src/components/ReverseQuestionStock.tsx
+++ b/term-board/src/components/ReverseQuestionStock.tsx
@@ -45,9 +45,9 @@ export function ReverseQuestionStock() {
   const availablePresets = PRESETS.filter((p) => !items.includes(p));
 
   return (
-    <section className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <h2 className="text-sm font-semibold text-slate-700 dark:text-slate-300">逆質問ストック</h2>
-      <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
+    <section className="hig-card p-5">
+      <h2 className="text-sm font-semibold text-label">逆質問ストック</h2>
+      <p className="mt-0.5 text-xs text-label-2">
         「最後に何か質問は？」に備えて、聞きたいことを貯めておきましょう。
       </p>
 
@@ -66,11 +66,11 @@ export function ReverseQuestionStock() {
           onChange={(e) => setDraft(e.target.value)}
           placeholder="自分の逆質問を追加…"
           aria-label="逆質問を入力"
-          className="flex-1 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+          className="flex-1 rounded-control border border-separator bg-surface px-3 py-2 text-sm text-label focus:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         />
         <button
           type="submit"
-          className="rounded-lg bg-sky-700 px-4 py-2 text-sm font-semibold text-white transition hover:bg-sky-800 focus:outline-none focus:ring-2 focus:ring-sky-400"
+          className="hig-btn-primary px-4 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         >
           追加
         </button>
@@ -78,12 +78,12 @@ export function ReverseQuestionStock() {
 
       {/* ストック一覧 */}
       {loaded && items.length === 0 ? (
-        <p className="mt-3 text-sm text-slate-500 dark:text-slate-400">まだありません。下の候補や自由入力から追加できます。</p>
+        <p className="mt-3 text-sm text-label-2">まだありません。下の候補や自由入力から追加できます。</p>
       ) : (
         <ul className="mt-3 flex flex-col gap-2">
           {items.map((q) => (
-            <li key={q} className="flex items-start justify-between gap-3 rounded-lg bg-slate-50 px-3 py-2 dark:bg-slate-900">
-              <span className="text-sm text-slate-800 dark:text-slate-200">{q}</span>
+            <li key={q} className="flex items-start justify-between gap-3 rounded-control bg-surface-2 px-3 py-2">
+              <span className="text-sm text-label">{q}</span>
               <button
                 type="button"
                 onClick={() => remove(q)}
@@ -100,14 +100,14 @@ export function ReverseQuestionStock() {
       {/* プリセット候補 */}
       {availablePresets.length > 0 && (
         <div className="mt-4">
-          <p className="text-xs font-medium text-slate-600 dark:text-slate-300">候補から追加：</p>
+          <p className="text-xs font-medium text-label-2">候補から追加：</p>
           <div className="mt-2 flex flex-col gap-2">
             {availablePresets.map((p) => (
               <button
                 key={p}
                 type="button"
                 onClick={() => add(p)}
-                className="rounded-lg border border-dashed border-slate-300 px-3 py-2 text-left text-sm text-slate-700 transition hover:border-sky-400 hover:bg-sky-50 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:border-slate-600 dark:text-slate-300 dark:hover:border-sky-500 dark:hover:bg-slate-700"
+                className="rounded-control border border-dashed border-separator px-3 py-2 text-left text-sm text-label-2 transition hover:border-accent hover:text-label focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
               >
                 ＋ {p}
               </button>


### PR DESCRIPTION
## 概要
Apple HIG デザイン土台（#372）の移行第3弾。「面接対策」グループの4ビューを新トークンへ。

## 変更
- `InterviewView` / `MockInterviewView` / `GuideView` / `ReverseQuestionStock`：`bg-white`/`slate-*`/`ring-slate-*`/`sky-*` を `hig-card`・`text-label`/`text-label-2`・`text-accent`・`hig-btn-primary`・`bg-fill-quaternary`・`border-separator` へ。入力/セレクト/textarea を `rounded-control border-separator bg-surface`、補助ボタンを `bg-fill-quaternary`、フォーカスを `focus-visible:ring-accent` に統一。
- 意味色は維持：回答の型（sky）/ NG例（rose）/ 深掘り（amber）/ タグ・カテゴリチップ（sky/amber）。

## 検証
- Chrome DevTools で面接練習（質問・模範回答・型・NG例・自己採点ボタン）を確認。
- `npm run build` green、Vitest **27**、E2E smoke+a11y **7** green（critical 0）。

Closes #375