### PR TITLE
feat: マイ問題（4択用語・面接Q&A）に編集ボタンを追加

### DIFF
--- a/term-board/e2e/tests/smoke.spec.js
+++ b/term-board/e2e/tests/smoke.spec.js
@@ -65,6 +65,30 @@ test.describe('smoke @smoke', () => {
     await expect(side).toBeHidden();
   });
 
+  test('マイ問題：面接Q&Aを登録→編集して保存できる（#389）', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: 'マイ問題', exact: true }).click();
+    // 1件登録
+    await page.getByLabel('分野・場面 *').fill('志望動機');
+    await page.getByLabel('質問 *').fill('なぜITを志望？');
+    await page.getByLabel('模範回答 *').fill('前職の効率化体験から');
+    await page.getByRole('button', { name: '追加する' }).click();
+    // 登録された項目の編集ボタンを押す
+    await page.getByRole('button', { name: /「なぜITを志望？」を編集/ }).click();
+    // 編集中バナーが出てフィールドが prefill されている
+    await expect(page.getByText(/編集中：なぜITを志望/)).toBeVisible();
+    await expect(page.getByLabel('質問 *')).toHaveValue('なぜITを志望？');
+    // 質問を更新して保存
+    await page.getByLabel('質問 *').fill('なぜIT業界を志望されたのですか？');
+    await page.getByRole('button', { name: '更新する' }).click();
+    // 一覧に更新後の値が出ている
+    await expect(page.getByText('なぜIT業界を志望されたのですか？')).toBeVisible();
+    // 登録件数は1件のまま（編集は新規追加にならない）
+    await expect(page.getByText(/登録した面接Q&A（1件）/)).toBeVisible();
+    // 後始末：削除しておく
+    await page.getByRole('button', { name: /を削除/ }).click();
+  });
+
   test('4択クイズを1問解ける（採点と解説が出る）', async ({ page }) => {
     await page.goto('/');
     await page.getByRole('button', { name: '覚える', exact: true }).click();

--- a/term-board/src/components/AuthorView.tsx
+++ b/term-board/src/components/AuthorView.tsx
@@ -9,6 +9,8 @@ const inputClass =
 const labelClass = "block text-sm font-medium text-label-2";
 const primaryBtn =
   "hig-btn-primary px-5 py-2.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-50";
+const secondaryBtn =
+  "rounded-control bg-fill-quaternary px-5 py-2.5 font-semibold text-label transition hover:brightness-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent";
 
 // F-USER-01/02: 自分で問題を書く（4択用語・面接Q&A）＋共有（エクスポート/インポート）。
 export function AuthorView({ user }: Props) {
@@ -59,32 +61,59 @@ function SubTab({
   );
 }
 
-// --- 面接Q&A 作成フォーム ---
+// --- 面接Q&A 作成フォーム（追加＋編集・#389） ---
 function InterviewForm({ user }: Props) {
+  const [editingId, setEditingId] = useState<string | null>(null);
   const [category, setCategory] = useState("");
   const [question, setQuestion] = useState("");
   const [answer, setAnswer] = useState("");
   const [memo, setMemo] = useState("");
   const valid = category.trim() && question.trim() && answer.trim();
+  const isEditing = editingId !== null;
 
-  const submit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!valid) return;
-    user.addInterviewQuestion({
-      category: category.trim(),
-      question: question.trim(),
-      answer: answer.trim(),
-      memo: memo.trim() || undefined,
-    });
+  const resetForm = () => {
+    setEditingId(null);
     setCategory("");
     setQuestion("");
     setAnswer("");
     setMemo("");
   };
 
+  const startEdit = (id: string) => {
+    const item = user.content.interviewQuestions.find((q) => q.id === id);
+    if (!item) return;
+    setEditingId(id);
+    setCategory(item.category);
+    setQuestion(item.question);
+    setAnswer(item.answer);
+    setMemo(item.memo ?? "");
+  };
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!valid) return;
+    const data = {
+      category: category.trim(),
+      question: question.trim(),
+      answer: answer.trim(),
+      memo: memo.trim() || undefined,
+    };
+    if (editingId) {
+      user.updateInterviewQuestion(editingId, data);
+    } else {
+      user.addInterviewQuestion(data);
+    }
+    resetForm();
+  };
+
   return (
     <div className="flex flex-col gap-5">
       <form onSubmit={submit} className="flex flex-col gap-3 hig-card p-5">
+        {isEditing && (
+          <p className="rounded-control bg-amber-50 px-3 py-2 text-xs font-medium text-amber-800 ring-1 ring-amber-200 dark:bg-amber-950 dark:text-amber-200 dark:ring-amber-900">
+            編集中：{question || "（タイトル未入力）"}
+          </p>
+        )}
         <p className="text-sm text-label-2">
           実際に聞かれた面接の質問と、自分の答え（模範回答）を登録できます。
         </p>
@@ -104,8 +133,15 @@ function InterviewForm({ user }: Props) {
           <label htmlFor="iv-memo" className={labelClass}>メモ（任意）</label>
           <input id="iv-memo" className={inputClass} value={memo} onChange={(e) => setMemo(e.target.value)} placeholder="聞かれた状況・コツなど" />
         </div>
-        <div>
-          <button type="submit" disabled={!valid} className={primaryBtn}>追加する</button>
+        <div className="flex flex-wrap gap-2">
+          <button type="submit" disabled={!valid} className={primaryBtn}>
+            {isEditing ? "更新する" : "追加する"}
+          </button>
+          {isEditing && (
+            <button type="button" onClick={resetForm} className={secondaryBtn}>
+              キャンセル
+            </button>
+          )}
         </div>
       </form>
 
@@ -116,14 +152,19 @@ function InterviewForm({ user }: Props) {
           primary: q.question,
           secondary: `${q.category}｜${q.answer}`,
         }))}
-        onRemove={user.removeInterviewQuestion}
+        onEdit={startEdit}
+        onRemove={(id) => {
+          if (editingId === id) resetForm();
+          user.removeInterviewQuestion(id);
+        }}
       />
     </div>
   );
 }
 
-// --- 4択用語 作成フォーム ---
+// --- 4択用語 作成フォーム（追加＋編集・#389） ---
 function QuizForm({ user }: Props) {
+  const [editingId, setEditingId] = useState<string | null>(null);
   const [term, setTerm] = useState("");
   const [category, setCategory] = useState("");
   const [meaning, setMeaning] = useState("");
@@ -135,25 +176,55 @@ function QuizForm({ user }: Props) {
   const valid =
     term.trim() && category.trim() && meaning.trim() && interview.trim() &&
     d0.trim() && d1.trim() && d2.trim();
+  const isEditing = editingId !== null;
+
+  const resetForm = () => {
+    setEditingId(null);
+    setTerm(""); setCategory(""); setMeaning(""); setD0(""); setD1(""); setD2("");
+    setInterview(""); setPlainMeaning("");
+  };
+
+  const startEdit = (id: string) => {
+    const item = user.content.quizTerms.find((t) => t.id === id);
+    if (!item) return;
+    setEditingId(id);
+    setTerm(item.term);
+    setCategory(item.category);
+    setMeaning(item.meaning);
+    setD0(item.distractors[0] ?? "");
+    setD1(item.distractors[1] ?? "");
+    setD2(item.distractors[2] ?? "");
+    setInterview(item.interview);
+    setPlainMeaning(item.plainMeaning ?? "");
+  };
 
   const submit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!valid) return;
-    user.addQuizTerm({
+    const data = {
       term: term.trim(),
       category: category.trim(),
       meaning: meaning.trim(),
       distractors: [d0.trim(), d1.trim(), d2.trim()],
       interview: interview.trim(),
       plainMeaning: plainMeaning.trim() || undefined,
-    });
-    setTerm(""); setCategory(""); setMeaning(""); setD0(""); setD1(""); setD2("");
-    setInterview(""); setPlainMeaning("");
+    };
+    if (editingId) {
+      user.updateQuizTerm(editingId, data);
+    } else {
+      user.addQuizTerm(data);
+    }
+    resetForm();
   };
 
   return (
     <div className="flex flex-col gap-5">
       <form onSubmit={submit} className="flex flex-col gap-3 hig-card p-5">
+        {isEditing && (
+          <p className="rounded-control bg-amber-50 px-3 py-2 text-xs font-medium text-amber-800 ring-1 ring-amber-200 dark:bg-amber-950 dark:text-amber-200 dark:ring-amber-900">
+            編集中：{term || "（用語未入力）"}
+          </p>
+        )}
         <p className="text-sm text-label-2">
           4択クイズに出る用語を作れます。誤答の選択肢を3つ用意してください。
         </p>
@@ -183,8 +254,15 @@ function QuizForm({ user }: Props) {
           <label htmlFor="q-plain" className={labelClass}>かんたんに言うと（任意）</label>
           <input id="q-plain" className={inputClass} value={plainMeaning} onChange={(e) => setPlainMeaning(e.target.value)} placeholder="中学生にも分かる言い方" />
         </div>
-        <div>
-          <button type="submit" disabled={!valid} className={primaryBtn}>追加する</button>
+        <div className="flex flex-wrap gap-2">
+          <button type="submit" disabled={!valid} className={primaryBtn}>
+            {isEditing ? "更新する" : "追加する"}
+          </button>
+          {isEditing && (
+            <button type="button" onClick={resetForm} className={secondaryBtn}>
+              キャンセル
+            </button>
+          )}
         </div>
       </form>
 
@@ -195,7 +273,11 @@ function QuizForm({ user }: Props) {
           primary: t.term,
           secondary: `${t.category}｜${t.meaning}`,
         }))}
-        onRemove={user.removeQuizTerm}
+        onEdit={startEdit}
+        onRemove={(id) => {
+          if (editingId === id) resetForm();
+          user.removeQuizTerm(id);
+        }}
       />
     </div>
   );
@@ -269,14 +351,16 @@ function SharePanel({ user }: Props) {
   );
 }
 
-// --- 共通：登録済み一覧（削除つき） ---
+// --- 共通：登録済み一覧（編集＋削除・#389） ---
 function ItemList({
   title,
   items,
+  onEdit,
   onRemove,
 }: {
   title: string;
   items: { id: string; primary: string; secondary: string }[];
+  onEdit?: (id: string) => void;
   onRemove: (id: string) => void;
 }) {
   if (items.length === 0) {
@@ -292,13 +376,26 @@ function ItemList({
               <p className="truncate font-medium text-label">{it.primary}</p>
               <p className="truncate text-xs text-label-2">{it.secondary}</p>
             </div>
-            <button
-              type="button"
-              onClick={() => onRemove(it.id)}
-              className="shrink-0 rounded-control px-2 py-1 text-sm text-rose-700 ring-1 ring-rose-200 transition hover:bg-rose-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 dark:text-rose-300 dark:ring-rose-800 dark:hover:bg-rose-950"
-            >
-              削除
-            </button>
+            <div className="flex shrink-0 gap-1">
+              {onEdit && (
+                <button
+                  type="button"
+                  onClick={() => onEdit(it.id)}
+                  aria-label={`「${it.primary}」を編集`}
+                  className="rounded-control px-2 py-1 text-sm font-medium text-accent ring-1 ring-separator transition hover:bg-fill-quaternary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                >
+                  編集
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => onRemove(it.id)}
+                aria-label={`「${it.primary}」を削除`}
+                className="rounded-control px-2 py-1 text-sm text-rose-700 ring-1 ring-rose-200 transition hover:bg-rose-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 dark:text-rose-300 dark:ring-rose-800 dark:hover:bg-rose-950"
+              >
+                削除
+              </button>
+            </div>
           </li>
         ))}
       </ul>

--- a/term-board/src/hooks/useUserContent.ts
+++ b/term-board/src/hooks/useUserContent.ts
@@ -13,6 +13,10 @@ export type UseUserContent = {
   content: UserContent;
   addQuizTerm: (t: NewQuizTerm) => void;
   addInterviewQuestion: (q: NewInterviewQuestion) => void;
+  /** 既存4択用語を更新（id・source は保持）。#389 */
+  updateQuizTerm: (id: string, t: NewQuizTerm) => void;
+  /** 既存面接Q&Aを更新（id・source は保持）。#389 */
+  updateInterviewQuestion: (id: string, q: NewInterviewQuestion) => void;
   removeQuizTerm: (id: string) => void;
   removeInterviewQuestion: (id: string) => void;
   exportCode: () => string;
@@ -57,6 +61,32 @@ export function useUserContent(): UseUserContent {
           ...prev.interviewQuestions,
           { ...q, id: newId(), source: "user" },
         ],
+      };
+      void repository.saveUserContent(next);
+      return next;
+    });
+  }, []);
+
+  // 既存4択用語の更新（id・source を保持）。#389
+  const updateQuizTerm = useCallback((id: string, t: NewQuizTerm) => {
+    setContent((prev) => {
+      const next: UserContent = {
+        ...prev,
+        quizTerms: prev.quizTerms.map((q) => (q.id === id ? { ...q, ...t } : q)),
+      };
+      void repository.saveUserContent(next);
+      return next;
+    });
+  }, []);
+
+  // 既存面接Q&Aの更新（id・source を保持）。#389
+  const updateInterviewQuestion = useCallback((id: string, q: NewInterviewQuestion) => {
+    setContent((prev) => {
+      const next: UserContent = {
+        ...prev,
+        interviewQuestions: prev.interviewQuestions.map((iq) =>
+          iq.id === id ? { ...iq, ...q } : iq,
+        ),
       };
       void repository.saveUserContent(next);
       return next;
@@ -112,6 +142,8 @@ export function useUserContent(): UseUserContent {
     content,
     addQuizTerm,
     addInterviewQuestion,
+    updateQuizTerm,
+    updateInterviewQuestion,
     removeQuizTerm,
     removeInterviewQuestion,
     exportCode,


### PR DESCRIPTION
## 概要
マイ問題で登録した 4択用語 / 面接Q&A に編集機能がなく、誤字や言い換えの調整ができなかった。編集ボタンを追加する。

## 変更
- `src/hooks/useUserContent.ts`：`updateQuizTerm(id, t)` / `updateInterviewQuestion(id, q)` を追加（id・source を保持して入れ替え）。
- `src/components/AuthorView.tsx`：
  - `InterviewForm` / `QuizForm`：`editingId` 状態を保持し、編集時はフィールドを prefill。送信を「追加する → 更新する」に変更し、「キャンセル」ボタンと「編集中：xxx」バナーを表示。編集中の項目を一覧から削除した場合は編集状態をリセット。
  - `ItemList`：「編集」ボタンを追加（削除の左、accent 系の控えめスタイル）。aria-label を「『xxx』を編集/削除」に統一。
- `e2e/tests/smoke.spec.js`：登録→編集→更新→件数維持 の往復をテスト。

## 検証
- `npm run build` green、Vitest **33**、E2E smoke **5**＋a11y **5** green。Lighthouse A11y=100 維持。

Closes #389