### PR TITLE
feat: HIGトークンへ移行（マイ問題）＋QuizView仕上げで全ビュー完了

### DIFF
--- a/term-board/docs/引き継ぎ書.md
+++ b/term-board/docs/引き継ぎ書.md
@@ -365,7 +365,7 @@ gh run list --repo 80-cloud/hideharu-AI --workflow "term-board-pages.yml" --bran
    - セマンティックカラーを **CSS変数**で持ち、`:root` と `.dark` で値だけ差し替える → `bg-canvas`/`bg-surface`/`text-label`/`text-label-2`/`border-separator`/`bg-accent-fill`/`text-accent`/`bg-fill-quaternary` の Tailwind ユーティリティが **light/dark 自動スイッチ**（個々に `dark:` 不要）。角丸は `rounded-card`(14px)/`rounded-control`(10px)。
    - コンポーネントクラス：`.hig-card`（面+角丸+ヘアライン罫線）、`.hig-btn-primary`（systemBlue 塗り・白文字でAA）。
    - ナビは iOS セグメントコントロール（第1段＝`SegmentTab`）＋ピル（第2段＝`PillTab`）。ヘッダーは `sticky` + `bg-bar` + `backdrop-blur-xl`（素材感）。
-   - **移行状況**：済＝共通クロム（App.tsx ヘッダー/ナビ/背景）・HomeView・QuizView・CategoryFilter。**未移行＝他の各ビュー**（CardView/DictionaryView/InterviewView/MockInterviewView/GuideView/ReverseQuestionStock/DashboardView/ReviewView/PrepView/LearnView/AuthorView）。各ビューで `bg-white`/`slate-*`/`ring-slate-*`/`sky-*` を上記トークンへ置換していく（1ビュー=1PR 目安）。
+   - **移行状況**：✅ **全ビュー移行完了**（共通クロム #372、覚える #374、面接対策 #376、学ぶ・記録 #378、マイ問題＋QuizView仕上げ #380）。`slate-*`/`bg-white`/`ring-slate-*` は全廃。残る `sky-*` は意図的な意味色（学ぶの図解 tint ボックス・チップ、青ヒーロー上の白ボタン、回答の型/カテゴリチップ）。状態色（emerald 正解/言えた・rose 不正解/削除・amber 中級/深掘り）も維持。
    - **PCナビの2案比較は別途**：macOS サイドバー案 vs 上部ツールバー案を実装してテストで比較予定（#371 のフォロー）。
    - 新トークンでも **A11y=100 を維持**（accent #0066cc/dark #0a84ff・label-2 は AA 確保の濃さを選定済み）。新ビュー移行時も light/dark 両方で audit。
 

--- a/term-board/src/App.tsx
+++ b/term-board/src/App.tsx
@@ -178,7 +178,7 @@ export default function App() {
                     onNext={quiz.next}
                   />
                 ) : (
-                  <p className="text-center text-slate-500 dark:text-slate-400">この分野には出題できる用語がありません。</p>
+                  <p className="text-center text-label-2">この分野には出題できる用語がありません。</p>
                 )}
               </>
             )}

--- a/term-board/src/components/AuthorView.tsx
+++ b/term-board/src/components/AuthorView.tsx
@@ -5,10 +5,10 @@ type Props = { user: UseUserContent };
 type Tab = "quiz" | "interview" | "share";
 
 const inputClass =
-  "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-800 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100";
-const labelClass = "block text-sm font-medium text-slate-700 dark:text-slate-300";
+  "w-full rounded-control border border-separator bg-surface px-3 py-2 text-sm text-label focus:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent";
+const labelClass = "block text-sm font-medium text-label-2";
 const primaryBtn =
-  "rounded-xl bg-sky-700 px-5 py-2.5 font-semibold text-white transition hover:bg-sky-800 focus:outline-none focus:ring-2 focus:ring-sky-400 disabled:bg-slate-300";
+  "hig-btn-primary px-5 py-2.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-50";
 
 // F-USER-01/02: 自分で問題を書く（4択用語・面接Q&A）＋共有（エクスポート/インポート）。
 export function AuthorView({ user }: Props) {
@@ -50,8 +50,8 @@ function SubTab({
       role="tab"
       aria-selected={active}
       onClick={onClick}
-      className={`rounded-lg px-3 py-1.5 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-sky-400 ${
-        active ? "bg-sky-700 text-white" : "bg-white text-slate-600 ring-1 ring-slate-300 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-600"
+      className={`rounded-full px-3.5 py-1.5 text-sm font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+        active ? "bg-accent-fill text-white" : "bg-surface text-label-2 ring-1 ring-separator hover:text-label"
       }`}
     >
       {children}
@@ -84,8 +84,8 @@ function InterviewForm({ user }: Props) {
 
   return (
     <div className="flex flex-col gap-5">
-      <form onSubmit={submit} className="flex flex-col gap-3 rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-        <p className="text-sm text-slate-600 dark:text-slate-300">
+      <form onSubmit={submit} className="flex flex-col gap-3 hig-card p-5">
+        <p className="text-sm text-label-2">
           実際に聞かれた面接の質問と、自分の答え（模範回答）を登録できます。
         </p>
         <div>
@@ -153,8 +153,8 @@ function QuizForm({ user }: Props) {
 
   return (
     <div className="flex flex-col gap-5">
-      <form onSubmit={submit} className="flex flex-col gap-3 rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-        <p className="text-sm text-slate-600 dark:text-slate-300">
+      <form onSubmit={submit} className="flex flex-col gap-3 hig-card p-5">
+        <p className="text-sm text-label-2">
           4択クイズに出る用語を作れます。誤答の選択肢を3つ用意してください。
         </p>
         <div>
@@ -231,9 +231,9 @@ function SharePanel({ user }: Props) {
 
   return (
     <div className="flex flex-col gap-5">
-      <div className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-        <h2 className="font-bold text-slate-900 dark:text-slate-100">書き出す（共有する）</h2>
-        <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
+      <div className="hig-card p-5">
+        <h2 className="font-bold text-label">書き出す（共有する）</h2>
+        <p className="mt-1 text-sm text-label-2">
           自分が作った問題（4択 {user.content.quizTerms.length}件・面接 {user.content.interviewQuestions.length}件）を
           共有コードにして、Discordなどに貼って渡せます。
         </p>
@@ -243,9 +243,9 @@ function SharePanel({ user }: Props) {
         )}
       </div>
 
-      <div className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
-        <h2 className="font-bold text-slate-900 dark:text-slate-100">取り込む（受け取る）</h2>
-        <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
+      <div className="hig-card p-5">
+        <h2 className="font-bold text-label">取り込む（受け取る）</h2>
+        <p className="mt-1 text-sm text-label-2">
           もらった共有コードを貼り付けて取り込むと、自分の問題に追加されます。
         </p>
         <label htmlFor="import-code" className="sr-only">共有コードを貼り付け</label>
@@ -280,22 +280,22 @@ function ItemList({
   onRemove: (id: string) => void;
 }) {
   if (items.length === 0) {
-    return <p className="text-center text-sm text-slate-500 dark:text-slate-400">まだ登録がありません。</p>;
+    return <p className="text-center text-sm text-label-2">まだ登録がありません。</p>;
   }
   return (
     <div>
-      <h2 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-300">{title}</h2>
+      <h2 className="mb-2 text-sm font-semibold text-label">{title}</h2>
       <ul className="flex flex-col gap-2">
         {items.map((it) => (
-          <li key={it.id} className="flex items-start justify-between gap-3 rounded-xl bg-white p-3 ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700">
+          <li key={it.id} className="hig-card flex items-start justify-between gap-3 p-3">
             <div className="min-w-0">
-              <p className="truncate font-medium text-slate-900 dark:text-slate-100">{it.primary}</p>
-              <p className="truncate text-xs text-slate-500 dark:text-slate-400">{it.secondary}</p>
+              <p className="truncate font-medium text-label">{it.primary}</p>
+              <p className="truncate text-xs text-label-2">{it.secondary}</p>
             </div>
             <button
               type="button"
               onClick={() => onRemove(it.id)}
-              className="shrink-0 rounded-lg px-2 py-1 text-sm text-rose-700 ring-1 ring-rose-200 transition hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-rose-400"
+              className="shrink-0 rounded-control px-2 py-1 text-sm text-rose-700 ring-1 ring-rose-200 transition hover:bg-rose-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 dark:text-rose-300 dark:ring-rose-800 dark:hover:bg-rose-950"
             >
               削除
             </button>

--- a/term-board/src/components/QuizView.tsx
+++ b/term-board/src/components/QuizView.tsx
@@ -27,7 +27,7 @@ function optionClass(args: {
   if (args.isThisSelected) {
     return `${base} border-rose-500 bg-rose-50 text-rose-900 dark:bg-rose-950 dark:text-rose-200`;
   }
-  return `${base} border-slate-200 bg-white text-slate-400 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-500`;
+  return `${base} border-separator bg-surface text-label-3`;
 }
 
 // F-INTV-03: 深掘り「なぜ?」チェーン。追い質問を段階的に開示する（§4-5）。
@@ -43,9 +43,9 @@ function FollowUpChain({ items }: { items: { q: string; a: string }[] }) {
       <ol className="mt-2 flex flex-col gap-3">
         {items.slice(0, visible).map((it, i) => (
           <li key={i}>
-            <p className="text-sm font-semibold text-slate-800 dark:text-slate-100">Q. {it.q}</p>
+            <p className="text-sm font-semibold text-label">Q. {it.q}</p>
             {i < step && (
-              <p className="mt-1 text-sm leading-relaxed text-slate-700 dark:text-slate-300">A. {it.a}</p>
+              <p className="mt-1 text-sm leading-relaxed text-label-2">A. {it.a}</p>
             )}
           </li>
         ))}
@@ -110,23 +110,23 @@ export function QuizView({ question, selected, isCorrect, onAnswer, onNext }: Pr
           </p>
           {question.term.plainMeaning && (
             <div className="mt-3 rounded-xl bg-sky-50 p-3 ring-1 ring-sky-100 dark:bg-sky-950 dark:ring-sky-900">
-              <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-200">
-                <span className="font-semibold text-sky-800 dark:text-sky-300">かんたんに言うと：</span>
+              <p className="text-sm leading-relaxed text-label">
+                <span className="font-semibold text-accent">かんたんに言うと：</span>
                 {question.term.plainMeaning}
               </p>
             </div>
           )}
-          <p className="mt-2 text-sm leading-relaxed text-slate-700 dark:text-slate-300">
-            <span className="font-semibold text-slate-900 dark:text-slate-100">正しい意味：</span>
+          <p className="mt-2 text-sm leading-relaxed text-label-2">
+            <span className="font-semibold text-label">正しい意味：</span>
             {question.answer}
           </p>
-          <p className="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
-            <span className="font-semibold text-slate-800 dark:text-slate-200">面接での言い方：</span>
+          <p className="mt-2 text-sm leading-relaxed text-label-2">
+            <span className="font-semibold text-label">面接での言い方：</span>
             {question.term.interview}
           </p>
           {question.term.scene && (
-            <p className="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
-              <span className="font-semibold text-slate-800 dark:text-slate-200">現場では：</span>
+            <p className="mt-2 text-sm leading-relaxed text-label-2">
+              <span className="font-semibold text-label">現場では：</span>
               {question.term.scene}
             </p>
           )}


### PR DESCRIPTION
## 概要
Apple HIG デザイン土台（#372）移行の**最終弾**。マイ問題（AuthorView）を移行し、土台PRで残っていた QuizView 解説文も仕上げて、**全ビューの HIG 化を完了**。

## 変更
- `AuthorView`：サブタブをピル化、フォーム=`hig-card`、入力=`rounded-control border-separator bg-surface`、追加ボタン=`hig-btn-primary`、一覧カード=`hig-card`、削除ボタンは rose（意味色）維持。
- `QuizView`：解説文（正しい意味/面接での言い方/現場では/かんたんに言うと/深掘りチェーン/回答済みの無効選択肢）を `text-label(-2)`・`text-accent`・`border-separator`・`bg-surface` へ。
- `App.tsx`：出題なし時の空状態文を `text-label-2` に。
- `docs/引き継ぎ書.md`：移行状況を「全ビュー完了」に更新。

## 全ビュー移行の達成
`slate-*` / `bg-white` / `ring-slate-*` を全廃。残る `sky-*` は意図的な意味色（学ぶの図解 tint ボックス・チップ、青ヒーロー上の白ボタン、回答の型/カテゴリチップ）。状態色（emerald/rose/amber）も維持。

## 検証
- Chrome DevTools でマイ問題を確認。Lighthouse（mobile snapshot）：**A11y=100 / BP=100 / SEO=100**。
- `npm run build` green、Vitest **27**、E2E smoke+a11y **7** green。

Closes #379