### PR TITLE
feat: URLクエリ ?import=<base64> で共有コードをワンクリック取り込み

### DIFF
--- a/term-board/src/App.tsx
+++ b/term-board/src/App.tsx
@@ -1,5 +1,7 @@
 import { useQuiz } from "./hooks/useQuiz";
 import { useUserContent } from "./hooks/useUserContent";
+import { usePendingImport } from "./hooks/usePendingImport";
+import type { PendingImport } from "./hooks/usePendingImport";
 import { useBookmarks } from "./hooks/useBookmarks";
 import { useTheme } from "./hooks/useTheme";
 import { useNavLayout } from "./hooks/useNavLayout";
@@ -89,6 +91,8 @@ export default function App() {
   const nav = useNavLayout();
   const user = useUserContent();
   const bookmarks = useBookmarks();
+  // #431: ?import=... を踏んで開いた場合のプレビュー（受信側のワンクリック共有）
+  const pendingImport = usePendingImport();
   // ユーザー作問の件数を渡し、追加・取り込みで出題に即反映する（F-USER）。
   const quiz = useQuiz(user.content.quizTerms.length);
   const rate =
@@ -201,6 +205,21 @@ export default function App() {
         </div>
       </header>
 
+      {/* #431: URL 取り込みバナー（明示操作で取り込む・コンテンツの上に出す） */}
+      {pendingImport.pending && (
+        <div className={`mx-auto ${mainWidth} px-4 pt-4`}>
+          <PendingImportBanner
+            pending={pendingImport.pending}
+            onAccept={() => {
+              user.importCode(pendingImport.pending!.code);
+              pendingImport.clear();
+              setView("author");
+            }}
+            onDismiss={() => pendingImport.clear()}
+          />
+        </div>
+      )}
+
       {sidebar ? (
         <div className="mx-auto flex w-full max-w-5xl gap-6 px-4 py-6">
           <main className="min-w-0 flex-1">
@@ -212,6 +231,59 @@ export default function App() {
       ) : (
         <main className={`mx-auto ${mainWidth} px-4 py-6`}>{viewContent}</main>
       )}
+    </div>
+  );
+}
+
+// #431: 取り込み確認バナー。?import=... で開いた時だけ表示される。
+function PendingImportBanner({
+  pending,
+  onAccept,
+  onDismiss,
+}: {
+  pending: PendingImport;
+  onAccept: () => void;
+  onDismiss: () => void;
+}) {
+  const { quiz, interview, reverse, flashcard } = pending.preview;
+  const total = quiz + interview + reverse + flashcard;
+  const summary = [
+    quiz > 0 ? `4択用語 ${quiz}件` : "",
+    interview > 0 ? `面接Q&A ${interview}件` : "",
+    flashcard > 0 ? `暗記カード ${flashcard}件` : "",
+    reverse > 0 ? `逆質問 ${reverse}件` : "",
+  ]
+    .filter(Boolean)
+    .join("・");
+  return (
+    <div
+      role="dialog"
+      aria-label="共有コードの取り込み確認"
+      className="hig-card flex flex-col gap-3 p-4 ring-1 ring-accent/40 sm:flex-row sm:items-center"
+    >
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-semibold text-label">共有コードが届いています</p>
+        <p className="mt-0.5 text-sm text-label-2">
+          {total > 0 ? summary : "内容を確認できませんでした"}
+          を取り込みます。既存の内容には影響しません（追記のみ）。
+        </p>
+      </div>
+      <div className="flex shrink-0 gap-2">
+        <button
+          type="button"
+          onClick={onAccept}
+          className="hig-btn-primary px-4 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          取り込む
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="rounded-control bg-fill-quaternary px-4 py-2 text-sm font-semibold text-label transition hover:brightness-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          キャンセル
+        </button>
+      </div>
     </div>
   );
 }

--- a/term-board/src/hooks/usePendingImport.ts
+++ b/term-board/src/hooks/usePendingImport.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react";
+import type { UserContent } from "../types";
+import { decodeShareCode } from "../utils/share";
+
+// #431: URL クエリ ?import=<base64> で渡された共有コードを「プレビュー状態」で保持する。
+// 自動取り込みはせず、画面側がユーザーの明示操作（取り込む/キャンセル）を受けてから反映する。
+
+export type PendingImport = {
+  code: string;
+  preview: {
+    quiz: number;
+    interview: number;
+    reverse: number;
+    flashcard: number;
+  };
+};
+
+// クエリパラメータ名（変更時は SharePanel と整合させること）。
+const QUERY_KEY = "import";
+
+// URL から `import` パラメータを除去（取り込み・キャンセル時にリロード再発火を防ぐため）。
+function stripImportFromURL() {
+  if (typeof window === "undefined") return;
+  const url = new URL(window.location.href);
+  if (!url.searchParams.has(QUERY_KEY)) return;
+  url.searchParams.delete(QUERY_KEY);
+  // クエリが空になったら "?" も落とす（クリーンな URL に）。
+  const search = url.searchParams.toString();
+  const newUrl = url.pathname + (search ? `?${search}` : "") + url.hash;
+  window.history.replaceState(null, "", newUrl);
+}
+
+export function usePendingImport(): {
+  pending: PendingImport | null;
+  clear: () => void;
+} {
+  const [pending, setPending] = useState<PendingImport | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const code = new URL(window.location.href).searchParams.get(QUERY_KEY);
+    if (!code) return;
+    try {
+      const decoded: UserContent = decodeShareCode(code);
+      setPending({
+        code,
+        preview: {
+          quiz: decoded.quizTerms.length,
+          interview: decoded.interviewQuestions.length,
+          reverse: decoded.reverseQuestions?.length ?? 0,
+          flashcard: decoded.flashcards?.length ?? 0,
+        },
+      });
+    } catch {
+      // 不正な base64・空コードは黙って無視（URL からは外して二重発火を防ぐ）。
+      stripImportFromURL();
+    }
+  }, []);
+
+  const clear = () => {
+    setPending(null);
+    stripImportFromURL();
+  };
+
+  return { pending, clear };
+}


### PR DESCRIPTION
## 関連 Issue

Closes #431

---

## 変更の概要

これまでの共有手順は「コードをコピー → Discord 等に貼る → 受け取った人がアプリを開く → 共有タブへ → 貼り付け → 取り込む」と工程が多かった。送り手が `?import=<base64>` 付きの URL を Discord に貼れば、受け取った人は **クリック1回 → バナーで「取り込む」を1回押すだけ**で反映できるようにする。

- `usePendingImport` フック新設：
  - URL クエリ `?import` を読み、`decodeShareCode` で安全に検証（壊れた値・空コードは黙って無視）
  - quiz / interview / reverse / flashcard の各件数プレビューを返す
- **自動取り込みはしない**：誤クリック防止のため、画面上部の確認バナーで明示的に「取り込む / キャンセル」を選ばせる
- 取り込み or キャンセル時は `history.replaceState` で URL から `?import=` を除去（リロード時の二重発火を防止）
- 取り込み成功時は `#author` に遷移して結果を確認しやすく
- `App.tsx` に `PendingImportBanner` コンポーネント追加（HIG カード＋accent リング・ライト/ダーク両対応）

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] `?import=<有効なbase64>` → バナー表示・件数表示
- [x] 「取り込む」→ `localStorage.userContent` に追記、`source="shared"` 付与、`#author` へ遷移、URL から `?import=` 削除、バナー消失
- [x] 「キャンセル」→ データ追加なし、URL から `?import=` 削除、バナー消失
- [x] リロードしても二重取り込みされない（URL がクリーンなので）
- [x] 不正な base64・空コードは黙って無視（バナー表示せず・URL から削除）
- [x] `npm run build` green / `npm run test` 33/33 green
- [x] Light/Dark 両対応・モバイル/PC 両対応

---

## 検証ログ（ブラウザ実機）

1. `?import=<有効な共有コード>` を踏む → バナー「共有コードが届いています / 面接Q&A 1件を取り込みます。既存の内容には影響しません（追記のみ）」が表示
2. 「取り込む」→ localStorage に保存、`#author` へ遷移、URL から `?import=` 削除
3. リロード → 二重取り込みされない（件数変わらず）
4. 別 URL でキャンセル → 何も追加されない、URL クリーン
5. 不正な base64 → アプリ正常表示、バナーなし、URL クリーン

---

## 使い方の例

送り手：
1. マイ問題 → 共有タブで共有コードを生成
2. `https://80-cloud.github.io/hideharu-AI/term-board/?import=<コード>` を作って Discord に貼る

受け取り手：
1. Discord のリンクをクリック
2. 画面上部のバナーで「取り込む」を1回押す（マイ問題に追記される）

---

## レビュー時に特に確認してほしい点

- 自動取り込みではなく明示確認にした設計判断（誤クリックで内容が勝手に入るのを防ぐ）
- `replaceState` で URL を綺麗に保つ動線（戻るで戻れない問題はないか）