### PR TITLE
feat: 逆質問ストックをマイ問題（UserContent）に統合し共有可能に

### DIFF
--- a/term-board/src/App.tsx
+++ b/term-board/src/App.tsx
@@ -145,7 +145,7 @@ export default function App() {
       {view === "mock" && <MockInterviewView />}
       {view === "guide" && <GuideView userQuestions={user.content.interviewQuestions} />}
       {view === "author" && <AuthorView user={user} />}
-      {view === "reverseq" && <ReverseQuestionStock />}
+      {view === "reverseq" && <ReverseQuestionStock user={user} />}
     </>
   );
 

--- a/term-board/src/api/localStorageTermRepository.ts
+++ b/term-board/src/api/localStorageTermRepository.ts
@@ -58,18 +58,33 @@ function readProgressFrom(key: string): Progress {
 function readUserContent(): UserContent {
   try {
     const raw = localStorage.getItem(USER_CONTENT_KEY);
-    if (!raw) return EMPTY_USER_CONTENT;
-    const parsed: unknown = JSON.parse(raw);
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-      return EMPTY_USER_CONTENT;
-    }
-    const obj = parsed as Partial<UserContent>;
-    return {
-      quizTerms: Array.isArray(obj.quizTerms) ? obj.quizTerms : [],
-      interviewQuestions: Array.isArray(obj.interviewQuestions) ? obj.interviewQuestions : [],
-    };
+    const parsed: unknown = raw ? JSON.parse(raw) : null;
+    const obj =
+      typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+        ? (parsed as Partial<UserContent>)
+        : {};
+    const quizTerms = Array.isArray(obj.quizTerms) ? obj.quizTerms : [];
+    const interviewQuestions = Array.isArray(obj.interviewQuestions) ? obj.interviewQuestions : [];
+    // #425: 逆質問が UserContent 側に未設定なら、旧キーから取り込んで一段化する
+    // （次回 saveUserContent で UserContent 側に永続化される）。
+    const fromUserContent = Array.isArray(obj.reverseQuestions) ? obj.reverseQuestions : null;
+    const reverseQuestions = fromUserContent ?? readLegacyReverseQuestions();
+    return { quizTerms, interviewQuestions, reverseQuestions };
   } catch {
     return EMPTY_USER_CONTENT;
+  }
+}
+
+// 旧 reverseQuestions:v1（#425 統合前の独立キー）の読み込み。
+// 破損時は空配列。
+function readLegacyReverseQuestions(): string[] {
+  try {
+    const raw = localStorage.getItem(REVERSE_Q_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === "string") : [];
+  } catch {
+    return [];
   }
 }
 
@@ -237,26 +252,6 @@ export const localStorageTermRepository: TermRepository = {
       localStorage.setItem(NOTES_KEY, JSON.stringify(notes));
     } catch {
       console.warn("[term-board] 学習メモの保存に失敗しました。");
-    }
-  },
-
-  async getReverseQuestions(): Promise<string[]> {
-    try {
-      const raw = localStorage.getItem(REVERSE_Q_KEY);
-      if (!raw) return [];
-      const parsed: unknown = JSON.parse(raw);
-      if (!Array.isArray(parsed)) return [];
-      return parsed.filter((q): q is string => typeof q === "string");
-    } catch {
-      return [];
-    }
-  },
-
-  async saveReverseQuestions(questions: string[]): Promise<void> {
-    try {
-      localStorage.setItem(REVERSE_Q_KEY, JSON.stringify(questions));
-    } catch {
-      console.warn("[term-board] 逆質問の保存に失敗しました。");
     }
   },
 

--- a/term-board/src/api/termRepository.ts
+++ b/term-board/src/api/termRepository.ts
@@ -38,10 +38,6 @@ export interface TermRepository {
   getNotes(): Promise<Record<string, string>>;
   saveNote(day: string, text: string): Promise<void>;
 
-  // F-INTV-07: 逆質問ストック（面接終盤の「最後に質問は?」に備える）。
-  getReverseQuestions(): Promise<string[]>;
-  saveReverseQuestions(questions: string[]): Promise<void>;
-
   // F-QUIZ-06: 混同ペア分析。誤答時に選んだ誤答テキストを用語ごとに記録する。
   getMisses(): Promise<Record<string, string[]>>;
   recordMiss(termId: string, chosen: string): Promise<void>;

--- a/term-board/src/components/AuthorView.tsx
+++ b/term-board/src/components/AuthorView.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
 import type { UseUserContent } from "../hooks/useUserContent";
+import { ReverseQuestionStock } from "./ReverseQuestionStock";
 
 type Props = { user: UseUserContent };
-type Tab = "quiz" | "interview" | "share";
+type Tab = "quiz" | "interview" | "reverse" | "share";
 
 const inputClass =
   "w-full rounded-control border border-separator bg-surface px-3 py-2 text-sm text-label focus:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent";
@@ -25,6 +26,9 @@ export function AuthorView({ user }: Props) {
         <SubTab active={tab === "quiz"} onClick={() => setTab("quiz")}>
           4択用語
         </SubTab>
+        <SubTab active={tab === "reverse"} onClick={() => setTab("reverse")}>
+          逆質問
+        </SubTab>
         <SubTab active={tab === "share"} onClick={() => setTab("share")}>
           共有
         </SubTab>
@@ -32,6 +36,7 @@ export function AuthorView({ user }: Props) {
 
       {tab === "interview" && <InterviewForm user={user} />}
       {tab === "quiz" && <QuizForm user={user} />}
+      {tab === "reverse" && <ReverseQuestionStock user={user} />}
       {tab === "share" && <SharePanel user={user} />}
     </section>
   );
@@ -314,7 +319,8 @@ function SharePanel({ user }: Props) {
   const [exported, setExported] = useState("");
   const [importText, setImportText] = useState("");
   const [message, setMessage] = useState<{ kind: "ok" | "err"; text: string } | null>(null);
-  const total = user.content.quizTerms.length + user.content.interviewQuestions.length;
+  const reverseCount = user.content.reverseQuestions?.length ?? 0;
+  const total = user.content.quizTerms.length + user.content.interviewQuestions.length + reverseCount;
 
   const doExport = () => {
     if (total === 0) {
@@ -329,9 +335,9 @@ function SharePanel({ user }: Props) {
 
   const doImport = () => {
     try {
-      const { quiz, interview } = user.importCode(importText);
+      const { quiz, interview, reverse } = user.importCode(importText);
       setImportText("");
-      setMessage({ kind: "ok", text: `取り込みました：4択用語 ${quiz}件／面接Q&A ${interview}件。` });
+      setMessage({ kind: "ok", text: `取り込みました：4択用語 ${quiz}件／面接Q&A ${interview}件／逆質問 ${reverse}件。` });
     } catch {
       setMessage({ kind: "err", text: "共有コードを読み取れませんでした。コードが正しいか確認してください。" });
     }
@@ -342,7 +348,7 @@ function SharePanel({ user }: Props) {
       <div className="hig-card p-5">
         <h2 className="font-bold text-label">書き出す（共有する）</h2>
         <p className="mt-1 text-sm text-label-2">
-          自分が作った問題（4択 {user.content.quizTerms.length}件・面接 {user.content.interviewQuestions.length}件）を
+          自分が作った問題（4択 {user.content.quizTerms.length}件・面接 {user.content.interviewQuestions.length}件・逆質問 {reverseCount}件）を
           共有コードにして、Discordなどに貼って渡せます。
         </p>
         <button type="button" onClick={doExport} className={`mt-3 ${primaryBtn}`}>共有コードを作る</button>

--- a/term-board/src/components/ReverseQuestionStock.tsx
+++ b/term-board/src/components/ReverseQuestionStock.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useState } from "react";
-import { repository } from "../api";
+import { useState } from "react";
+import type { UseUserContent } from "../hooks/useUserContent";
 
 // F-INTV-07: 逆質問ストック。面接終盤の「最後に何か質問は？」に備えて貯める。
-// プリセット候補からの追加・自由入力・削除に対応し、localStorage に保存する。
+// データは UserContent の reverseQuestions に統合済み（#425）。マイ問題（共有可能）と一体運用。
 
 const PRESETS = [
   "入社後、最初の3か月で期待される役割は何ですか？",
@@ -12,35 +12,17 @@ const PRESETS = [
   "評価制度やキャリアの伸ばし方について教えてください。",
 ];
 
-export function ReverseQuestionStock() {
-  const [items, setItems] = useState<string[]>([]);
+type Props = { user: UseUserContent };
+
+export function ReverseQuestionStock({ user }: Props) {
+  const items = user.content.reverseQuestions ?? [];
   const [draft, setDraft] = useState("");
-  const [loaded, setLoaded] = useState(false);
-
-  useEffect(() => {
-    let active = true;
-    repository.getReverseQuestions().then((qs) => {
-      if (!active) return;
-      setItems(qs);
-      setLoaded(true);
-    });
-    return () => {
-      active = false;
-    };
-  }, []);
-
-  const persist = (next: string[]) => {
-    setItems(next);
-    void repository.saveReverseQuestions(next);
-  };
 
   const add = (q: string) => {
-    const v = q.trim();
-    if (!v || items.includes(v)) return;
-    persist([...items, v]);
+    user.addReverseQuestion(q);
   };
 
-  const remove = (q: string) => persist(items.filter((x) => x !== q));
+  const remove = (q: string) => user.removeReverseQuestion(q);
 
   const availablePresets = PRESETS.filter((p) => !items.includes(p));
 
@@ -77,7 +59,7 @@ export function ReverseQuestionStock() {
       </form>
 
       {/* ストック一覧 */}
-      {loaded && items.length === 0 ? (
+      {items.length === 0 ? (
         <p className="mt-3 text-sm text-label-2">まだありません。下の候補や自由入力から追加できます。</p>
       ) : (
         <ul className="mt-3 flex flex-col gap-2">

--- a/term-board/src/hooks/useUserContent.ts
+++ b/term-board/src/hooks/useUserContent.ts
@@ -19,12 +19,16 @@ export type UseUserContent = {
   updateInterviewQuestion: (id: string, q: NewInterviewQuestion) => void;
   removeQuizTerm: (id: string) => void;
   removeInterviewQuestion: (id: string) => void;
+  /** 逆質問を追加（重複は無視）。#425 */
+  addReverseQuestion: (q: string) => void;
+  /** 逆質問を削除。#425 */
+  removeReverseQuestion: (q: string) => void;
   exportCode: () => string;
   /** 共有コードを取り込み、追加件数を返す。失敗時は例外を投げる。 */
-  importCode: (code: string) => { quiz: number; interview: number };
+  importCode: (code: string) => { quiz: number; interview: number; reverse: number };
 };
 
-const EMPTY: UserContent = { quizTerms: [], interviewQuestions: [] };
+const EMPTY: UserContent = { quizTerms: [], interviewQuestions: [], reverseQuestions: [] };
 
 export function useUserContent(): UseUserContent {
   const [content, setContent] = useState<UserContent>(EMPTY);
@@ -112,10 +116,32 @@ export function useUserContent(): UseUserContent {
     });
   }, []);
 
+  const addReverseQuestion = useCallback((q: string) => {
+    const v = q.trim();
+    if (!v) return;
+    setContent((prev) => {
+      const current = prev.reverseQuestions ?? [];
+      if (current.includes(v)) return prev; // 重複は追加しない
+      const next: UserContent = { ...prev, reverseQuestions: [...current, v] };
+      void repository.saveUserContent(next);
+      return next;
+    });
+  }, []);
+
+  const removeReverseQuestion = useCallback((q: string) => {
+    setContent((prev) => {
+      const current = prev.reverseQuestions ?? [];
+      const next: UserContent = { ...prev, reverseQuestions: current.filter((x) => x !== q) };
+      void repository.saveUserContent(next);
+      return next;
+    });
+  }, []);
+
   const exportCode = useCallback(() => encodeShareCode(content), [content]);
 
   // 取り込み時はIDを振り直して衝突を避け、既存に追記する。
   // 取り込んだ問題は他者作なので source="shared" を付与（自作 user と区別。#385）。
+  // 逆質問は文字列なのでIDなし、重複は無視（#425）。
   const importCode = useCallback(
     (code: string) => {
       const incoming = decodeShareCode(code);
@@ -125,15 +151,26 @@ export function useUserContent(): UseUserContent {
         id: newId(),
         source: "shared" as const,
       }));
+      const incomingReverse = incoming.reverseQuestions ?? [];
+      let addedReverse = 0;
       setContent((prev) => {
+        const prevReverse = prev.reverseQuestions ?? [];
+        const mergedReverse = [...prevReverse];
+        for (const q of incomingReverse) {
+          if (!mergedReverse.includes(q)) {
+            mergedReverse.push(q);
+            addedReverse++;
+          }
+        }
         const next: UserContent = {
           quizTerms: [...prev.quizTerms, ...quiz],
           interviewQuestions: [...prev.interviewQuestions, ...interview],
+          reverseQuestions: mergedReverse,
         };
         void repository.saveUserContent(next);
         return next;
       });
-      return { quiz: quiz.length, interview: interview.length };
+      return { quiz: quiz.length, interview: interview.length, reverse: addedReverse };
     },
     [],
   );
@@ -146,6 +183,8 @@ export function useUserContent(): UseUserContent {
     updateInterviewQuestion,
     removeQuizTerm,
     removeInterviewQuestion,
+    addReverseQuestion,
+    removeReverseQuestion,
     exportCode,
     importCode,
   };

--- a/term-board/src/types.ts
+++ b/term-board/src/types.ts
@@ -50,6 +50,7 @@ export type InterviewQuestion = {
 export type UserContent = {
   quizTerms: Term[]; // ユーザー作問の4択用語
   interviewQuestions: InterviewQuestion[]; // ユーザー作問の面接Q&A
+  reverseQuestions?: string[]; // 逆質問（#425・任意フィールドで後方互換）
 };
 
 // B5: 自己紹介・志望動機の下書き素材（穴埋め式・localStorage保存）。

--- a/term-board/src/utils/share.ts
+++ b/term-board/src/utils/share.ts
@@ -34,13 +34,17 @@ export function encodeShareCode(content: UserContent): string {
 export function decodeShareCode(code: string): UserContent {
   const obj: unknown = JSON.parse(base64ToUtf8(code));
   if (typeof obj !== "object" || obj === null) throw new Error("共有コードの形式が不正です。");
-  const o = obj as { quizTerms?: unknown; interviewQuestions?: unknown };
+  const o = obj as { quizTerms?: unknown; interviewQuestions?: unknown; reverseQuestions?: unknown };
   const quizTerms = Array.isArray(o.quizTerms) ? (o.quizTerms as Term[]) : [];
   const interviewQuestions = Array.isArray(o.interviewQuestions)
     ? (o.interviewQuestions as InterviewQuestion[])
     : [];
-  if (quizTerms.length === 0 && interviewQuestions.length === 0) {
+  // 逆質問は文字列配列。型不一致は黙って捨てる（落とすほうが安全）。
+  const reverseQuestions = Array.isArray(o.reverseQuestions)
+    ? (o.reverseQuestions.filter((x): x is string => typeof x === "string"))
+    : [];
+  if (quizTerms.length === 0 && interviewQuestions.length === 0 && reverseQuestions.length === 0) {
     throw new Error("取り込める問題が含まれていません。");
   }
-  return { quizTerms, interviewQuestions };
+  return { quizTerms, interviewQuestions, reverseQuestions };
 }


### PR DESCRIPTION
## 関連 Issue

Closes #425

---

## 変更の概要

逆質問は実質「ユーザー作成の再利用可能な教材」だが、これまで独立キー `term-board:reverseQuestions:v1` に保存され、共有コードに含まれていなかった。4択/Q&A と同じく `UserContent` 配下に取り込み、共有可能にする統合 PR。

- `types.ts`: `UserContent.reverseQuestions?: string[]`（任意フィールドで後方互換）
- `share.ts decodeShareCode`: `reverseQuestions` を取り込み対象に追加
- `localStorageTermRepository`:
  - `readUserContent` で旧キーを fallback として読み、UserContent 側に未設定ならマージ（自動マイグレーション）
  - 旧 `getReverseQuestions` / `saveReverseQuestions` を削除
- `useUserContent`: `addReverseQuestion` / `removeReverseQuestion` 追加。`importCode` の戻り値に `reverse` を追加
- `ReverseQuestionStock`: `user: UseUserContent` を props 受領し、UserContent 経由で読み書き
- `App.tsx`: `<ReverseQuestionStock user={user} />` を渡す
- `AuthorView`: 4タブ目「逆質問」追加。SharePanel の件数表示・取り込みメッセージにも逆質問件数を反映

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] AuthorView の「逆質問」タブで追加・削除できる
- [x] 単独画面 (#reverseq) と AuthorView タブで同じデータが表示される（リアルタイム同期）
- [x] 共有コードに逆質問が含まれる（base64 round-trip 確認）
- [x] 取り込みメッセージに「逆質問 N件」が表示される
- [x] `npm run build` green / `npm run test` 33/33 green
- [x] 旧 `reverseQuestions:v1` データはマイグレーションで救済（次回 save で UserContent 側へ一本化）

---

## 検証ログ（ブラウザ実機）

1. 逆質問タブで「テスト逆質問A」を追加 → `localStorage.userContent.reverseQuestions: ["テスト逆質問A"]` 確認
2. 共有コード生成（120 chars）→ `localStorage` クリア → リロード
3. 取り込み実行 → 「取り込みました：4択用語 0件／面接Q&A 0件／逆質問 1件。」表示
4. 逆質問タブで「テスト逆質問A」が一覧に復元
5. 単独画面 (#reverseq) でも同じ内容が見える

---

## レビュー時に特に確認してほしい点

- 旧キー (`reverseQuestions:v1`) を残したままにしている（マイグレーション時のロールバック安全策）。次回 PR で削除も検討可。
- `decodeShareCode` の「取り込める問題がない」判定に reverseQuestions も含めた。