### PR TITLE
feat: PCサイドバーを右側に変更

### DIFF
--- a/term-board/src/App.tsx
+++ b/term-board/src/App.tsx
@@ -181,10 +181,11 @@ export default function App() {
 
       {sidebar ? (
         <div className="mx-auto flex w-full max-w-5xl gap-6 px-4 py-6">
-          <SideNav view={view} setView={setView} className="hidden w-56 shrink-0 lg:block" />
           <main className="min-w-0 flex-1">
             <div className="mx-auto max-w-2xl">{viewContent}</div>
           </main>
+          {/* サイドバーは右側に配置（#383）。 */}
+          <SideNav view={view} setView={setView} className="hidden w-56 shrink-0 lg:block" />
         </div>
       ) : (
         <main className="mx-auto max-w-2xl px-4 py-6">{viewContent}</main>


### PR DESCRIPTION
## 概要
PCナビのサイドバー（#382）を左→右配置に変更。コンテンツが左、ナビが右になる。

## 変更
- `src/App.tsx`：sidebar レイアウトの flex 子要素の順序を入れ替え（`<main>` → `<SideNav>`）。モバイルは従来どおり上部セグメントにフォールバック。

## 検証
- Chrome DevTools（desktop）：サイドバーが右に表示され、右ナビから遷移可。
- Lighthouse（desktop・sidebar）：**A11y=100 / BP=100 / SEO=100**。
- `npm run build` green、Vitest **27**、E2E smoke **3**＋a11y **5** green。

Closes #383