### PR TITLE
feat: ホームの機能カードに4グループのアクセントカラーを導入

### DIFF
--- a/term-board/src/components/HomeView.tsx
+++ b/term-board/src/components/HomeView.tsx
@@ -4,10 +4,20 @@ type Props = { onNavigate: (view: Target) => void };
 
 type Mode = { key: Target; title: string; desc: string };
 
+// グループ別アクセント色（CSS 変数で light/dark を自動切替）。
+type GroupAccent = "memorize" | "interview" | "learn" | "author";
+const ACCENT_VAR: Record<GroupAccent, string> = {
+  memorize: "var(--color-accent-memorize)",
+  interview: "var(--color-accent-interview)",
+  learn: "var(--color-accent-learn)",
+  author: "var(--color-accent-author)",
+};
+
 // ナビ（App.tsx の NAV_GROUPS）と同じ4グループで整理し、一貫した導線にする。
-const MODE_GROUPS: { label: string; modes: Mode[] }[] = [
+const MODE_GROUPS: { label: string; accent: GroupAccent; modes: Mode[] }[] = [
   {
     label: "覚える",
+    accent: "memorize",
     modes: [
       { key: "quiz", title: "4択クイズ", desc: "用語の意味を4択で。即採点＋解説で定着させる。" },
       { key: "card", title: "暗記カード", desc: "表に用語、裏に意味。タップで裏返してサクッと暗記。" },
@@ -16,6 +26,7 @@ const MODE_GROUPS: { label: string; modes: Mode[] }[] = [
   },
   {
     label: "面接対策",
+    accent: "interview",
     modes: [
       { key: "interview", title: "面接練習", desc: "面接の質問（志望動機・技術など）に声で答え、模範回答・型・NG例で確認。" },
       { key: "mock", title: "模擬面接", desc: "用語の説明を30秒で。模範解答と並べて3観点で自己採点。" },
@@ -25,6 +36,7 @@ const MODE_GROUPS: { label: string; modes: Mode[] }[] = [
   },
   {
     label: "学ぶ・記録",
+    accent: "learn",
     modes: [
       { key: "learn", title: "学ぶ", desc: "学習ロードマップ・職種解説・図解で全体像をつかむ。" },
       { key: "dashboard", title: "ダッシュボード", desc: "正答率・苦手・連続学習を可視化。次の一手が分かる。" },
@@ -34,6 +46,7 @@ const MODE_GROUPS: { label: string; modes: Mode[] }[] = [
   },
   {
     label: "マイ問題",
+    accent: "author",
     modes: [
       { key: "author", title: "マイ問題", desc: "自分で問題を作り、共有コードで配布・取り込み。" },
     ],
@@ -91,26 +104,38 @@ export function HomeView({ onNavigate }: Props) {
           <p className="hig-kicker">MODES</p>
           <h2 className="hig-display mt-1 text-base font-semibold text-label">機能から選ぶ</h2>
         </div>
-        {MODE_GROUPS.map((group) => (
-          <div key={group.label}>
-            <h3 className="hig-kicker mb-3">
-              {group.label}
-            </h3>
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-              {group.modes.map((m) => (
-                <button
-                  key={m.key}
-                  type="button"
-                  onClick={() => onNavigate(m.key)}
-                  className="hig-card p-4 text-left transition hover:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent active:scale-[0.99]"
-                >
-                  <p className="font-semibold text-label">{m.title}</p>
-                  <p className="mt-1 text-sm text-label-2">{m.desc}</p>
-                </button>
-              ))}
+        {MODE_GROUPS.map((group) => {
+          const accentVar = ACCENT_VAR[group.accent];
+          return (
+            <div key={group.label}>
+              <h3
+                className="hig-kicker mb-3 flex items-center gap-2"
+                style={{ color: accentVar }}
+              >
+                <span
+                  aria-hidden="true"
+                  className="inline-block h-1.5 w-1.5 rounded-full"
+                  style={{ backgroundColor: accentVar }}
+                />
+                {group.label}
+              </h3>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                {group.modes.map((m) => (
+                  <button
+                    key={m.key}
+                    type="button"
+                    onClick={() => onNavigate(m.key)}
+                    className="hig-card hig-card-accent p-4 pl-5 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-accent active:scale-[0.99]"
+                    style={{ ["--accent-color" as string]: accentVar }}
+                  >
+                    <p className="font-semibold text-label">{m.title}</p>
+                    <p className="mt-1 text-sm text-label-2">{m.desc}</p>
+                  </button>
+                ))}
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </section>
   );

--- a/term-board/src/index.css
+++ b/term-board/src/index.css
@@ -36,6 +36,12 @@
   /* 角丸（iOS のカード ~14、コントロール ~10） */
   --radius-card: 14px;
   --radius-control: 10px;
+
+  /* グループアクセント（彩度を抑え、毎日使いに合う範囲） */
+  --color-accent-memorize: var(--c-cat-memorize);
+  --color-accent-interview: var(--c-cat-interview);
+  --color-accent-learn: var(--c-cat-learn);
+  --color-accent-author: var(--c-cat-author);
 }
 
 :root {
@@ -50,6 +56,10 @@
   --c-accent: #0066cc;
   --c-accent-fill: #0066cc;
   --c-fill-4: rgba(118, 118, 128, 0.12);
+  --c-cat-memorize: #5b6cf0;
+  --c-cat-interview: #14a39a;
+  --c-cat-learn: #c9892b;
+  --c-cat-author: #d6529e;
 }
 
 .dark {
@@ -64,6 +74,10 @@
   --c-accent: #5aa9ff;
   --c-accent-fill: #0a84ff;
   --c-fill-4: rgba(118, 118, 128, 0.24);
+  --c-cat-memorize: #8a96ff;
+  --c-cat-interview: #45c8be;
+  --c-cat-learn: #e9b557;
+  --c-cat-author: #ee7fbf;
 }
 
 html {
@@ -96,6 +110,27 @@ html {
     border-radius: var(--radius-card);
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
     border: 1px solid var(--color-separator);
+  }
+
+  /* グループ別アクセント付きカード：左 3px のバー＋ホバーで弱い tint。
+     使い方: <button class="hig-card hig-card-accent" style="--accent-color: var(--color-accent-memorize)"> */
+  .hig-card-accent {
+    position: relative;
+    overflow: hidden;
+    transition: background-color 0.15s ease, border-color 0.15s ease;
+  }
+  .hig-card-accent::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 3px;
+    background: var(--accent-color, var(--color-accent));
+  }
+  .hig-card-accent:hover {
+    background-color: color-mix(in oklab, var(--color-surface) 94%, var(--accent-color, var(--color-accent)));
+    border-color: color-mix(in oklab, var(--color-separator) 60%, var(--accent-color, var(--color-accent)));
   }
 
   /* 塗りボタン（systemBlue・白文字で AA）。iOS の角丸・押し心地に寄せる。 */


### PR DESCRIPTION
## 関連 Issue

Closes #401

---

## 変更の概要

PC版「華」アップ第2弾（#400 の書体・kicker 強化の続き）。書体だけでは色味が控えめだったため、4グループに彩度を抑えたアクセント色を当てて識別性を上げる。

- `index.css` に CSS 変数を追加（`:root` と `.dark` の両方）
  - `--c-cat-memorize` (覚える / indigo)
  - `--c-cat-interview` (面接対策 / teal)
  - `--c-cat-learn` (学ぶ・記録 / amber)
  - `--c-cat-author` (マイ問題 / pink)
- `.hig-card-accent` クラス：左 3px のアクセントバー＋ホバーで弱い tint（`color-mix(in oklab, …)`）
- `HomeView` のグループ kicker に色付きドット＋色文字、機能カードに `hig-card-accent` 適用

将来の用語辞典（9分野）拡張に再利用できるユーティリティ設計。

## 変更の種別

- [x] feat（新機能の追加）
- [ ] fix
- [ ] docs
- [ ] style
- [ ] refactor
- [ ] test
- [ ] chore

---

## 動作確認チェックリスト

- [x] ローカルで PC 1440px と モバイル 390px で確認
- [x] ライト / ダーク両方で表示崩れなし（ダーク用に各色を一段明るく）
- [x] `npm run build` green / `npm run test` 33/33 green
- [x] `.env` ファイルやパスワードをコミットしていない

---

## スクリーンショット

| Mode | 状態 |
|---|---|
| Light | カード左 3px のアクセントバー＋グループ kicker のドット＋色文字 |
| Dark  | 同左（色は light より一段明るく） |

実装画面はローカルで light/dark を切替して確認済み。

---

## レビュー時に特に確認してほしい点

- 色の彩度感（毎日見ても疲れない範囲か）。
- kicker の色文字が AA を満たしているか（背景は `bg-surface` / `bg-canvas`）。
- 3px の左バーが過度に目立っていないか。