### PR TITLE
feat: HIGトークンへ移行（学ぶ・記録グループ：ダッシュボード・振り返り・自己PR・学ぶ）

### DIFF
--- a/term-board/src/components/DashboardView.tsx
+++ b/term-board/src/components/DashboardView.tsx
@@ -135,7 +135,7 @@ export function DashboardView({ bookmarks }: Props) {
     return "知識も「言える」も好調です。この調子で続けましょう。";
   }, [totals.answered, weakTerms, unlearned, interview]);
 
-  const card = "rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700";
+  const card = "hig-card p-5";
 
   return (
     <section className="flex flex-col gap-4">
@@ -149,22 +149,22 @@ export function DashboardView({ bookmarks }: Props) {
 
       {/* 学習おすすめ */}
       <div className={card}>
-        <h2 className="text-sm font-semibold text-sky-700 dark:text-sky-400">学習おすすめ</h2>
-        <p className="mt-1 text-slate-800 dark:text-slate-100">{recommendation}</p>
+        <h2 className="text-sm font-semibold text-accent">学習おすすめ</h2>
+        <p className="mt-1 text-label">{recommendation}</p>
       </div>
 
       {/* 面接練習の実績（F-INTV-02） */}
       <div className={card}>
-        <h2 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-300">面接練習の実績</h2>
+        <h2 className="mb-2 text-sm font-semibold text-label-2">面接練習の実績</h2>
         {interview.asked === 0 ? (
-          <p className="text-sm text-slate-500 dark:text-slate-400">
+          <p className="text-sm text-label-2">
             まだ面接練習の記録がありません。「面接練習」で答えて自己採点しましょう。
           </p>
         ) : (
           <div className="flex items-center justify-between gap-3">
-            <p className="text-sm text-slate-700 dark:text-slate-300">
-              練習回数 <span className="font-semibold text-slate-900 dark:text-slate-100">{interview.asked}</span> 回
-              <span className="ml-2">言えた <span className="font-semibold text-slate-900 dark:text-slate-100">{interview.said}</span> 回</span>
+            <p className="text-sm text-label-2">
+              練習回数 <span className="font-semibold text-label">{interview.asked}</span> 回
+              <span className="ml-2">言えた <span className="font-semibold text-label">{interview.said}</span> 回</span>
             </p>
             <p className="text-sm">
               言えた率 <span className="font-bold text-emerald-700 dark:text-emerald-400">{interview.rate}%</span>
@@ -175,21 +175,21 @@ export function DashboardView({ bookmarks }: Props) {
 
       {/* 分野別正答率 */}
       <div className={card}>
-        <h2 className="mb-3 text-sm font-semibold text-slate-700 dark:text-slate-300">分野別の正答率</h2>
+        <h2 className="mb-3 text-sm font-semibold text-label-2">分野別の正答率</h2>
         {catStats.length === 0 ? (
-          <p className="text-sm text-slate-500 dark:text-slate-400">まだ解答記録がありません。</p>
+          <p className="text-sm text-label-2">まだ解答記録がありません。</p>
         ) : (
           <ul className="flex flex-col gap-3">
             {catStats.map((c) => (
               <li key={c.category}>
                 <div className="flex items-center justify-between text-sm">
-                  <span className="text-slate-700 dark:text-slate-300">{c.category}</span>
-                  <span className="font-semibold text-slate-900 dark:text-slate-100">
-                    {c.rate}%<span className="ml-1 text-xs font-normal text-slate-500 dark:text-slate-400">（{c.correct}/{c.correct + c.wrong}）</span>
+                  <span className="text-label-2">{c.category}</span>
+                  <span className="font-semibold text-label">
+                    {c.rate}%<span className="ml-1 text-xs font-normal text-label-2">（{c.correct}/{c.correct + c.wrong}）</span>
                   </span>
                 </div>
-                <div className="mt-1 h-2 w-full overflow-hidden rounded-full bg-slate-200 dark:bg-slate-700">
-                  <div className="h-full rounded-full bg-sky-600 dark:bg-sky-500" style={{ width: `${c.rate}%` }} />
+                <div className="mt-1 h-2 w-full overflow-hidden rounded-full bg-fill-quaternary">
+                  <div className="h-full rounded-full bg-accent-fill" style={{ width: `${c.rate}%` }} />
                 </div>
               </li>
             ))}
@@ -199,14 +199,14 @@ export function DashboardView({ bookmarks }: Props) {
 
       {/* 苦手用語 */}
       <div className={card}>
-        <h2 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-300">苦手な用語（要復習）</h2>
+        <h2 className="mb-2 text-sm font-semibold text-label-2">苦手な用語（要復習）</h2>
         {weakTerms.length === 0 ? (
-          <p className="text-sm text-slate-500 dark:text-slate-400">苦手な用語はまだありません。</p>
+          <p className="text-sm text-label-2">苦手な用語はまだありません。</p>
         ) : (
           <ul className="flex flex-col gap-2">
             {weakTerms.map((w) => (
               <li key={w.term.id} className="flex items-center justify-between gap-3 text-sm">
-                <span className="truncate text-slate-800 dark:text-slate-200">{w.term.term}</span>
+                <span className="truncate text-label">{w.term.term}</span>
                 <span className="shrink-0 text-rose-700 dark:text-rose-400">
                   誤答 {w.wrong}/{w.total}
                 </span>
@@ -219,12 +219,12 @@ export function DashboardView({ bookmarks }: Props) {
       {/* 混同ペア分析（F-QUIZ-06） */}
       {confusions.length > 0 && (
         <div className={card}>
-          <h2 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-300">混同しやすい用語</h2>
-          <p className="mb-3 text-xs text-slate-500 dark:text-slate-400">4択で選んだ誤答と、正しい意味を見比べましょう。</p>
+          <h2 className="mb-2 text-sm font-semibold text-label-2">混同しやすい用語</h2>
+          <p className="mb-3 text-xs text-label-2">4択で選んだ誤答と、正しい意味を見比べましょう。</p>
           <ul className="flex flex-col gap-3">
             {confusions.map((c) => (
               <li key={c.term.id}>
-                <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">{c.term.term}</p>
+                <p className="text-sm font-semibold text-label">{c.term.term}</p>
                 {c.chosen.map((ch) => (
                   <p key={ch} className="mt-1 text-sm leading-relaxed text-rose-700 dark:text-rose-400">
                     ✕ 選んだ誤答：{ch}
@@ -239,7 +239,7 @@ export function DashboardView({ bookmarks }: Props) {
         </div>
       )}
 
-      <p className="text-center text-xs text-slate-500 dark:text-slate-400">
+      <p className="text-center text-xs text-label-2">
         学習日数 {studyDays.length} 日 ／ 未学習 {unlearned} 件
       </p>
 
@@ -250,9 +250,9 @@ export function DashboardView({ bookmarks }: Props) {
 
 function Stat({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded-xl bg-white px-3 py-3 text-center shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-      <p className="text-xs text-slate-500 dark:text-slate-400">{label}</p>
-      <p className="mt-0.5 text-lg font-bold text-slate-900 dark:text-slate-100">{value}</p>
+    <div className="hig-card px-3 py-3 text-center">
+      <p className="text-xs text-label-2">{label}</p>
+      <p className="mt-0.5 text-lg font-bold text-label">{value}</p>
     </div>
   );
 }

--- a/term-board/src/components/DataManager.tsx
+++ b/term-board/src/components/DataManager.tsx
@@ -51,33 +51,33 @@ export function DataManager() {
     setTimeout(() => window.location.reload(), 800);
   };
 
-  const card = "rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700";
+  const card = "hig-card p-5";
 
   return (
     <div className={card}>
-      <h2 className="text-sm font-semibold text-slate-700 dark:text-slate-300">データ管理</h2>
-      <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+      <h2 className="text-sm font-semibold text-label">データ管理</h2>
+      <p className="mt-1 text-xs text-label-2">
         データはこのブラウザにのみ保存されます。機種変更やバックアップにはエクスポートをご利用ください。
       </p>
       <div className="mt-3 flex flex-wrap gap-2">
         <button
           type="button"
           onClick={handleExport}
-          className="rounded-xl bg-sky-700 px-4 py-2 text-sm font-semibold text-white transition hover:bg-sky-800 focus:outline-none focus:ring-2 focus:ring-sky-400"
+          className="hig-btn-primary px-4 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         >
           エクスポート（保存）
         </button>
         <button
           type="button"
           onClick={() => fileRef.current?.click()}
-          className="rounded-xl bg-slate-200 px-4 py-2 text-sm font-semibold text-slate-800 transition hover:bg-slate-300 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600"
+          className="rounded-control bg-fill-quaternary px-4 py-2 text-sm font-semibold text-label transition hover:brightness-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         >
           インポート（復元）
         </button>
         <button
           type="button"
           onClick={handleReset}
-          className="rounded-xl bg-white px-4 py-2 text-sm font-semibold text-rose-700 ring-1 ring-rose-300 transition hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-rose-400 dark:bg-slate-800 dark:text-rose-300 dark:ring-rose-800 dark:hover:bg-rose-950"
+          className="rounded-control bg-surface px-4 py-2 text-sm font-semibold text-rose-700 ring-1 ring-rose-300 transition hover:bg-rose-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 dark:text-rose-300 dark:ring-rose-800 dark:hover:bg-rose-950"
         >
           進捗をリセット
         </button>

--- a/term-board/src/components/LearnView.tsx
+++ b/term-board/src/components/LearnView.tsx
@@ -10,7 +10,7 @@ const jobRoles = jobRolesData as JobRole[];
 
 type Tab = "roadmap" | "jobs" | "diagram";
 
-const card = "rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700";
+const card = "hig-card p-5";
 const chip = "rounded-full bg-sky-100 px-2 py-0.5 text-xs font-medium text-sky-800 dark:bg-sky-900 dark:text-sky-200";
 
 // B6: 学ぶ指針（学習ロードマップ・業界職種解説・図解説明）。
@@ -30,12 +30,12 @@ export function LearnView() {
           {roadmap.map((s) => (
             <li key={s.step} className={card}>
               <div className="flex items-center gap-3">
-                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-sky-700 text-sm font-bold text-white">
+                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-accent-fill text-sm font-bold text-white">
                   {s.step}
                 </span>
-                <h2 className="font-bold text-slate-900 dark:text-slate-100">{s.title}</h2>
+                <h2 className="font-bold text-label">{s.title}</h2>
               </div>
-              <p className="mt-2 text-sm leading-relaxed text-slate-700 dark:text-slate-300">{s.desc}</p>
+              <p className="mt-2 text-sm leading-relaxed text-label-2">{s.desc}</p>
               {s.keywords.length > 0 && (
                 <div className="mt-2 flex flex-wrap gap-1.5">
                   {s.keywords.map((k) => (
@@ -52,9 +52,9 @@ export function LearnView() {
         <ul className="flex flex-col gap-3">
           {jobRoles.map((j) => (
             <li key={j.role} className={card}>
-              <h2 className="font-bold text-slate-900 dark:text-slate-100">{j.role}</h2>
-              <p className="mt-1 text-sm font-medium text-sky-700 dark:text-sky-400">{j.summary}</p>
-              <p className="mt-1 text-sm leading-relaxed text-slate-700 dark:text-slate-300">{j.doing}</p>
+              <h2 className="font-bold text-label">{j.role}</h2>
+              <p className="mt-1 text-sm font-medium text-accent">{j.summary}</p>
+              <p className="mt-1 text-sm leading-relaxed text-label-2">{j.doing}</p>
               {j.keywords.length > 0 && (
                 <div className="mt-2 flex flex-wrap gap-1.5">
                   {j.keywords.map((k) => (
@@ -89,13 +89,13 @@ export function LearnView() {
 function ClientServerDiagram() {
   return (
     <figure className={card}>
-      <figcaption className="font-bold text-slate-900 dark:text-slate-100">クライアントとサーバー</figcaption>
-      <p className="mt-1 mb-3 text-sm text-slate-700 dark:text-slate-300">
+      <figcaption className="font-bold text-label">クライアントとサーバー</figcaption>
+      <p className="mt-1 mb-3 text-sm text-label-2">
         ブラウザ（クライアント）が「ください」と頼み、サーバーが「どうぞ」と返す関係。
       </p>
       <div className="flex items-center justify-center gap-3 text-center text-sm">
         <Box label="ブラウザ" sub="クライアント" />
-        <div className="flex flex-col items-center text-xs text-slate-500 dark:text-slate-400">
+        <div className="flex flex-col items-center text-xs text-label-2">
           <span aria-hidden="true">→ リクエスト</span>
           <span aria-hidden="true">← レスポンス</span>
         </div>
@@ -109,8 +109,8 @@ function ClientServerDiagram() {
 function RequestFlowDiagram() {
   return (
     <figure className={card}>
-      <figcaption className="font-bold text-slate-900 dark:text-slate-100">ページが表示されるまで</figcaption>
-      <p className="mt-1 mb-3 text-sm text-slate-700 dark:text-slate-300">
+      <figcaption className="font-bold text-label">ページが表示されるまで</figcaption>
+      <p className="mt-1 mb-3 text-sm text-label-2">
         名前を住所に変換し（DNS）、確実に届け（TCP/IP）、暗号化して安全にやりとりする（HTTPS）。
       </p>
       <ol className="flex flex-col gap-2 sm:flex-row sm:items-stretch">
@@ -130,8 +130,8 @@ function RequestFlowDiagram() {
 function ThreeTierDiagram() {
   return (
     <figure className={card}>
-      <figcaption className="font-bold text-slate-900 dark:text-slate-100">アプリの3層構造</figcaption>
-      <p className="mt-1 mb-3 text-sm text-slate-700 dark:text-slate-300">
+      <figcaption className="font-bold text-label">アプリの3層構造</figcaption>
+      <p className="mt-1 mb-3 text-sm text-label-2">
         画面・処理・保存で役割を分ける。フロントは見た目、バックは処理とAPI、DBはデータ保存を担う。
       </p>
       <ol className="flex flex-col gap-2 sm:flex-row sm:items-stretch">
@@ -149,8 +149,8 @@ function ThreeTierDiagram() {
 function TestTypesDiagram() {
   return (
     <figure className={card}>
-      <figcaption className="font-bold text-slate-900 dark:text-slate-100">テストの種類</figcaption>
-      <p className="mt-1 mb-3 text-sm text-slate-700 dark:text-slate-300">
+      <figcaption className="font-bold text-label">テストの種類</figcaption>
+      <p className="mt-1 mb-3 text-sm text-label-2">
         小さく速い単体から、つないで確認する結合、ユーザー操作全体のE2Eへ。役割を分けて組み合わせる。
       </p>
       <ol className="flex flex-col gap-2 sm:flex-row sm:items-stretch">
@@ -233,8 +233,8 @@ const COMPARE_DIAGRAMS: Compare[] = [
 function FlowDiagram({ title, desc, steps }: Flow) {
   return (
     <figure className={card}>
-      <figcaption className="font-bold text-slate-900 dark:text-slate-100">{title}</figcaption>
-      <p className="mt-1 mb-3 text-sm text-slate-700 dark:text-slate-300">{desc}</p>
+      <figcaption className="font-bold text-label">{title}</figcaption>
+      <p className="mt-1 mb-3 text-sm text-label-2">{desc}</p>
       <ol className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-stretch">
         {steps.map((s, i) => (
           <Fragment key={s.t + i}>
@@ -250,13 +250,13 @@ function FlowDiagram({ title, desc, steps }: Flow) {
 function CompareDiagram({ title, desc, left, right }: Compare) {
   return (
     <figure className={card}>
-      <figcaption className="font-bold text-slate-900 dark:text-slate-100">{title}</figcaption>
-      <p className="mt-1 mb-3 text-sm text-slate-700 dark:text-slate-300">{desc}</p>
+      <figcaption className="font-bold text-label">{title}</figcaption>
+      <p className="mt-1 mb-3 text-sm text-label-2">{desc}</p>
       <div className="grid grid-cols-2 gap-3">
         {[left, right].map((col) => (
           <div key={col.label} className="rounded-xl border-2 border-sky-300 bg-sky-50 p-3 dark:border-sky-700 dark:bg-sky-950">
-            <p className="text-sm font-bold text-slate-900 dark:text-slate-100">{col.label}</p>
-            <ul className="mt-1 list-disc space-y-0.5 pl-4 text-xs text-slate-600 dark:text-slate-300">
+            <p className="text-sm font-bold text-label">{col.label}</p>
+            <ul className="mt-1 list-disc space-y-0.5 pl-4 text-xs text-label-2">
               {col.points.map((p) => (
                 <li key={p}>{p}</li>
               ))}
@@ -271,19 +271,19 @@ function CompareDiagram({ title, desc, left, right }: Compare) {
 function Box({ label, sub }: { label: string; sub: string }) {
   return (
     <div className="rounded-xl border-2 border-sky-300 bg-sky-50 px-4 py-3 dark:border-sky-700 dark:bg-sky-950">
-      <p className="font-bold text-slate-900 dark:text-slate-100">{label}</p>
-      <p className="text-xs text-slate-600 dark:text-slate-300">{sub}</p>
+      <p className="font-bold text-label">{label}</p>
+      <p className="text-xs text-label-2">{sub}</p>
     </div>
   );
 }
 
 function Step({ n, t, d }: { n: string; t: string; d: string }) {
   return (
-    <li className="flex flex-1 items-center gap-2 rounded-xl bg-slate-100 px-3 py-2 dark:bg-slate-700">
-      <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-sky-700 text-xs font-bold text-white">{n}</span>
+    <li className="flex flex-1 items-center gap-2 rounded-control bg-surface-2 px-3 py-2">
+      <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent-fill text-xs font-bold text-white">{n}</span>
       <span>
-        <span className="block text-sm font-semibold text-slate-900 dark:text-slate-100">{t}</span>
-        <span className="block text-xs text-slate-600 dark:text-slate-300">{d}</span>
+        <span className="block text-sm font-semibold text-label">{t}</span>
+        <span className="block text-xs text-label-2">{d}</span>
       </span>
     </li>
   );
@@ -291,7 +291,7 @@ function Step({ n, t, d }: { n: string; t: string; d: string }) {
 
 function Arrow() {
   return (
-    <li aria-hidden="true" className="flex items-center justify-center text-slate-400 dark:text-slate-500">
+    <li aria-hidden="true" className="flex items-center justify-center text-label-3">
       <span className="hidden sm:inline">→</span>
       <span className="sm:hidden">↓</span>
     </li>
@@ -305,8 +305,8 @@ function SubTab({ active, onClick, children }: { active: boolean; onClick: () =>
       role="tab"
       aria-selected={active}
       onClick={onClick}
-      className={`rounded-lg px-3 py-1.5 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-sky-400 ${
-        active ? "bg-sky-700 text-white" : "bg-white text-slate-600 ring-1 ring-slate-300 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-600"
+      className={`rounded-full px-3.5 py-1.5 text-sm font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+        active ? "bg-accent-fill text-white" : "bg-surface text-label-2 ring-1 ring-separator hover:text-label"
       }`}
     >
       {children}

--- a/term-board/src/components/PrepView.tsx
+++ b/term-board/src/components/PrepView.tsx
@@ -4,9 +4,9 @@ import { useProfileDraft } from "../hooks/useProfileDraft";
 type Tab = "selfIntro" | "motivation";
 
 const inputClass =
-  "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-800 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100";
-const labelClass = "block text-sm font-medium text-slate-700 dark:text-slate-300";
-const card = "rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700";
+  "w-full rounded-control border border-separator bg-surface px-3 py-2 text-sm text-label focus:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent";
+const labelClass = "block text-sm font-medium text-label-2";
+const card = "hig-card p-5";
 
 // B5: 自己紹介作成・志望動機整理。穴埋め → 下書き生成 → コピー。保存は自動（localStorage）。
 export function PrepView() {
@@ -52,7 +52,7 @@ export function PrepView() {
       </div>
 
       <div className={`${card} flex flex-col gap-3`}>
-        <p className="text-sm text-slate-600 dark:text-slate-300">
+        <p className="text-sm text-label-2">
           項目を埋めると下書きが組み上がります。入力は自動保存されます。
         </p>
         {tab === "selfIntro" ? (
@@ -75,17 +75,17 @@ export function PrepView() {
 
       <div className={card}>
         <div className="flex items-center justify-between">
-          <h2 className="text-sm font-semibold text-slate-700 dark:text-slate-300">下書き</h2>
+          <h2 className="text-sm font-semibold text-label">下書き</h2>
           <button
             type="button"
             onClick={copy}
             disabled={!generated}
-            className="rounded-lg px-3 py-1 text-sm font-medium text-sky-700 ring-1 ring-sky-200 transition hover:bg-sky-50 focus:outline-none focus:ring-2 focus:ring-sky-400 disabled:text-slate-400 disabled:ring-slate-200 dark:text-sky-300 dark:ring-sky-800 dark:hover:bg-slate-700"
+            className="rounded-control px-3 py-1 text-sm font-medium text-accent ring-1 ring-separator transition hover:bg-fill-quaternary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:text-label-3"
           >
             {copied ? "コピーしました" : "コピー"}
           </button>
         </div>
-        <p className="mt-2 min-h-[3rem] whitespace-pre-wrap text-sm leading-relaxed text-slate-800 dark:text-slate-100">
+        <p className="mt-2 min-h-[3rem] whitespace-pre-wrap text-sm leading-relaxed text-label">
           {generated || "上の項目を入力すると、ここに下書きが表示されます。"}
         </p>
       </div>
@@ -121,8 +121,8 @@ function SubTab({ active, onClick, children }: { active: boolean; onClick: () =>
       role="tab"
       aria-selected={active}
       onClick={onClick}
-      className={`rounded-lg px-3 py-1.5 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-sky-400 ${
-        active ? "bg-sky-700 text-white" : "bg-white text-slate-600 ring-1 ring-slate-300 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-600"
+      className={`rounded-full px-3.5 py-1.5 text-sm font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+        active ? "bg-accent-fill text-white" : "bg-surface text-label-2 ring-1 ring-separator hover:text-label"
       }`}
     >
       {children}

--- a/term-board/src/components/ReviewView.tsx
+++ b/term-board/src/components/ReviewView.tsx
@@ -73,37 +73,37 @@ export function ReviewView() {
     return [...map.values()].sort((a, b) => (a.date < b.date ? 1 : -1));
   }, [log, studyDays, notes]);
 
-  const card = "rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700";
+  const card = "hig-card p-5";
 
   return (
     <section className="flex flex-col gap-4">
       {/* 今日のメモ（F-LOG-03） */}
       <div className={card}>
-        <label htmlFor="today-note" className="text-sm font-semibold text-sky-700 dark:text-sky-400">
+        <label htmlFor="today-note" className="text-sm font-semibold text-accent">
           今日の学習メモ
         </label>
-        <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">気づき・覚えにくい用語・面接で詰まった点など（自動保存）</p>
+        <p className="mt-0.5 text-xs text-label-2">気づき・覚えにくい用語・面接で詰まった点など（自動保存）</p>
         <textarea
           id="today-note"
           value={draft}
           onChange={(e) => onChangeDraft(e.target.value)}
           rows={3}
           placeholder="例：TCP/UDPの違いが曖昧。明日もう一度。"
-          className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+          className="mt-2 w-full rounded-control border border-separator bg-surface px-3 py-2 text-sm text-label focus:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         />
       </div>
 
       {/* 振り返り一覧（F-LOG-04） */}
       <div className={card}>
-        <h2 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-300">これまでの振り返り</h2>
+        <h2 className="mb-2 text-sm font-semibold text-label">これまでの振り返り</h2>
         {rows.length === 0 ? (
-          <p className="text-sm text-slate-500 dark:text-slate-400">まだ記録がありません。学習するとここに日々の記録が並びます。</p>
+          <p className="text-sm text-label-2">まだ記録がありません。学習するとここに日々の記録が並びます。</p>
         ) : (
           <ul className="flex flex-col gap-3">
             {rows.map((r) => (
-              <li key={r.date} className="border-l-2 border-sky-200 pl-3 dark:border-sky-800">
-                <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">{r.date}</p>
-                <div className="mt-0.5 flex flex-wrap gap-x-4 gap-y-0.5 text-xs text-slate-600 dark:text-slate-400">
+              <li key={r.date} className="border-l-2 border-accent pl-3">
+                <p className="text-sm font-semibold text-label">{r.date}</p>
+                <div className="mt-0.5 flex flex-wrap gap-x-4 gap-y-0.5 text-xs text-label-2">
                   {r.interview.asked > 0 && (
                     <span>面接練習 {r.interview.asked}回・言えた {r.interview.said}</span>
                   )}
@@ -111,7 +111,7 @@ export function ReviewView() {
                   {r.interview.asked === 0 && r.card.asked === 0 && <span>4択クイズで学習</span>}
                 </div>
                 {r.note && (
-                  <p className="mt-1 whitespace-pre-wrap rounded-lg bg-slate-50 p-2 text-sm text-slate-700 dark:bg-slate-900 dark:text-slate-200">
+                  <p className="mt-1 whitespace-pre-wrap rounded-control bg-surface-2 p-2 text-sm text-label">
                     {r.note}
                   </p>
                 )}


### PR DESCRIPTION
## 概要
Apple HIG デザイン土台（#372）の移行第4弾。「学ぶ・記録」グループ＋データ管理を新トークンへ。

## 変更
- `DashboardView` / `ReviewView` / `PrepView` / `LearnView` / `DataManager`：`bg-white`/`slate-*`/`ring-slate-*`/`sky-*` を `hig-card`・`text-label`/`text-label-2`・`text-accent`・`hig-btn-primary`・`bg-fill-quaternary`・`border-separator` へ。
- ダッシュボードのプログレスバーを `bg-accent-fill`（トラック `bg-fill-quaternary`）に。サブタブをピル化。振り返りのタイムラインを `border-accent`。
- 意味色は維持：学ぶの図解（sky tint ボックス・チップ）、面接実績の emerald、進捗リセットの rose。

## 検証
- Chrome DevTools でダッシュボード（統計・実績・分野別バー）と学ぶ（ロードマップ・図解）を確認。
- `npm run build` green、Vitest **27**、E2E smoke+a11y **7** green（critical 0、学ぶビュー含む）。

Closes #377