### PR TITLE
feat: Term/InterviewQuestion に source="shared" を追加（もらった問題を区別）

### DIFF
--- a/term-board/docs/データモデル.md
+++ b/term-board/docs/データモデル.md
@@ -56,7 +56,7 @@
 | `reverseQuestions` | string[]? | 任意 | 派生する逆質問 | F-INTV-07（予定） |
 | `related` | string[]? | 任意 | 関連用語ID（知識マップ） | F-PROG-06（予定） |
 | `confusedWith` | string[]? | 任意 | 混同しやすい用語ID | F-QUIZ-06（予定） |
-| `source` | "builtin"\|"user"? | 任意 | 出所。同梱=builtin／ユーザー作問=user | F-USER-01 |
+| `source` | "builtin"\|"user"\|"shared"? | 任意 | 出所。同梱=builtin／自作=user／共有取込=shared（#385） | F-USER-01 |
 
 > **拡張フィールドは全て任意。** 既存用語は中核フィールドだけで動き、列追加で段階的に機能を増やせる（母 M-11）。
 
@@ -101,7 +101,7 @@ type InterviewQuestion = {
   question: string;   // 実際に聞かれた質問
   answer: string;     // 模範回答／自分の答え
   memo?: string;      // 補足（聞かれた状況・コツ）
-  source?: "builtin" | "user";
+  source?: "builtin" | "user" | "shared";
 };
 
 type UserContent = {

--- a/term-board/docs/引き継ぎ書.md
+++ b/term-board/docs/引き継ぎ書.md
@@ -107,7 +107,7 @@ export type Term = {
   meaning: string; distractors: string[]; interview: string;
   plainMeaning?: string;            // F-TERM-05 かんたん説明
   scene?: string;                   // F-TERM-04 現場での使われ方
-  source?: "builtin" | "user";      // 出所
+  source?: "builtin" | "user" | "shared"; // 出所（同梱/自作/もらった・#385）
   level?: "初級" | "中級" | "上級";  // B1 レベル
 };
 

--- a/term-board/src/api/localStorageTermRepository.test.ts
+++ b/term-board/src/api/localStorageTermRepository.test.ts
@@ -62,6 +62,20 @@ describe("getTerms（builtin＋user統合）", () => {
     expect(mine?.source).toBe("user");
   });
 
+  it("source=shared を持つユーザー作問は shared のまま保持される（#385）", async () => {
+    localStorage.setItem(
+      USER_CONTENT_KEY,
+      JSON.stringify({
+        quizTerms: [
+          { id: "s1", category: "テスト", term: "もらった用語", meaning: "m", distractors: ["a", "b", "c"], interview: "i", source: "shared" },
+        ],
+        interviewQuestions: [],
+      }),
+    );
+    const terms = await repo.getTerms();
+    expect(terms.find((t) => t.id === "s1")?.source).toBe("shared");
+  });
+
   it("作問データが壊れていても builtin の出題は継続する", async () => {
     localStorage.setItem(USER_CONTENT_KEY, "{壊れた");
     const terms = await repo.getTerms();

--- a/term-board/src/api/localStorageTermRepository.ts
+++ b/term-board/src/api/localStorageTermRepository.ts
@@ -75,9 +75,10 @@ function readUserContent(): UserContent {
 
 export const localStorageTermRepository: TermRepository = {
   async getTerms(): Promise<Term[]> {
-    // 同梱（builtin）＋ ユーザー作問（user）を統合して出題対象にする。
+    // 同梱（builtin）＋ ユーザー作問（user / shared）を統合して出題対象にする。
+    // 既存の source を尊重し、未指定なら user とみなす（shared は importCode で付与済み）。
     const builtin = (termsData as Term[]).map((t) => ({ ...t, source: "builtin" as const }));
-    const user = readUserContent().quizTerms.map((t) => ({ ...t, source: "user" as const }));
+    const user = readUserContent().quizTerms.map((t) => ({ ...t, source: t.source ?? "user" }));
     return [...builtin, ...user];
   },
 

--- a/term-board/src/components/DictionaryView.tsx
+++ b/term-board/src/components/DictionaryView.tsx
@@ -122,6 +122,16 @@ export function DictionaryView({ bookmarks }: Props) {
                       {t.level}
                     </span>
                   )}
+                  {t.source === "shared" && (
+                    <span className="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900 dark:text-amber-200">
+                      もらった
+                    </span>
+                  )}
+                  {t.source === "user" && (
+                    <span className="shrink-0 rounded-full bg-fill-quaternary px-2 py-0.5 text-xs font-medium text-label-2">
+                      自作
+                    </span>
+                  )}
                   <span className="shrink-0 text-xs text-label-2">{t.category}</span>
                 </button>
                 <button

--- a/term-board/src/components/InterviewView.tsx
+++ b/term-board/src/components/InterviewView.tsx
@@ -122,9 +122,14 @@ export function InterviewView({ userQuestions }: Props) {
       <div className="hig-card p-6">
         <div className="flex flex-wrap items-center gap-2">
           <span className="text-sm font-medium text-accent">{current.category}</span>
-          {current.source === "user" && (
+          {current.source === "shared" && (
             <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900 dark:text-amber-200">
-              みんなの問題
+              もらった問題
+            </span>
+          )}
+          {current.source === "user" && (
+            <span className="rounded-full bg-fill-quaternary px-2 py-0.5 text-xs font-medium text-label-2">
+              自作
             </span>
           )}
           {current.tags?.map((tg) => (

--- a/term-board/src/hooks/useUserContent.ts
+++ b/term-board/src/hooks/useUserContent.ts
@@ -85,14 +85,15 @@ export function useUserContent(): UseUserContent {
   const exportCode = useCallback(() => encodeShareCode(content), [content]);
 
   // 取り込み時はIDを振り直して衝突を避け、既存に追記する。
+  // 取り込んだ問題は他者作なので source="shared" を付与（自作 user と区別。#385）。
   const importCode = useCallback(
     (code: string) => {
       const incoming = decodeShareCode(code);
-      const quiz = incoming.quizTerms.map((t) => ({ ...t, id: newId(), source: "user" as const }));
+      const quiz = incoming.quizTerms.map((t) => ({ ...t, id: newId(), source: "shared" as const }));
       const interview = incoming.interviewQuestions.map((q) => ({
         ...q,
         id: newId(),
-        source: "user" as const,
+        source: "shared" as const,
       }));
       setContent((prev) => {
         const next: UserContent = {

--- a/term-board/src/types.ts
+++ b/term-board/src/types.ts
@@ -17,9 +17,9 @@ export type Term = {
   // イメージを与え、面接で「使ったことは?」に最低限答えられる素地を作る（§13-1）。
   scene?: string;
 
-  // F-USER-01: 出所。同梱データは "builtin"、ユーザー作問は "user"。
-  // 未指定は builtin 相当（既存12件は無改修）。
-  source?: "builtin" | "user";
+  // F-USER-01 / #385: 出所。同梱=builtin / 自作=user / 共有コードで取り込んだ他者作=shared。
+  // 未指定は builtin 相当（既存データは無改修）。
+  source?: "builtin" | "user" | "shared";
 
   // B1: 難易度レベル（辞典でのバッジ表示・用語レベル表示）。
   level?: "初級" | "中級" | "上級";
@@ -38,7 +38,7 @@ export type InterviewQuestion = {
   question: string; // 実際に聞かれた質問（例「アジャイルとは？」「なぜIT業界？」）
   answer: string; // 模範回答／自分の答え
   memo?: string; // 補足（聞かれた状況・コツなど）
-  source?: "builtin" | "user";
+  source?: "builtin" | "user" | "shared";
 
   // B4: 面接コンテンツの強化（任意）。
   tags?: string[]; // 例 ["頻出", "未経験定番"]。面接練習でフィルタに使う


### PR DESCRIPTION
## 概要
データモデル §2 の `source` は現状 `builtin`(同梱) / `user`(ユーザー作問) のみ。共有コード(F-USER-02)で取り込んだ他者作の問題も `user` 扱いになり「自作」と「もらった問題」が区別できなかった。第3の出所として **`shared`** を追加する。

## 変更
- `src/types.ts`：`Term.source` / `InterviewQuestion.source` のユニオンに `"shared"` を追加（後方互換、任意フィールド）。
- `src/hooks/useUserContent.ts`：`importCode` で取り込んだ問題に `source: "shared"` を付与。
- `src/api/localStorageTermRepository.ts`：`getTerms` が userContent の既存 source を尊重（shared を保持・未指定は user）。
- `src/components/InterviewView.tsx`：「みんなの問題」バッジを source==="shared" に紐付け（自作は「自作」薄色バッジ）。
- `src/components/DictionaryView.tsx`：shared に「もらった」(amber) バッジ、user に「自作」薄色バッジ。
- Vitest：shared 保持の単体テストを追加（**28件**）。
- `docs/データモデル.md` / `docs/引き継ぎ書.md`：型定義と表を更新。

## 検証
- `npm run build` green、Vitest **28**、E2E smoke **3**＋a11y **5** green。Lighthouse A11y=100 維持。

Closes #385