### PR TITLE
feat: ホームをPC向け横型カンバンに刷新（4列＋ヒーロー横並び）

### DIFF
--- a/term-board/src/App.tsx
+++ b/term-board/src/App.tsx
@@ -150,12 +150,18 @@ export default function App() {
   );
 
   const sidebar = nav.layout === "sidebar";
+  // ホームのみ PC で広いコンテンツ幅にして、4列カンバンの横レイアウトを活かす。
+  // 他ビュー（辞典・面接練習など）は本文の可読幅を優先して従来の max-w-2xl を維持。
+  const wideHome = view === "home";
+  const mainWidth = wideHome ? "max-w-6xl" : "max-w-2xl";
+  // ヘッダーはビュー切替で幅が動くと違和感が出るため、常に広い幅で固定。
+  const headerWidth = sidebar ? "max-w-5xl" : "max-w-6xl";
 
   return (
     <div className="min-h-screen bg-canvas text-label">
       {/* iOS/macOS のナビバー風：上部固定・半透明 + backdrop blur（素材感）。 */}
       <header className="sticky top-0 z-20 border-b border-separator bg-bar backdrop-blur-xl backdrop-saturate-150">
-        <div className={`mx-auto flex flex-col gap-3 px-4 py-3 ${sidebar ? "max-w-5xl" : "max-w-2xl"}`}>
+        <div className={`mx-auto flex flex-col gap-3 px-4 py-3 ${headerWidth}`}>
           <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-start justify-between gap-2">
               <div>
@@ -198,13 +204,13 @@ export default function App() {
       {sidebar ? (
         <div className="mx-auto flex w-full max-w-5xl gap-6 px-4 py-6">
           <main className="min-w-0 flex-1">
-            <div className="mx-auto max-w-2xl">{viewContent}</div>
+            <div className={`mx-auto ${mainWidth}`}>{viewContent}</div>
           </main>
           {/* サイドバーは右側に配置（#383）。 */}
           <SideNav view={view} setView={setView} className="hidden w-56 shrink-0 lg:block" />
         </div>
       ) : (
-        <main className="mx-auto max-w-2xl px-4 py-6">{viewContent}</main>
+        <main className={`mx-auto ${mainWidth} px-4 py-6`}>{viewContent}</main>
       )}
     </div>
   );

--- a/term-board/src/components/HomeView.tsx
+++ b/term-board/src/components/HomeView.tsx
@@ -56,86 +56,88 @@ const MODE_GROUPS: { label: string; accent: GroupAccent; modes: Mode[] }[] = [
 // B7: トップページ（アプリ紹介・各モードへの入口）。
 export function HomeView({ onNavigate }: Props) {
   return (
-    <section className="flex flex-col gap-6">
-      {/* ヒーロー：Display 書体＋kicker で「華」を出す（#399） */}
-      <div className="rounded-card bg-gradient-to-br from-sky-700 to-sky-900 p-8 text-white shadow-sm">
-        <p className="hig-kicker text-sky-200/90">term-board</p>
-        <h2 className="hig-display mt-2 text-2xl text-white sm:text-3xl">IT用語を「面接で言える」まで。</h2>
-        <p className="mt-4 max-w-xl text-base leading-relaxed text-sky-50/95">
-          IT業界へ初めて転職する人のための学習アプリ。4択で覚えて、面接で自分の言葉にする。
-          ログイン不要・無料・ブラウザだけで今すぐ。
-        </p>
-        <div className="mt-4 flex flex-wrap gap-2">
-          <button
-            type="button"
-            onClick={() => onNavigate("quiz")}
-            className="rounded-control bg-white px-5 py-2.5 font-semibold text-sky-800 transition hover:bg-sky-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-white active:scale-[0.98]"
-          >
-            今すぐ4択を始める
-          </button>
-          <button
-            type="button"
-            onClick={() => onNavigate("learn")}
-            className="rounded-control px-5 py-2.5 font-semibold text-white ring-1 ring-white/70 transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white active:scale-[0.98]"
-          >
-            学習ロードマップを見る
-          </button>
+    <section className="flex flex-col gap-4">
+      {/* ヒーロー＋FLOW: PC(lg+) は横並びにして縦スクロールを抑え、機能カードを上に引き上げる。 */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        {/* ヒーロー */}
+        <div className="rounded-card bg-gradient-to-br from-sky-700 to-sky-900 p-5 text-white shadow-sm lg:col-span-2">
+          <p className="hig-kicker text-sky-200/90">term-board</p>
+          <h2 className="hig-display mt-1 text-xl text-white sm:text-2xl">IT用語を「面接で言える」まで。</h2>
+          <p className="mt-2 max-w-xl text-sm leading-relaxed text-sky-50/95">
+            IT業界へ初めて転職する人のための学習アプリ。4択で覚えて、面接で自分の言葉にする。
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => onNavigate("quiz")}
+              className="rounded-control bg-white px-4 py-2 text-sm font-semibold text-sky-800 transition hover:bg-sky-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-white active:scale-[0.98]"
+            >
+              今すぐ4択を始める
+            </button>
+            <button
+              type="button"
+              onClick={() => onNavigate("learn")}
+              className="rounded-control px-4 py-2 text-sm font-semibold text-white ring-1 ring-white/70 transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white active:scale-[0.98]"
+            >
+              学習ロードマップを見る
+            </button>
+          </div>
+        </div>
+
+        {/* 使い方の流れ */}
+        <div className="hig-card p-4">
+          <p className="hig-kicker">FLOW</p>
+          <h2 className="hig-display mt-0.5 text-sm font-semibold text-label">おすすめの進め方</h2>
+          <ol className="mt-2 flex flex-col gap-1 text-sm text-label">
+            <li className="font-medium">① 学ぶ（全体像）</li>
+            <li className="font-medium">② 4択で定着</li>
+            <li className="font-medium">③ 面接練習で言える</li>
+            <li className="font-medium">④ 自己PRを整える</li>
+          </ol>
         </div>
       </div>
 
-      {/* 使い方の流れ */}
-      <div className="hig-card p-6">
-        <p className="hig-kicker">FLOW</p>
-        <h2 className="hig-display mt-1 text-base font-semibold text-label">おすすめの進め方</h2>
-        <ol className="mt-4 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-label">
-          <li className="font-medium">① 学ぶ（全体像）</li>
-          <li aria-hidden="true" className="text-label-3">→</li>
-          <li className="font-medium">② 4択で定着</li>
-          <li aria-hidden="true" className="text-label-3">→</li>
-          <li className="font-medium">③ 面接練習で言える</li>
-          <li aria-hidden="true" className="text-label-3">→</li>
-          <li className="font-medium">④ 自己PRを整える</li>
-        </ol>
-      </div>
-
-      {/* モード一覧（ナビと同じ4グループで整理） */}
-      <div className="flex flex-col gap-6">
+      {/* モード一覧（ナビと同じ4グループで整理）。
+          PC(lg+) は 4 グループ = 4 列のカンバン、タブレットは 1 列に sm:2 列、モバイルは 1 列。 */}
+      <div className="flex flex-col gap-4">
         <div>
           <p className="hig-kicker">MODES</p>
           <h2 className="hig-display mt-1 text-base font-semibold text-label">機能から選ぶ</h2>
         </div>
-        {MODE_GROUPS.map((group) => {
-          const accentVar = ACCENT_VAR[group.accent];
-          return (
-            <div key={group.label}>
-              <h3
-                className="hig-kicker mb-3 flex items-center gap-2"
-                style={{ color: accentVar }}
-              >
-                <span
-                  aria-hidden="true"
-                  className="inline-block h-1.5 w-1.5 rounded-full"
-                  style={{ backgroundColor: accentVar }}
-                />
-                {group.label}
-              </h3>
-              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                {group.modes.map((m) => (
-                  <button
-                    key={m.key}
-                    type="button"
-                    onClick={() => onNavigate(m.key)}
-                    className="hig-card hig-card-accent p-4 pl-5 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-accent active:scale-[0.99]"
-                    style={{ ["--accent-color" as string]: accentVar }}
-                  >
-                    <p className="font-semibold text-label">{m.title}</p>
-                    <p className="mt-1 text-sm text-label-2">{m.desc}</p>
-                  </button>
-                ))}
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-4 lg:gap-5">
+          {MODE_GROUPS.map((group) => {
+            const accentVar = ACCENT_VAR[group.accent];
+            return (
+              <div key={group.label} className="flex flex-col gap-3">
+                <h3
+                  className="hig-kicker flex items-center gap-2"
+                  style={{ color: accentVar }}
+                >
+                  <span
+                    aria-hidden="true"
+                    className="inline-block h-1.5 w-1.5 rounded-full"
+                    style={{ backgroundColor: accentVar }}
+                  />
+                  {group.label}
+                </h3>
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-1">
+                  {group.modes.map((m) => (
+                    <button
+                      key={m.key}
+                      type="button"
+                      onClick={() => onNavigate(m.key)}
+                      className="hig-card hig-card-accent p-4 pl-5 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-accent active:scale-[0.99]"
+                      style={{ ["--accent-color" as string]: accentVar }}
+                    >
+                      <p className="font-semibold text-label">{m.title}</p>
+                      <p className="mt-1 text-sm text-label-2">{m.desc}</p>
+                    </button>
+                  ))}
+                </div>
               </div>
-            </div>
-          );
-        })}
+            );
+          })}
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
## 関連 Issue

Closes #423

---

## 変更の概要

PC で「モバイル版の焼き直し」に見えていたホームを、PC らしい横型レイアウトに作り直した。

- `App.tsx`
  - ホーム時のみ main を `max-w-6xl` に広げる（他ビューは `max-w-2xl` の可読幅を維持）
  - ヘッダーは常に `max-w-6xl`（toolbar）/ `max-w-5xl`（sidebar）で固定し、ビュー切替で幅が動かないように
- `HomeView`
  - lg+ で **ヒーロー(2/3) + FLOW(1/3) を横並び** に
  - MODES を **lg+ で 4 グループ = 4 列のカンバン** に（外側 `lg:grid-cols-4`、内側 `lg:grid-cols-1`）
  - ヒーロー / FLOW のフォントサイズ・padding を縮小し、PC で「機能から選ぶ」がファーストビューに収まるよう調整
- タブレット（sm-lg）はグループ縦並び＋カード2列の従来挙動を維持
- モバイル（<sm）は完全に縦並び、崩れなし

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] PC 1440px：4列カンバン + ヒーロー横並びがファーストビューに収まる
- [x] タブレット 768px：従来の縦並び+カード2列を維持
- [x] モバイル 390px：完全縦並び、崩れなし
- [x] ライト / ダーク両対応
- [x] 4択クイズ等の他ビューに遷移してもヘッダー幅は固定
- [x] `npm run build` green / `npm run test` 33/33 green
- [x] `.env` ファイルやパスワードをコミットしていない

---

## スクリーンショット

ローカルで PC/tablet/mobile × light/dark を全て確認済み（添付省略）。

---

## レビュー時に特に確認してほしい点

- ヒーロー＋FLOW を 2:1 で横並びにした際の比率（FLOW が縦の番号リストに変化）。
- ホームとそれ以外のビューでコンテンツ幅が変わる（`max-w-6xl` ⇄ `max-w-2xl`）が、ヘッダー幅は固定にしたので違和感は最小化したつもり。