### PR TITLE
feat: 用語辞典で複数項目を同時展開可能に＋マイ問題の重複登録を抑止

### DIFF
--- a/term-board/e2e/tests/smoke.spec.js
+++ b/term-board/e2e/tests/smoke.spec.js
@@ -89,6 +89,44 @@ test.describe('smoke @smoke', () => {
     await page.getByRole('button', { name: /を削除/ }).click();
   });
 
+  test('用語辞典で複数項目を同時に展開できる（#397）', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: '覚える', exact: true }).click();
+    await page.getByRole('button', { name: '用語辞典', exact: true }).click();
+    // 検索で件数を絞ってから2件開く
+    await page.getByPlaceholder('用語・意味で検索').fill('TCP');
+    const items = page.locator('ul li button[aria-expanded]');
+    await items.nth(0).click();
+    await items.nth(1).click();
+    // 両方が展開されている（aria-expanded=true が2件以上）
+    await expect(items.nth(0)).toHaveAttribute('aria-expanded', 'true');
+    await expect(items.nth(1)).toHaveAttribute('aria-expanded', 'true');
+    // 「すべて閉じる」で一括クローズ
+    await page.getByRole('button', { name: 'すべて閉じる' }).click();
+    await expect(items.nth(0)).toHaveAttribute('aria-expanded', 'false');
+    await expect(items.nth(1)).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('マイ問題：同じ質問の重複登録は抑止される（#397）', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: 'マイ問題', exact: true }).click();
+    // 1件登録
+    await page.getByLabel('分野・場面 *').fill('技術');
+    await page.getByLabel('質問 *').fill('REST API とは？');
+    await page.getByLabel('模範回答 *').fill('URL とメソッドで操作する設計。');
+    await page.getByRole('button', { name: '追加する' }).click();
+    // 同じ質問でもう一度入力 → 警告が出て「追加する」が無効化される
+    await page.getByLabel('分野・場面 *').fill('技術');
+    await page.getByLabel('質問 *').fill('REST API とは？');
+    await page.getByLabel('模範回答 *').fill('別の回答。');
+    await expect(page.getByText('同じ質問が既に登録されています')).toBeVisible();
+    await expect(page.getByRole('button', { name: '追加する' })).toBeDisabled();
+    // 件数は1件のまま
+    await expect(page.getByText(/登録した面接Q&A（1件）/)).toBeVisible();
+    // 後始末
+    await page.getByRole('button', { name: /を削除/ }).click();
+  });
+
   test('4択クイズを1問解ける（採点と解説が出る）', async ({ page }) => {
     await page.goto('/');
     await page.getByRole('button', { name: '覚える', exact: true }).click();

--- a/term-board/src/components/AuthorView.tsx
+++ b/term-board/src/components/AuthorView.tsx
@@ -89,9 +89,17 @@ function InterviewForm({ user }: Props) {
     setMemo(item.memo ?? "");
   };
 
+  // #397: 既に同じ質問が登録済みかどうか（編集中は自分自身を除外）。
+  const trimmedQ = question.trim();
+  const isDuplicate =
+    !!trimmedQ &&
+    user.content.interviewQuestions.some(
+      (q) => q.question.trim() === trimmedQ && q.id !== editingId,
+    );
+
   const submit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!valid) return;
+    if (!valid || isDuplicate) return;
     const data = {
       category: category.trim(),
       question: question.trim(),
@@ -114,6 +122,11 @@ function InterviewForm({ user }: Props) {
             編集中：{question || "（タイトル未入力）"}
           </p>
         )}
+        {isDuplicate && (
+          <p role="alert" className="rounded-control bg-rose-50 px-3 py-2 text-xs font-medium text-rose-700 ring-1 ring-rose-200 dark:bg-rose-950 dark:text-rose-300 dark:ring-rose-900">
+            同じ質問が既に登録されています。重複登録は抑止しました。
+          </p>
+        )}
         <p className="text-sm text-label-2">
           実際に聞かれた面接の質問と、自分の答え（模範回答）を登録できます。
         </p>
@@ -134,7 +147,7 @@ function InterviewForm({ user }: Props) {
           <input id="iv-memo" className={inputClass} value={memo} onChange={(e) => setMemo(e.target.value)} placeholder="聞かれた状況・コツなど" />
         </div>
         <div className="flex flex-wrap gap-2">
-          <button type="submit" disabled={!valid} className={primaryBtn}>
+          <button type="submit" disabled={!valid || isDuplicate} className={primaryBtn}>
             {isEditing ? "更新する" : "追加する"}
           </button>
           {isEditing && (
@@ -198,9 +211,17 @@ function QuizForm({ user }: Props) {
     setPlainMeaning(item.plainMeaning ?? "");
   };
 
+  // #397: 既に同じ用語名（自作分）が登録済みかどうか（編集中は自分自身を除外）。
+  const trimmedT = term.trim();
+  const isDuplicate =
+    !!trimmedT &&
+    user.content.quizTerms.some(
+      (t) => t.term.trim() === trimmedT && t.id !== editingId,
+    );
+
   const submit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!valid) return;
+    if (!valid || isDuplicate) return;
     const data = {
       term: term.trim(),
       category: category.trim(),
@@ -223,6 +244,11 @@ function QuizForm({ user }: Props) {
         {isEditing && (
           <p className="rounded-control bg-amber-50 px-3 py-2 text-xs font-medium text-amber-800 ring-1 ring-amber-200 dark:bg-amber-950 dark:text-amber-200 dark:ring-amber-900">
             編集中：{term || "（用語未入力）"}
+          </p>
+        )}
+        {isDuplicate && (
+          <p role="alert" className="rounded-control bg-rose-50 px-3 py-2 text-xs font-medium text-rose-700 ring-1 ring-rose-200 dark:bg-rose-950 dark:text-rose-300 dark:ring-rose-900">
+            同じ用語が既に登録されています。重複登録は抑止しました。
           </p>
         )}
         <p className="text-sm text-label-2">
@@ -255,7 +281,7 @@ function QuizForm({ user }: Props) {
           <input id="q-plain" className={inputClass} value={plainMeaning} onChange={(e) => setPlainMeaning(e.target.value)} placeholder="中学生にも分かる言い方" />
         </div>
         <div className="flex flex-wrap gap-2">
-          <button type="submit" disabled={!valid} className={primaryBtn}>
+          <button type="submit" disabled={!valid || isDuplicate} className={primaryBtn}>
             {isEditing ? "更新する" : "追加する"}
           </button>
           {isEditing && (

--- a/term-board/src/components/DictionaryView.tsx
+++ b/term-board/src/components/DictionaryView.tsx
@@ -18,7 +18,17 @@ export function DictionaryView({ bookmarks }: Props) {
   const [category, setCategory] = useState("");
   const [onlyBookmarked, setOnlyBookmarked] = useState(false);
   const [sort, setSort] = useState<"default" | "asc" | "desc">("default");
-  const [openId, setOpenId] = useState<string | null>(null);
+  // #397: 複数項目を同時に展開できるよう Set で管理する（旧来の単一 openId からの拡張）。
+  const [openIds, setOpenIds] = useState<Set<string>>(new Set());
+  const isOpen = (id: string) => openIds.has(id);
+  const toggleOpen = (id: string) => {
+    setOpenIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
 
   useEffect(() => {
     let active = true;
@@ -102,17 +112,37 @@ export function DictionaryView({ bookmarks }: Props) {
         </div>
       </div>
 
-      <p className="text-sm text-label-2">{filtered.length} 件</p>
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-sm text-label-2">{filtered.length} 件</p>
+        {filtered.length > 0 && (
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => setOpenIds(new Set(filtered.map((t) => t.id)))}
+              className="rounded-control px-2 py-1 text-xs font-medium text-accent ring-1 ring-separator transition hover:bg-fill-quaternary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              すべて開く
+            </button>
+            <button
+              type="button"
+              onClick={() => setOpenIds(new Set())}
+              className="rounded-control px-2 py-1 text-xs font-medium text-label-2 ring-1 ring-separator transition hover:bg-fill-quaternary hover:text-label focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              すべて閉じる
+            </button>
+          </div>
+        )}
+      </div>
 
       <ul className="flex flex-col gap-2">
         {filtered.map((t) => {
-          const open = openId === t.id;
+          const open = isOpen(t.id);
           return (
             <li key={t.id} className="hig-card">
               <div className="flex items-center gap-2 p-3">
                 <button
                   type="button"
-                  onClick={() => setOpenId(open ? null : t.id)}
+                  onClick={() => toggleOpen(t.id)}
                   aria-expanded={open}
                   className="flex min-w-0 flex-1 items-center gap-2 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                 >


### PR DESCRIPTION
## 概要
ご報告いただいた2件を修正。

### ① 用語辞典で一度に1件しか中身が見られない
複数項目の中身を見比べたい時に毎回前のを閉じる必要があり不便だった。**複数同時に展開可能** に変更。

### ② 「REST API」が同梱1＋自作2で重複していた
スクリーンショットで自作問題に同じ用語が二重登録されていた。**重複登録を抑止** する。

## 変更
### `src/components/DictionaryView.tsx`
- `openId: string | null` → `openIds: Set<string>` に変更。
- `toggleOpen(id)` で各項目を独立に開閉。
- フィルタ近くに「すべて開く／閉じる」のクイックアクションを追加。

### `src/components/AuthorView.tsx`
- InterviewForm / QuizForm に `isDuplicate` 判定を追加。同じ `question`（面接Q&A）／`term`（4択用語）が既に登録済みの場合、警告バナーを表示し「追加する」ボタンを無効化。**編集中は自分自身を除外** して判定。

### `e2e/tests/smoke.spec.js`
- 複数項目の同時展開→「すべて閉じる」の往復をテスト。
- 同じ質問を二度追加しようとすると抑止される（件数1件のまま）テスト。

## 既存の重複データについて
既に登録済みの REST API ×2 などのユーザーデータは、マイ問題の **削除ボタン** で除去いただけます（今回の修正は **以後の重複登録の予防**）。

## 検証
- `npm run build` green、Vitest **33**、E2E smoke **7**＋a11y **5** = **12 件 green**

Closes #397