### PR TITLE
fix: 戻るボタンで真っ暗になる問題（URLハッシュ履歴に同期）

### DIFF
--- a/term-board/e2e/tests/smoke.spec.js
+++ b/term-board/e2e/tests/smoke.spec.js
@@ -32,6 +32,25 @@ test.describe('smoke @smoke', () => {
     await expect(page.getByRole('heading', { name: /面接で言える/ })).toBeVisible();
   });
 
+  test('ブラウザの戻るボタンでアプリ内の前のビューに戻る（#387）', async ({ page }) => {
+    await page.goto('/');
+    // 初回ロードで #home が付くこと（基準点）。
+    await expect.poll(() => page.url()).toContain('#home');
+    // ホーム→4択クイズ→用語辞典 と遷移し、hashが順に変わる。
+    await page.getByRole('button', { name: '覚える', exact: true }).click();
+    await expect.poll(() => page.url()).toContain('#quiz');
+    await page.getByRole('button', { name: '用語辞典', exact: true }).click();
+    await expect.poll(() => page.url()).toContain('#dictionary');
+    // 戻るで quiz へ。
+    await page.goBack();
+    await expect.poll(() => page.url()).toContain('#quiz');
+    await expect(page.getByRole('heading', { name: /の意味は/ })).toBeVisible();
+    // さらに戻ると home。アプリ外には出ない（真っ暗にならない）。
+    await page.goBack();
+    await expect.poll(() => page.url()).toContain('#home');
+    await expect(page.getByRole('heading', { name: /面接で言える/ })).toBeVisible();
+  });
+
   test('PCナビをサイドバーに切替でき、サイドバーから遷移できる', async ({ page }) => {
     await page.goto('/');
     // desktop の様式トグルでサイドバーへ。

--- a/term-board/package-lock.json
+++ b/term-board/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.4",
@@ -307,6 +308,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1917,6 +1928,63 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2188,6 +2256,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2210,6 +2289,17 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2470,6 +2560,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2479,6 +2580,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.362",
@@ -3463,6 +3572,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3709,6 +3829,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3739,6 +3889,14 @@
       "peerDependencies": {
         "react": "^19.2.6"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/term-board/package.json
+++ b/term-board/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.4",

--- a/term-board/src/App.tsx
+++ b/term-board/src/App.tsx
@@ -1,10 +1,10 @@
-import { useState } from "react";
 import { useQuiz } from "./hooks/useQuiz";
 import { useUserContent } from "./hooks/useUserContent";
 import { useBookmarks } from "./hooks/useBookmarks";
 import { useTheme } from "./hooks/useTheme";
 import { useNavLayout } from "./hooks/useNavLayout";
 import type { NavLayout } from "./hooks/useNavLayout";
+import { useViewHistory } from "./hooks/useViewHistory";
 import { CategoryFilter } from "./components/CategoryFilter";
 import { QuizView } from "./components/QuizView";
 import { InterviewView } from "./components/InterviewView";
@@ -20,7 +20,23 @@ import { PrepView } from "./components/PrepView";
 import { LearnView } from "./components/LearnView";
 import { HomeView } from "./components/HomeView";
 
-type View = "home" | "quiz" | "card" | "dictionary" | "interview" | "mock" | "guide" | "author" | "reverseq" | "dashboard" | "review" | "prep" | "learn";
+// 全ビューの列挙（useViewHistory に渡してURLハッシュで履歴同期する・#387）。
+const VIEWS = [
+  "home",
+  "quiz",
+  "card",
+  "dictionary",
+  "interview",
+  "mock",
+  "guide",
+  "author",
+  "reverseq",
+  "dashboard",
+  "review",
+  "prep",
+  "learn",
+] as const;
+type View = (typeof VIEWS)[number];
 
 // ナビのグループ定義（モバイルUX：13タブを4グループに集約）。
 // View ユニオンは維持し、ナビUIのみ2段構成にする。
@@ -68,7 +84,7 @@ const NAV_GROUPS: NavGroup[] = [
 ];
 
 export default function App() {
-  const [view, setView] = useState<View>("home");
+  const [view, setView] = useViewHistory(VIEWS, "home");
   const theme = useTheme();
   const nav = useNavLayout();
   const user = useUserContent();

--- a/term-board/src/components/DictionaryView.tsx
+++ b/term-board/src/components/DictionaryView.tsx
@@ -128,7 +128,7 @@ export function DictionaryView({ bookmarks }: Props) {
                     </span>
                   )}
                   {t.source === "user" && (
-                    <span className="shrink-0 rounded-full bg-fill-quaternary px-2 py-0.5 text-xs font-medium text-label-2">
+                    <span className="shrink-0 rounded-full bg-fill-quaternary px-2 py-0.5 text-xs font-medium text-label">
                       自作
                     </span>
                   )}

--- a/term-board/src/components/InterviewView.tsx
+++ b/term-board/src/components/InterviewView.tsx
@@ -128,7 +128,7 @@ export function InterviewView({ userQuestions }: Props) {
             </span>
           )}
           {current.source === "user" && (
-            <span className="rounded-full bg-fill-quaternary px-2 py-0.5 text-xs font-medium text-label-2">
+            <span className="rounded-full bg-fill-quaternary px-2 py-0.5 text-xs font-medium text-label">
               自作
             </span>
           )}

--- a/term-board/src/hooks/useViewHistory.test.ts
+++ b/term-board/src/hooks/useViewHistory.test.ts
@@ -1,0 +1,55 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useViewHistory } from "./useViewHistory";
+
+const VIEWS = ["home", "quiz", "dictionary"] as const;
+
+beforeEach(() => {
+  // 各テストで履歴とハッシュを初期化（jsdom はファイル単位で共有のため）。
+  window.history.replaceState(null, "", "/");
+});
+
+afterEach(() => {
+  window.history.replaceState(null, "", "/");
+});
+
+describe("useViewHistory", () => {
+  it("hashが無いときは初期値を採用し、replaceStateで #初期 を記録する", () => {
+    const { result } = renderHook(() => useViewHistory(VIEWS, "home"));
+    expect(result.current[0]).toBe("home");
+    expect(window.location.hash).toBe("#home");
+    expect((window.history.state as { view?: string }).view).toBe("home");
+  });
+
+  it("hashが有効なら初期値より優先される", () => {
+    window.history.replaceState(null, "", "/#quiz");
+    const { result } = renderHook(() => useViewHistory(VIEWS, "home"));
+    expect(result.current[0]).toBe("quiz");
+  });
+
+  it("hashが未知の値なら初期値にフォールバック", () => {
+    window.history.replaceState(null, "", "/#bogus");
+    const { result } = renderHook(() => useViewHistory(VIEWS, "home"));
+    expect(result.current[0]).toBe("home");
+  });
+
+  it("setView は pushState で履歴を積む", () => {
+    const { result } = renderHook(() => useViewHistory(VIEWS, "home"));
+    act(() => result.current[1]("quiz"));
+    expect(result.current[0]).toBe("quiz");
+    expect(window.location.hash).toBe("#quiz");
+    expect((window.history.state as { view?: string }).view).toBe("quiz");
+  });
+
+  it("popstate でビューが復元される（戻るボタン相当）", () => {
+    const { result } = renderHook(() => useViewHistory(VIEWS, "home"));
+    act(() => result.current[1]("quiz"));
+    act(() => result.current[1]("dictionary"));
+    // 戻るで quiz へ。jsdom は実 popstate を発火しないため hash 変更 + イベント発火で代用。
+    act(() => {
+      window.history.replaceState({ view: "quiz" }, "", "#quiz");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+    expect(result.current[0]).toBe("quiz");
+  });
+});

--- a/term-board/src/hooks/useViewHistory.ts
+++ b/term-board/src/hooks/useViewHistory.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useState } from "react";
+
+// SPAの戻る/進むでビューを同期する（URLハッシュベース・GitHub Pages 互換）。
+// view が変わったら `history.pushState('#view')` し、ブラウザの戻るで前のビューへ戻れるようにする。
+// 戻った先がアプリ外（リダイレクト前のURLや空ページ）になり真っ暗に見える挙動を防ぐ（#387）。
+
+export function useViewHistory<V extends string>(views: readonly V[], initial: V): readonly [V, (v: V) => void] {
+  const isView = (s: string): s is V => (views as readonly string[]).includes(s);
+  const readHash = (): V => {
+    if (typeof window === "undefined") return initial;
+    const h = window.location.hash.replace(/^#/, "");
+    return isView(h) ? h : initial;
+  };
+
+  const [view, setViewState] = useState<V>(readHash);
+
+  useEffect(() => {
+    // 初回：基準点を必ず履歴に置く（戻る先がアプリ外にならないようにする）。
+    // hash が無ければ現在の view を replaceState で記録、あれば状態だけ同期。
+    if (window.history.state == null || (window.history.state as { view?: string }).view == null) {
+      const cur = readHash();
+      window.history.replaceState({ view: cur }, "", `#${cur}`);
+    }
+    const onPop = () => setViewState(readHash());
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const setView = useCallback((next: V) => {
+    setViewState(next);
+    if (typeof window === "undefined") return;
+    const cur = window.location.hash.replace(/^#/, "");
+    if (cur !== next) {
+      window.history.pushState({ view: next }, "", `#${next}`);
+    }
+  }, []);
+
+  return [view, setView] as const;
+}


### PR DESCRIPTION
## 症状
ブラウザの戻るボタンを押すと画面が真っ暗になる。SPA なのにビューを履歴に積んでおらず、戻るがアプリ外（リダイレクト前URLや空ページ）に出ていたため。

## 修正
- `useViewHistory` フックを追加し、URLハッシュ（`#quiz` 等）で view を履歴に同期。初回マウントで `replaceState(#home)`、`setView` で `pushState`、`popstate` で復元。
- `App.tsx`：`VIEWS` を const 配列化し `View` を導出。`useState<View>` → `useViewHistory(VIEWS, "home")` に差し替え。
- 「自作」バッジ（#386）のコントラストを AA 確保（`text-label-2`→`text-label`）。

## 検証
- Chrome DevTools（preview）：ホーム→4択→戻る、で home に戻りアプリ外に出ない。
- Vitest **33件**（useViewHistory に 5件追加）、E2E smoke **4件**（戻る挙動追加）＋a11y 5件 green。
- `npm run build` green。Lighthouse A11y=100 維持。

Closes #387