### PR TITLE
feat: ホームのヒーロー・見出しに kicker＋Display 書体を導入

### DIFF
--- a/term-board/src/components/HomeView.tsx
+++ b/term-board/src/components/HomeView.tsx
@@ -44,10 +44,11 @@ const MODE_GROUPS: { label: string; modes: Mode[] }[] = [
 export function HomeView({ onNavigate }: Props) {
   return (
     <section className="flex flex-col gap-6">
-      {/* ヒーロー */}
-      <div className="rounded-card bg-gradient-to-br from-sky-700 to-sky-900 p-6 text-white shadow-sm">
-        <h2 className="text-2xl font-bold tracking-tight">IT用語を「面接で言える」まで。</h2>
-        <p className="mt-2 text-sm leading-relaxed text-sky-50">
+      {/* ヒーロー：Display 書体＋kicker で「華」を出す（#399） */}
+      <div className="rounded-card bg-gradient-to-br from-sky-700 to-sky-900 p-8 text-white shadow-sm">
+        <p className="hig-kicker text-sky-200/90">term-board</p>
+        <h2 className="hig-display mt-2 text-2xl text-white sm:text-3xl">IT用語を「面接で言える」まで。</h2>
+        <p className="mt-4 max-w-xl text-base leading-relaxed text-sky-50/95">
           IT業界へ初めて転職する人のための学習アプリ。4択で覚えて、面接で自分の言葉にする。
           ログイン不要・無料・ブラウザだけで今すぐ。
         </p>
@@ -70,9 +71,10 @@ export function HomeView({ onNavigate }: Props) {
       </div>
 
       {/* 使い方の流れ */}
-      <div className="hig-card p-5">
-        <h2 className="text-sm font-semibold text-label">おすすめの進め方</h2>
-        <ol className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-label">
+      <div className="hig-card p-6">
+        <p className="hig-kicker">FLOW</p>
+        <h2 className="hig-display mt-1 text-base font-semibold text-label">おすすめの進め方</h2>
+        <ol className="mt-4 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-label">
           <li className="font-medium">① 学ぶ（全体像）</li>
           <li aria-hidden="true" className="text-label-3">→</li>
           <li className="font-medium">② 4択で定着</li>
@@ -84,11 +86,14 @@ export function HomeView({ onNavigate }: Props) {
       </div>
 
       {/* モード一覧（ナビと同じ4グループで整理） */}
-      <div className="flex flex-col gap-5">
-        <h2 className="text-sm font-semibold text-label">機能から選ぶ</h2>
+      <div className="flex flex-col gap-6">
+        <div>
+          <p className="hig-kicker">MODES</p>
+          <h2 className="hig-display mt-1 text-base font-semibold text-label">機能から選ぶ</h2>
+        </div>
         {MODE_GROUPS.map((group) => (
           <div key={group.label}>
-            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-label-2">
+            <h3 className="hig-kicker mb-3">
               {group.label}
             </h3>
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">

--- a/term-board/src/index.css
+++ b/term-board/src/index.css
@@ -75,6 +75,21 @@ html {
 }
 
 @layer components {
+  /* Display 見出し：SF Pro Display 風（大きく軽く、字間を締める）。 */
+  .hig-display {
+    font-weight: 500;
+    letter-spacing: -0.022em;
+    line-height: 1.1;
+  }
+  /* kicker：オールキャップスの小キャプション。Display 見出しの余韻を作る。 */
+  .hig-kicker {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--color-label-3);
+  }
+
   /* HIG カード：面 + 角丸 + ヘアライン罫線。全画面共通の基本ブロック。 */
   .hig-card {
     background-color: var(--color-surface);


### PR DESCRIPTION
## 関連 Issue

Closes #399

---

## 変更の概要

PC版ホームが質素に見えるレビューを受け、書体だけで効く控えめな「華」を追加（4案を実機比較した結果、案②を採用）。

- `index.css` に `.hig-display` / `.hig-kicker` を追加（全画面で再利用できるユーティリティ）
- `HomeView`
  - ヒーロー：`TERM-BOARD` kicker ＋ Display 級 h2（`text-2xl sm:text-3xl hig-display`）
  - 「おすすめの進め方」「機能から選ぶ」: `FLOW` / `MODES` kicker ＋ Display h2
  - グループ見出し（覚える/面接対策/学ぶ・記録/マイ問題）を kicker 化

階層: ヒーロー h2 > セクション h2 > グループ h3(kicker)。色や装飾は増やさず、書体と余白でメリハリを付ける方針。

## 変更の種別

- [x] feat（新機能の追加）
- [ ] fix
- [ ] docs
- [ ] style
- [ ] refactor
- [ ] test
- [ ] chore

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（PC 1440px / モバイル 390px）
- [x] 既存の機能が壊れていないことを確認した（`npm run build` green / `npm run test` 33/33 green）
- [x] `.env` ファイルやパスワードをコミットしていない

---

## スクリーンショット

PC 1440px:

| Before | After |
|---|---|
| baseline（ヒーロー `text-2xl` のみ、kicker なし） | TERM-BOARD kicker＋Display h2、各セクションに FLOW/MODES kicker |

実装画面はローカル比較で確認済み（添付は省略）。

---

## レビュー時に特に確認してほしい点

- ヒーロー見出しのサイズ感（`text-2xl sm:text-3xl`）。レビュー中に「大きい」とフィードバックを受けて一段下げ済み。
- セクション見出し（`text-base font-semibold`）が小さすぎないか。
- 後続 PR で 案①（グループアクセントカラー）を機能カードに追加予定。