### PR TITLE
feat: マイ問題に暗記カード（front/back）を追加し共有可能に

### DIFF
--- a/term-board/src/api/localStorageTermRepository.ts
+++ b/term-board/src/api/localStorageTermRepository.ts
@@ -69,7 +69,8 @@ function readUserContent(): UserContent {
     // （次回 saveUserContent で UserContent 側に永続化される）。
     const fromUserContent = Array.isArray(obj.reverseQuestions) ? obj.reverseQuestions : null;
     const reverseQuestions = fromUserContent ?? readLegacyReverseQuestions();
-    return { quizTerms, interviewQuestions, reverseQuestions };
+    const flashcards = Array.isArray(obj.flashcards) ? obj.flashcards : [];
+    return { quizTerms, interviewQuestions, reverseQuestions, flashcards };
   } catch {
     return EMPTY_USER_CONTENT;
   }
@@ -92,9 +93,27 @@ export const localStorageTermRepository: TermRepository = {
   async getTerms(): Promise<Term[]> {
     // 同梱（builtin）＋ ユーザー作問（user / shared）を統合して出題対象にする。
     // 既存の source を尊重し、未指定なら user とみなす（shared は importCode で付与済み）。
+    // Flashcard は distractors を持たないので 4択/辞典では使わない（getCardItems で合流）。
     const builtin = (termsData as Term[]).map((t) => ({ ...t, source: "builtin" as const }));
     const user = readUserContent().quizTerms.map((t) => ({ ...t, source: t.source ?? "user" }));
     return [...builtin, ...user];
+  },
+
+  // #427: 暗記カードビュー用。4択用語＋Flashcard を Term 形に正規化して返す。
+  // Flashcard は distractors=[]・interview="" で埋め、CardView 側は空のとき非表示にする。
+  async getCardItems(): Promise<Term[]> {
+    const base = await this.getTerms();
+    const flashcards = readUserContent().flashcards ?? [];
+    const asTerms: Term[] = flashcards.map((f) => ({
+      id: f.id,
+      category: f.category && f.category.trim() !== "" ? f.category : "暗記カード",
+      term: f.front,
+      meaning: f.back,
+      distractors: [],
+      interview: "",
+      source: f.source ?? "user",
+    }));
+    return [...base, ...asTerms];
   },
 
   async getProgress(): Promise<Progress> {

--- a/term-board/src/api/termRepository.ts
+++ b/term-board/src/api/termRepository.ts
@@ -38,6 +38,9 @@ export interface TermRepository {
   getNotes(): Promise<Record<string, string>>;
   saveNote(day: string, text: string): Promise<void>;
 
+  // F-CARD-01 拡張: 暗記カード用の出題対象（4択用語＋Flashcard を Term 形に正規化）。#427
+  getCardItems(): Promise<Term[]>;
+
   // F-QUIZ-06: 混同ペア分析。誤答時に選んだ誤答テキストを用語ごとに記録する。
   getMisses(): Promise<Record<string, string[]>>;
   recordMiss(termId: string, chosen: string): Promise<void>;

--- a/term-board/src/components/AuthorView.tsx
+++ b/term-board/src/components/AuthorView.tsx
@@ -3,7 +3,7 @@ import type { UseUserContent } from "../hooks/useUserContent";
 import { ReverseQuestionStock } from "./ReverseQuestionStock";
 
 type Props = { user: UseUserContent };
-type Tab = "quiz" | "interview" | "reverse" | "share";
+type Tab = "quiz" | "interview" | "card" | "reverse" | "share";
 
 const inputClass =
   "w-full rounded-control border border-separator bg-surface px-3 py-2 text-sm text-label focus:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent";
@@ -26,6 +26,9 @@ export function AuthorView({ user }: Props) {
         <SubTab active={tab === "quiz"} onClick={() => setTab("quiz")}>
           4択用語
         </SubTab>
+        <SubTab active={tab === "card"} onClick={() => setTab("card")}>
+          暗記カード
+        </SubTab>
         <SubTab active={tab === "reverse"} onClick={() => setTab("reverse")}>
           逆質問
         </SubTab>
@@ -36,6 +39,7 @@ export function AuthorView({ user }: Props) {
 
       {tab === "interview" && <InterviewForm user={user} />}
       {tab === "quiz" && <QuizForm user={user} />}
+      {tab === "card" && <FlashcardForm user={user} />}
       {tab === "reverse" && <ReverseQuestionStock user={user} />}
       {tab === "share" && <SharePanel user={user} />}
     </section>
@@ -314,13 +318,122 @@ function QuizForm({ user }: Props) {
   );
 }
 
+// --- 暗記カード 作成フォーム（追加＋編集・#427） ---
+function FlashcardForm({ user }: Props) {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [front, setFront] = useState("");
+  const [back, setBack] = useState("");
+  const [category, setCategory] = useState("");
+  const valid = front.trim() && back.trim();
+  const isEditing = editingId !== null;
+  const cards = user.content.flashcards ?? [];
+
+  const resetForm = () => {
+    setEditingId(null);
+    setFront("");
+    setBack("");
+    setCategory("");
+  };
+
+  const startEdit = (id: string) => {
+    const item = cards.find((c) => c.id === id);
+    if (!item) return;
+    setEditingId(id);
+    setFront(item.front);
+    setBack(item.back);
+    setCategory(item.category ?? "");
+  };
+
+  // 重複チェック（表が同じ・編集中は自分を除外）
+  const trimmedF = front.trim();
+  const isDuplicate =
+    !!trimmedF && cards.some((c) => c.front.trim() === trimmedF && c.id !== editingId);
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!valid || isDuplicate) return;
+    const data = {
+      front: front.trim(),
+      back: back.trim(),
+      category: category.trim() || undefined,
+    };
+    if (editingId) {
+      user.updateFlashcard(editingId, data);
+    } else {
+      user.addFlashcard(data);
+    }
+    resetForm();
+  };
+
+  return (
+    <div className="flex flex-col gap-5">
+      <form onSubmit={submit} className="flex flex-col gap-3 hig-card p-5">
+        {isEditing && (
+          <p className="rounded-control bg-amber-50 px-3 py-2 text-xs font-medium text-amber-800 ring-1 ring-amber-200 dark:bg-amber-950 dark:text-amber-200 dark:ring-amber-900">
+            編集中：{front || "（表未入力）"}
+          </p>
+        )}
+        {isDuplicate && (
+          <p role="alert" className="rounded-control bg-rose-50 px-3 py-2 text-xs font-medium text-rose-700 ring-1 ring-rose-200 dark:bg-rose-950 dark:text-rose-300 dark:ring-rose-900">
+            同じ表のカードが既に登録されています。重複登録は抑止しました。
+          </p>
+        )}
+        <p className="text-sm text-label-2">
+          表（用語など）と裏（意味・回答）だけの軽い暗記カードを作れます。略語・コマンド・予約語の暗記に向いています。
+        </p>
+        <div>
+          <label htmlFor="fc-front" className={labelClass}>表 <span className="text-rose-600">*</span></label>
+          <input id="fc-front" className={inputClass} value={front} onChange={(e) => setFront(e.target.value)} placeholder="例：DRY" />
+        </div>
+        <div>
+          <label htmlFor="fc-back" className={labelClass}>裏 <span className="text-rose-600">*</span></label>
+          <textarea id="fc-back" className={inputClass} rows={3} value={back} onChange={(e) => setBack(e.target.value)} placeholder="例：Don't Repeat Yourself（同じことを繰り返さない）" />
+        </div>
+        <div>
+          <label htmlFor="fc-cat" className={labelClass}>分野（任意）</label>
+          <input id="fc-cat" className={inputClass} value={category} onChange={(e) => setCategory(e.target.value)} placeholder="例：略語 / コマンド" />
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button type="submit" disabled={!valid || isDuplicate} className={primaryBtn}>
+            {isEditing ? "更新する" : "追加する"}
+          </button>
+          {isEditing && (
+            <button type="button" onClick={resetForm} className={secondaryBtn}>
+              キャンセル
+            </button>
+          )}
+        </div>
+      </form>
+
+      <ItemList
+        title={`登録した暗記カード（${cards.length}件）`}
+        items={cards.map((c) => ({
+          id: c.id,
+          primary: c.front,
+          secondary: `${c.category ?? "暗記カード"}｜${c.back}`,
+        }))}
+        onEdit={startEdit}
+        onRemove={(id) => {
+          if (editingId === id) resetForm();
+          user.removeFlashcard(id);
+        }}
+      />
+    </div>
+  );
+}
+
 // --- 共有（エクスポート/インポート） ---
 function SharePanel({ user }: Props) {
   const [exported, setExported] = useState("");
   const [importText, setImportText] = useState("");
   const [message, setMessage] = useState<{ kind: "ok" | "err"; text: string } | null>(null);
   const reverseCount = user.content.reverseQuestions?.length ?? 0;
-  const total = user.content.quizTerms.length + user.content.interviewQuestions.length + reverseCount;
+  const flashcardCount = user.content.flashcards?.length ?? 0;
+  const total =
+    user.content.quizTerms.length +
+    user.content.interviewQuestions.length +
+    reverseCount +
+    flashcardCount;
 
   const doExport = () => {
     if (total === 0) {
@@ -335,9 +448,12 @@ function SharePanel({ user }: Props) {
 
   const doImport = () => {
     try {
-      const { quiz, interview, reverse } = user.importCode(importText);
+      const { quiz, interview, reverse, flashcard } = user.importCode(importText);
       setImportText("");
-      setMessage({ kind: "ok", text: `取り込みました：4択用語 ${quiz}件／面接Q&A ${interview}件／逆質問 ${reverse}件。` });
+      setMessage({
+        kind: "ok",
+        text: `取り込みました：4択用語 ${quiz}件／面接Q&A ${interview}件／暗記カード ${flashcard}件／逆質問 ${reverse}件。`,
+      });
     } catch {
       setMessage({ kind: "err", text: "共有コードを読み取れませんでした。コードが正しいか確認してください。" });
     }
@@ -348,7 +464,7 @@ function SharePanel({ user }: Props) {
       <div className="hig-card p-5">
         <h2 className="font-bold text-label">書き出す（共有する）</h2>
         <p className="mt-1 text-sm text-label-2">
-          自分が作った問題（4択 {user.content.quizTerms.length}件・面接 {user.content.interviewQuestions.length}件・逆質問 {reverseCount}件）を
+          自分が作った問題（4択 {user.content.quizTerms.length}件・面接 {user.content.interviewQuestions.length}件・暗記カード {flashcardCount}件・逆質問 {reverseCount}件）を
           共有コードにして、Discordなどに貼って渡せます。
         </p>
         <button type="button" onClick={doExport} className={`mt-3 ${primaryBtn}`}>共有コードを作る</button>

--- a/term-board/src/components/CardView.tsx
+++ b/term-board/src/components/CardView.tsx
@@ -22,7 +22,7 @@ export function CardView() {
 
   useEffect(() => {
     let active = true;
-    Promise.all([repository.getTerms(), repository.getCardProgress()]).then(([t, cp]) => {
+    Promise.all([repository.getCardItems(), repository.getCardProgress()]).then(([t, cp]) => {
       if (!active) return;
       setTerms(t);
       setCardProgress(cp);
@@ -187,10 +187,13 @@ export function CardView() {
                   <span className="font-semibold text-label">意味：</span>
                   {current.meaning}
                 </p>
-                <p className="text-sm leading-relaxed text-label-2">
-                  <span className="font-semibold text-label">面接での言い方：</span>
-                  {current.interview}
-                </p>
+                {/* Flashcard は interview を持たない（空文字）ため、ある時だけ表示。 */}
+                {current.interview && (
+                  <p className="text-sm leading-relaxed text-label-2">
+                    <span className="font-semibold text-label">面接での言い方：</span>
+                    {current.interview}
+                  </p>
+                )}
               </div>
             )}
           </button>

--- a/term-board/src/hooks/useUserContent.ts
+++ b/term-board/src/hooks/useUserContent.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import type { Term, InterviewQuestion, UserContent } from "../types";
+import type { Term, InterviewQuestion, UserContent, Flashcard } from "../types";
 import { repository } from "../api";
 import { newId, encodeShareCode, decodeShareCode } from "../utils/share";
 
@@ -8,6 +8,7 @@ import { newId, encodeShareCode, decodeShareCode } from "../utils/share";
 
 export type NewQuizTerm = Omit<Term, "id" | "source">;
 export type NewInterviewQuestion = Omit<InterviewQuestion, "id" | "source">;
+export type NewFlashcard = Omit<Flashcard, "id" | "source">;
 
 export type UseUserContent = {
   content: UserContent;
@@ -23,12 +24,23 @@ export type UseUserContent = {
   addReverseQuestion: (q: string) => void;
   /** 逆質問を削除。#425 */
   removeReverseQuestion: (q: string) => void;
+  /** 暗記カードを追加。#427 */
+  addFlashcard: (c: NewFlashcard) => void;
+  /** 暗記カードを更新（id・source は保持）。#427 */
+  updateFlashcard: (id: string, c: NewFlashcard) => void;
+  /** 暗記カードを削除。#427 */
+  removeFlashcard: (id: string) => void;
   exportCode: () => string;
   /** 共有コードを取り込み、追加件数を返す。失敗時は例外を投げる。 */
-  importCode: (code: string) => { quiz: number; interview: number; reverse: number };
+  importCode: (code: string) => { quiz: number; interview: number; reverse: number; flashcard: number };
 };
 
-const EMPTY: UserContent = { quizTerms: [], interviewQuestions: [], reverseQuestions: [] };
+const EMPTY: UserContent = {
+  quizTerms: [],
+  interviewQuestions: [],
+  reverseQuestions: [],
+  flashcards: [],
+};
 
 export function useUserContent(): UseUserContent {
   const [content, setContent] = useState<UserContent>(EMPTY);
@@ -137,6 +149,39 @@ export function useUserContent(): UseUserContent {
     });
   }, []);
 
+  const addFlashcard = useCallback((c: NewFlashcard) => {
+    setContent((prev) => {
+      const list = prev.flashcards ?? [];
+      const next: UserContent = {
+        ...prev,
+        flashcards: [...list, { ...c, id: newId(), source: "user" }],
+      };
+      void repository.saveUserContent(next);
+      return next;
+    });
+  }, []);
+
+  const updateFlashcard = useCallback((id: string, c: NewFlashcard) => {
+    setContent((prev) => {
+      const list = prev.flashcards ?? [];
+      const next: UserContent = {
+        ...prev,
+        flashcards: list.map((f) => (f.id === id ? { ...f, ...c } : f)),
+      };
+      void repository.saveUserContent(next);
+      return next;
+    });
+  }, []);
+
+  const removeFlashcard = useCallback((id: string) => {
+    setContent((prev) => {
+      const list = prev.flashcards ?? [];
+      const next: UserContent = { ...prev, flashcards: list.filter((f) => f.id !== id) };
+      void repository.saveUserContent(next);
+      return next;
+    });
+  }, []);
+
   const exportCode = useCallback(() => encodeShareCode(content), [content]);
 
   // 取り込み時はIDを振り直して衝突を避け、既存に追記する。
@@ -152,6 +197,11 @@ export function useUserContent(): UseUserContent {
         source: "shared" as const,
       }));
       const incomingReverse = incoming.reverseQuestions ?? [];
+      const incomingFlash = (incoming.flashcards ?? []).map((f) => ({
+        ...f,
+        id: newId(),
+        source: "shared" as const,
+      }));
       let addedReverse = 0;
       setContent((prev) => {
         const prevReverse = prev.reverseQuestions ?? [];
@@ -166,11 +216,17 @@ export function useUserContent(): UseUserContent {
           quizTerms: [...prev.quizTerms, ...quiz],
           interviewQuestions: [...prev.interviewQuestions, ...interview],
           reverseQuestions: mergedReverse,
+          flashcards: [...(prev.flashcards ?? []), ...incomingFlash],
         };
         void repository.saveUserContent(next);
         return next;
       });
-      return { quiz: quiz.length, interview: interview.length, reverse: addedReverse };
+      return {
+        quiz: quiz.length,
+        interview: interview.length,
+        reverse: addedReverse,
+        flashcard: incomingFlash.length,
+      };
     },
     [],
   );
@@ -185,6 +241,9 @@ export function useUserContent(): UseUserContent {
     removeInterviewQuestion,
     addReverseQuestion,
     removeReverseQuestion,
+    addFlashcard,
+    updateFlashcard,
+    removeFlashcard,
     exportCode,
     importCode,
   };

--- a/term-board/src/types.ts
+++ b/term-board/src/types.ts
@@ -51,6 +51,17 @@ export type UserContent = {
   quizTerms: Term[]; // ユーザー作問の4択用語
   interviewQuestions: InterviewQuestion[]; // ユーザー作問の面接Q&A
   reverseQuestions?: string[]; // 逆質問（#425・任意フィールドで後方互換）
+  flashcards?: Flashcard[]; // 暗記カード（#427・任意フィールドで後方互換）
+};
+
+// F-CARD-01 拡張: ユーザー作問の軽量カード（distractors なし）。
+// 4択用語より自由度が高く、略語・コマンド・予約語の暗記に向く。
+export type Flashcard = {
+  id: string;
+  front: string; // 表（用語・問題）
+  back: string; // 裏（意味・回答）
+  category?: string; // 分野（任意）
+  source?: "user" | "shared";
 };
 
 // B5: 自己紹介・志望動機の下書き素材（穴埋め式・localStorage保存）。

--- a/term-board/src/utils/share.ts
+++ b/term-board/src/utils/share.ts
@@ -1,4 +1,4 @@
-import type { UserContent, Term, InterviewQuestion } from "../types";
+import type { UserContent, Term, InterviewQuestion, Flashcard } from "../types";
 
 // F-USER-02: 作問データを「共有コード」に変換／復元する（サーバー無しのピア共有）。
 // 共有コードは Discord 等に貼れる base64 文字列。Unicode を壊さず往復させる。
@@ -34,7 +34,12 @@ export function encodeShareCode(content: UserContent): string {
 export function decodeShareCode(code: string): UserContent {
   const obj: unknown = JSON.parse(base64ToUtf8(code));
   if (typeof obj !== "object" || obj === null) throw new Error("共有コードの形式が不正です。");
-  const o = obj as { quizTerms?: unknown; interviewQuestions?: unknown; reverseQuestions?: unknown };
+  const o = obj as {
+    quizTerms?: unknown;
+    interviewQuestions?: unknown;
+    reverseQuestions?: unknown;
+    flashcards?: unknown;
+  };
   const quizTerms = Array.isArray(o.quizTerms) ? (o.quizTerms as Term[]) : [];
   const interviewQuestions = Array.isArray(o.interviewQuestions)
     ? (o.interviewQuestions as InterviewQuestion[])
@@ -43,8 +48,20 @@ export function decodeShareCode(code: string): UserContent {
   const reverseQuestions = Array.isArray(o.reverseQuestions)
     ? (o.reverseQuestions.filter((x): x is string => typeof x === "string"))
     : [];
-  if (quizTerms.length === 0 && interviewQuestions.length === 0 && reverseQuestions.length === 0) {
+  // Flashcard は front/back が両方文字列のものだけ受理（型不一致は捨てる）。
+  const flashcards = Array.isArray(o.flashcards)
+    ? (o.flashcards as Flashcard[]).filter(
+        (f): f is Flashcard =>
+          typeof f === "object" && f !== null && typeof f.front === "string" && typeof f.back === "string",
+      )
+    : [];
+  if (
+    quizTerms.length === 0 &&
+    interviewQuestions.length === 0 &&
+    reverseQuestions.length === 0 &&
+    flashcards.length === 0
+  ) {
     throw new Error("取り込める問題が含まれていません。");
   }
-  return { quizTerms, interviewQuestions, reverseQuestions };
+  return { quizTerms, interviewQuestions, reverseQuestions, flashcards };
 }


### PR DESCRIPTION
## 関連 Issue

Closes #427

---

## 変更の概要

CardView は distractors を持つ Term しか出題できず、ユーザーは「表＝用語、裏＝意味」だけの軽量カード（略語・コマンド・予約語など）を作るのに 4択用語として誤答を3つ書く必要があった。Flashcard 型を追加して **マイ問題に5つ目のタブ「暗記カード」** を設け、軽量に作成・共有可能にする。

- `types.ts`: `Flashcard` 型 / `UserContent.flashcards?: Flashcard[]`（任意）
- `share.ts decodeShareCode`: `flashcards` を取り込み対象に追加（front/back が文字列のものだけ受理）
- `useUserContent`: `addFlashcard` / `updateFlashcard` / `removeFlashcard`、`importCode` の戻り値に `flashcard` 件数
- `localStorageTermRepository.getCardItems()`: 4択用語＋Flashcard を Term 形に正規化（CardView 用）
- `termRepository`: `getCardItems` インタフェース追加
- `CardView`: `getCardItems()` を使用。`interview` が空のとき「面接での言い方」を非表示
- `AuthorView`: 5つ目のタブ「暗記カード」追加（表/裏/分野(任意) ＋ 編集・削除・重複防止）
- `SharePanel`: 件数表示・取り込みメッセージに暗記カード件数

Flashcard は **4択クイズ・用語辞典には混ざらない**（getTerms に含めず getCardItems でのみ合流）。

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] AuthorView の暗記カードタブで表・裏・分野（任意）を入力して追加できる
- [x] CardView で Flashcard が出題され、裏返すと back が表示される
- [x] 裏面で「面接での言い方」ラベルが非表示（Flashcard では未使用）
- [x] 4択クイズの分野フィルタに「略語」が出ない（QuizView に混ざらない）
- [x] 共有コードに暗記カードが含まれ、取り込みで復元される（往復確認）
- [x] 取り込みメッセージに「暗記カード N件」が表示される
- [x] `npm run build` green / `npm run test` 33/33 green

---

## 検証ログ（ブラウザ実機）

1. 暗記カードタブで「DRY / Don't Repeat Yourself / 略語」を追加 → `localStorage.userContent.flashcards` に保存
2. CardView の分野フィルタに「略語」が追加され、絞り込むと DRY が出題される
3. 裏返すと `意味：Don't Repeat Yourself` のみ表示。`面接での言い方：` は非表示
4. 4択クイズの分野リストに「略語」は出ない
5. 共有コード生成（280 chars）→ `localStorage` クリア → リロード → 取り込み
6. 「取り込みました：4択用語 0件／面接Q&A 0件／暗記カード 1件／逆質問 0件。」表示・DRY 復元（source="shared"・id 再振り）

---

## レビュー時に特に確認してほしい点

- `interview` 空時の条件描画（CardView lines around 191）。
- 既存ユーザーで `flashcards` を持たない UserContent が `getCardItems` を呼んだとき、空配列扱いで通常通り動く（後方互換）。