### PR TITLE
feat: PCナビ2案（macOSサイドバー / 上部ツールバー）を切替トグルで比較可能に

### DIFF
--- a/term-board/docs/引き継ぎ書.md
+++ b/term-board/docs/引き継ぎ書.md
@@ -366,7 +366,7 @@ gh run list --repo 80-cloud/hideharu-AI --workflow "term-board-pages.yml" --bran
    - コンポーネントクラス：`.hig-card`（面+角丸+ヘアライン罫線）、`.hig-btn-primary`（systemBlue 塗り・白文字でAA）。
    - ナビは iOS セグメントコントロール（第1段＝`SegmentTab`）＋ピル（第2段＝`PillTab`）。ヘッダーは `sticky` + `bg-bar` + `backdrop-blur-xl`（素材感）。
    - **移行状況**：✅ **全ビュー移行完了**（共通クロム #372、覚える #374、面接対策 #376、学ぶ・記録 #378、マイ問題＋QuizView仕上げ #380）。`slate-*`/`bg-white`/`ring-slate-*` は全廃。残る `sky-*` は意図的な意味色（学ぶの図解 tint ボックス・チップ、青ヒーロー上の白ボタン、回答の型/カテゴリチップ）。状態色（emerald 正解/言えた・rose 不正解/削除・amber 中級/深掘り）も維持。
-   - **PCナビの2案比較は別途**：macOS サイドバー案 vs 上部ツールバー案を実装してテストで比較予定（#371 のフォロー）。
+   - **PCナビの2案（#381・実装済）**：desktop で `useNavLayout`（localStorage `term-board:navLayout:v1`・既定 `toolbar`）により**上部ツールバー ⇄ macOS サイドバー**をヘッダーのトグルで即切替して比較できる。サイドバー＝左ソースリスト（`SideNav`・グループ見出し＋モード行）＋右コンテンツ（desktop限定、モバイルは常に上部セグメント）。**どちらを既定にするかは未決**（比較して決める）。E2E smoke にサイドバー導線あり。
    - 新トークンでも **A11y=100 を維持**（accent #0066cc/dark #0a84ff・label-2 は AA 確保の濃さを選定済み）。新ビュー移行時も light/dark 両方で audit。
 
 1. **ダークはクラス式**：`index.css` に `@custom-variant dark (&:where(.dark, .dark *))`。`dark:` は `<html class="dark">` 配下でのみ効く。

--- a/term-board/e2e/tests/smoke.spec.js
+++ b/term-board/e2e/tests/smoke.spec.js
@@ -32,6 +32,20 @@ test.describe('smoke @smoke', () => {
     await expect(page.getByRole('heading', { name: /面接で言える/ })).toBeVisible();
   });
 
+  test('PCナビをサイドバーに切替でき、サイドバーから遷移できる', async ({ page }) => {
+    await page.goto('/');
+    // desktop の様式トグルでサイドバーへ。
+    await page.getByRole('button', { name: /サイドバーに切り替え/ }).click();
+    // サイドバー（モード一覧）から用語辞典へ。
+    const side = page.getByRole('navigation', { name: 'モード一覧' });
+    await expect(side).toBeVisible();
+    await side.getByRole('button', { name: '用語辞典', exact: true }).click();
+    await expect(page.getByPlaceholder('用語・意味で検索')).toBeVisible();
+    // 上部ツールバーへ戻せる。
+    await page.getByRole('button', { name: /上部ツールバーに切り替え/ }).click();
+    await expect(side).toBeHidden();
+  });
+
   test('4択クイズを1問解ける（採点と解説が出る）', async ({ page }) => {
     await page.goto('/');
     await page.getByRole('button', { name: '覚える', exact: true }).click();

--- a/term-board/src/App.tsx
+++ b/term-board/src/App.tsx
@@ -3,6 +3,8 @@ import { useQuiz } from "./hooks/useQuiz";
 import { useUserContent } from "./hooks/useUserContent";
 import { useBookmarks } from "./hooks/useBookmarks";
 import { useTheme } from "./hooks/useTheme";
+import { useNavLayout } from "./hooks/useNavLayout";
+import type { NavLayout } from "./hooks/useNavLayout";
 import { CategoryFilter } from "./components/CategoryFilter";
 import { QuizView } from "./components/QuizView";
 import { InterviewView } from "./components/InterviewView";
@@ -68,6 +70,7 @@ const NAV_GROUPS: NavGroup[] = [
 export default function App() {
   const [view, setView] = useState<View>("home");
   const theme = useTheme();
+  const nav = useNavLayout();
   const user = useUserContent();
   const bookmarks = useBookmarks();
   // ユーザー作問の件数を渡し、追加・取り込みで出題に即反映する（F-USER）。
@@ -80,11 +83,63 @@ export default function App() {
   // 現在のビューが属するグループ（home のときは未選択）。
   const activeGroup = NAV_GROUPS.find((g) => g.views.some((v) => v.view === view));
 
+  // ビュー本体（レイアウトに依存しないので切り出して両レイアウトで共有する）。
+  const viewContent = (
+    <>
+      {view === "home" && <HomeView onNavigate={(v) => setView(v)} />}
+
+      {view === "quiz" && (
+        <>
+          {quiz.status === "loading" && <p className="text-center text-label-2">読み込み中…</p>}
+          {quiz.status === "error" && (
+            <p className="rounded-control bg-rose-50 p-4 text-center text-rose-700 ring-1 ring-rose-200 dark:bg-rose-950 dark:text-rose-300 dark:ring-rose-900">
+              用語データを読み込めませんでした。
+            </p>
+          )}
+          {quiz.status === "ready" && (
+            <>
+              <div className="hig-card mb-5 flex items-center justify-between px-4 py-3 text-sm">
+                <span className="text-label-2">解答数 <span className="font-bold text-label">{quiz.answeredCount}</span></span>
+                <span className="text-label-2">正答 <span className="font-bold text-emerald-700 dark:text-emerald-400">{quiz.correctCount}</span></span>
+                <span className="text-label-2">正答率 <span className="font-bold text-accent">{rate}%</span></span>
+              </div>
+              {quiz.question ? (
+                <QuizView
+                  question={quiz.question}
+                  selected={quiz.selected}
+                  isCorrect={quiz.isCorrect}
+                  onAnswer={quiz.answer}
+                  onNext={quiz.next}
+                />
+              ) : (
+                <p className="text-center text-label-2">この分野には出題できる用語がありません。</p>
+              )}
+            </>
+          )}
+        </>
+      )}
+
+      {view === "card" && <CardView />}
+      {view === "dictionary" && <DictionaryView bookmarks={bookmarks} />}
+      {view === "learn" && <LearnView />}
+      {view === "dashboard" && <DashboardView bookmarks={bookmarks} />}
+      {view === "review" && <ReviewView />}
+      {view === "prep" && <PrepView />}
+      {view === "interview" && <InterviewView userQuestions={user.content.interviewQuestions} />}
+      {view === "mock" && <MockInterviewView />}
+      {view === "guide" && <GuideView userQuestions={user.content.interviewQuestions} />}
+      {view === "author" && <AuthorView user={user} />}
+      {view === "reverseq" && <ReverseQuestionStock />}
+    </>
+  );
+
+  const sidebar = nav.layout === "sidebar";
+
   return (
     <div className="min-h-screen bg-canvas text-label">
       {/* iOS/macOS のナビバー風：上部固定・半透明 + backdrop blur（素材感）。 */}
       <header className="sticky top-0 z-20 border-b border-separator bg-bar backdrop-blur-xl backdrop-saturate-150">
-        <div className="mx-auto flex max-w-2xl flex-col gap-3 px-4 py-3">
+        <div className={`mx-auto flex flex-col gap-3 px-4 py-3 ${sidebar ? "max-w-5xl" : "max-w-2xl"}`}>
           <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-start justify-between gap-2">
               <div>
@@ -111,105 +166,136 @@ export default function App() {
                   onChange={quiz.setCategory}
                 />
               )}
+              {/* PCナビ様式トグル（desktop のみ・#381 の2案比較用）。 */}
+              <LayoutToggle layout={nav.layout} onToggle={nav.toggle} className="hidden lg:flex" />
               <ThemeToggle theme={theme.theme} onToggle={theme.toggle} className="hidden sm:flex" />
             </div>
           </div>
 
-          {/* 第1段：グループ。iOS のセグメントコントロール（薄い面に白ピルが滑る）。 */}
-          <nav
-            className="flex gap-1 rounded-control bg-fill-quaternary p-1"
-            aria-label="カテゴリ切替"
-          >
-            {NAV_GROUPS.map((g) => (
-              <SegmentTab
-                key={g.key}
-                active={activeGroup?.key === g.key}
-                onClick={() => setView(g.views[0].view)}
-              >
-                {g.label}
-              </SegmentTab>
-            ))}
-          </nav>
-
-          {/* 第2段：選択中グループのモード（単独グループは第1段で完結するため省略）。ピル列。 */}
-          {activeGroup && activeGroup.views.length > 1 && (
-            <nav
-              className="flex flex-wrap gap-2"
-              aria-label={`${activeGroup.label}のモード切替`}
-            >
-              {activeGroup.views.map((v) => (
-                <PillTab
-                  key={v.view}
-                  active={view === v.view}
-                  onClick={() => setView(v.view)}
-                >
-                  {v.label}
-                </PillTab>
-              ))}
-            </nav>
-          )}
+          {/* 上部ナビ（セグメント＋ピル）。toolbar は常時／sidebar は desktop でサイドバーに譲りモバイルのみ表示。 */}
+          <div className={`flex flex-col gap-3 ${sidebar ? "lg:hidden" : ""}`}>
+            <TopNav view={view} activeGroup={activeGroup} setView={setView} />
+          </div>
         </div>
       </header>
 
-      <main className="mx-auto max-w-2xl px-4 py-6">
-        {view === "home" && <HomeView onNavigate={(v) => setView(v)} />}
-
-        {view === "quiz" && (
-          <>
-            {quiz.status === "loading" && <p className="text-center text-label-2">読み込み中…</p>}
-            {quiz.status === "error" && (
-              <p className="rounded-control bg-rose-50 p-4 text-center text-rose-700 ring-1 ring-rose-200 dark:bg-rose-950 dark:text-rose-300 dark:ring-rose-900">
-                用語データを読み込めませんでした。
-              </p>
-            )}
-            {quiz.status === "ready" && (
-              <>
-                <div className="hig-card mb-5 flex items-center justify-between px-4 py-3 text-sm">
-                  <span className="text-label-2">解答数 <span className="font-bold text-label">{quiz.answeredCount}</span></span>
-                  <span className="text-label-2">正答 <span className="font-bold text-emerald-700 dark:text-emerald-400">{quiz.correctCount}</span></span>
-                  <span className="text-label-2">正答率 <span className="font-bold text-accent">{rate}%</span></span>
-                </div>
-                {quiz.question ? (
-                  <QuizView
-                    question={quiz.question}
-                    selected={quiz.selected}
-                    isCorrect={quiz.isCorrect}
-                    onAnswer={quiz.answer}
-                    onNext={quiz.next}
-                  />
-                ) : (
-                  <p className="text-center text-label-2">この分野には出題できる用語がありません。</p>
-                )}
-              </>
-            )}
-          </>
-        )}
-
-        {view === "card" && <CardView />}
-
-        {view === "dictionary" && <DictionaryView bookmarks={bookmarks} />}
-
-        {view === "learn" && <LearnView />}
-
-        {view === "dashboard" && <DashboardView bookmarks={bookmarks} />}
-
-        {view === "review" && <ReviewView />}
-
-        {view === "prep" && <PrepView />}
-
-        {view === "interview" && (
-          <InterviewView userQuestions={user.content.interviewQuestions} />
-        )}
-
-        {view === "mock" && <MockInterviewView />}
-
-        {view === "guide" && <GuideView userQuestions={user.content.interviewQuestions} />}
-
-        {view === "author" && <AuthorView user={user} />}
-
-        {view === "reverseq" && <ReverseQuestionStock />}
-      </main>
+      {sidebar ? (
+        <div className="mx-auto flex w-full max-w-5xl gap-6 px-4 py-6">
+          <SideNav view={view} setView={setView} className="hidden w-56 shrink-0 lg:block" />
+          <main className="min-w-0 flex-1">
+            <div className="mx-auto max-w-2xl">{viewContent}</div>
+          </main>
+        </div>
+      ) : (
+        <main className="mx-auto max-w-2xl px-4 py-6">{viewContent}</main>
+      )}
     </div>
+  );
+}
+
+// 上部ナビ：第1段＝iOS セグメント、第2段＝モードのピル列。
+function TopNav({
+  view,
+  activeGroup,
+  setView,
+}: {
+  view: View;
+  activeGroup: NavGroup | undefined;
+  setView: (v: View) => void;
+}) {
+  return (
+    <>
+      <nav className="flex gap-1 rounded-control bg-fill-quaternary p-1" aria-label="カテゴリ切替">
+        {NAV_GROUPS.map((g) => (
+          <SegmentTab key={g.key} active={activeGroup?.key === g.key} onClick={() => setView(g.views[0].view)}>
+            {g.label}
+          </SegmentTab>
+        ))}
+      </nav>
+      {activeGroup && activeGroup.views.length > 1 && (
+        <nav className="flex flex-wrap gap-2" aria-label={`${activeGroup.label}のモード切替`}>
+          {activeGroup.views.map((v) => (
+            <PillTab key={v.view} active={view === v.view} onClick={() => setView(v.view)}>
+              {v.label}
+            </PillTab>
+          ))}
+        </nav>
+      )}
+    </>
+  );
+}
+
+// 左サイドバー（macOS のソースリスト風）。グループ見出し＋モード行。desktop 専用。
+function SideNav({
+  view,
+  setView,
+  className = "",
+}: {
+  view: View;
+  setView: (v: View) => void;
+  className?: string;
+}) {
+  return (
+    <nav className={`flex flex-col gap-1 self-start ${className}`} aria-label="モード一覧">
+      <SideRow active={view === "home"} onClick={() => setView("home")}>ホーム</SideRow>
+      {NAV_GROUPS.map((g) => (
+        <div key={g.key} className="mt-3 first:mt-0">
+          <p className="px-3 pb-1 text-[11px] font-semibold uppercase tracking-wide text-label-2">{g.label}</p>
+          {g.views.map((v) => (
+            <SideRow key={v.view} active={view === v.view} onClick={() => setView(v.view)}>
+              {v.label}
+            </SideRow>
+          ))}
+        </div>
+      ))}
+    </nav>
+  );
+}
+
+function SideRow({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-current={active ? "page" : undefined}
+      className={`w-full rounded-control px-3 py-1.5 text-left text-sm font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+        active ? "bg-accent-fill text-white" : "text-label hover:bg-fill-quaternary"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+// PCナビ様式の切替（上部ツールバー ⇄ サイドバー）。desktop のみ表示。
+function LayoutToggle({
+  layout,
+  onToggle,
+  className = "",
+}: {
+  layout: NavLayout;
+  onToggle: () => void;
+  className?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-label={layout === "sidebar" ? "サイドバー表示中。クリックで上部ツールバーに切り替え" : "ツールバー表示中。クリックでサイドバーに切り替え"}
+      title={layout === "sidebar" ? "サイドバー表示中（クリックで上部ツールバー）" : "上部ツールバー表示中（クリックでサイドバー）"}
+      className={`h-8 items-center gap-1.5 rounded-full px-3 text-xs font-medium text-label-2 ring-1 ring-separator transition hover:bg-fill-quaternary hover:text-label focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${className}`}
+    >
+      <span aria-hidden="true">{layout === "sidebar" ? "◧" : "▤"}</span>
+      {layout === "sidebar" ? "サイドバー" : "ツールバー"}
+    </button>
   );
 }
 

--- a/term-board/src/hooks/useNavLayout.ts
+++ b/term-board/src/hooks/useNavLayout.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+
+// PCナビの様式（#381）。desktop で「上部ツールバー」と「サイドバー」を比較するための切替。
+// モバイルは様式に関わらず上部セグメントを使う（サイドバーは desktop 限定）。
+const NAV_LAYOUT_KEY = "term-board:navLayout:v1";
+export type NavLayout = "toolbar" | "sidebar";
+
+function initialLayout(): NavLayout {
+  try {
+    const saved = localStorage.getItem(NAV_LAYOUT_KEY);
+    if (saved === "toolbar" || saved === "sidebar") return saved;
+  } catch {
+    // localStorage 不可でも続行
+  }
+  return "toolbar";
+}
+
+export function useNavLayout() {
+  const [layout, setLayout] = useState<NavLayout>(initialLayout);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(NAV_LAYOUT_KEY, layout);
+    } catch {
+      // 保存失敗でも表示は継続
+    }
+  }, [layout]);
+
+  const toggle = () => setLayout((l) => (l === "sidebar" ? "toolbar" : "sidebar"));
+
+  return { layout, toggle };
+}


### PR DESCRIPTION
## 概要
PC（macOS）レイアウトのナビ「サイドバー」と「上部ツールバー」の2案を、**desktop の切替トグル**で1ビルド内に同居させ、実機で見比べられるようにした（後で既定を決める）。

## 変更
- `src/hooks/useNavLayout.ts`：`toolbar`(既定)/`sidebar` を localStorage 保存。
- `src/App.tsx`：ビュー本体を `viewContent` に切り出し、レイアウト分岐を追加。
  - **toolbar**：現行の上部セグメント＋ピル（`TopNav`）。
  - **sidebar**：左ソースリスト（`SideNav`・グループ見出し＋モード行・active は accent-fill）＋右コンテンツ。**desktop(lg+)限定**、モバイルは常に上部セグメントにフォールバック。
  - ヘッダーに様式トグル（`LayoutToggle`・desktopのみ）。
- `e2e/tests/smoke.spec.js`：サイドバー切替＋サイドバー遷移＋ツールバー復帰の smoke を追加。

## 検証
- Chrome DevTools：desktop でトグル切替→サイドバーから遷移を確認。モバイルは上部ナビにフォールバック。
- Lighthouse（desktop・sidebar）：**A11y=100 / BP=100 / SEO=100**（サイドバー見出しの contrast と トグルの label-content-name-mismatch を修正済み）。
- `npm run build` green、Vitest **27**、E2E smoke **3**＋a11y **5** green。

## 未決
- 既定をどちらにするかは比較のうえ別途決定（現状の既定は `toolbar`）。

Closes #381