### PR TITLE
chore: study-boards にリネーム後の URL/path を全反映

### DIFF
--- a/.github/workflows/term-board-pages.yml
+++ b/.github/workflows/term-board-pages.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           mkdir -p ../_site/term-board
           cp -r dist/* ../_site/term-board/
-          # ルート（/hideharu-AI/）アクセスを term-board へ誘導する。
+          # ルート（/study-boards/）アクセスを term-board へ誘導する。
           cat > ../_site/index.html <<'HTML'
           <!doctype html>
           <html lang="ja">

--- a/term-board/README.md
+++ b/term-board/README.md
@@ -5,7 +5,7 @@ IT業界への就職・転職を目指す**未経験者**向けの、IT用語学
 
 ## 🌐 公開URL（誰でも使えます・ログイン不要）
 
-**https://80-cloud.github.io/hideharu-AI/term-board/**
+**https://80-cloud.github.io/study-boards/term-board/**
 
 - **ログイン不要。** URLを開けばすぐに学習を始められます。
 - **進捗はお使いのブラウザに保存されます**（localStorage）。アカウントもサーバーもありません。
@@ -19,7 +19,7 @@ URLを貼ると **タイトル・説明つきのリンクプレビュー**（OGP
 
 ```
 IT用語ボードで面接対策しよう（ログイン不要・無料）
-https://80-cloud.github.io/hideharu-AI/term-board/
+https://80-cloud.github.io/study-boards/term-board/
 ```
 
 > 補足：プレビューに画像サムネイルも出したい場合は、`og:image`（絶対URLのPNG/JPG）を
@@ -47,7 +47,7 @@ nvm use            # .nvmrc により 24 LTS
 npm install
 npm run dev        # http://localhost:5176/ で起動
 npm run build      # 本番ビルド（dist/）
-npm run preview    # 本番ビルドをローカル確認（base付き = /hideharu-AI/term-board/）
+npm run preview    # 本番ビルドをローカル確認（base付き = /study-boards/term-board/）
 ```
 
 > ポートは **5176 固定**（他アプリと分離・[../CLAUDE.md](../CLAUDE.md) §10）。

--- a/term-board/docs/引き継ぎ書.md
+++ b/term-board/docs/引き継ぎ書.md
@@ -3,7 +3,7 @@
 **最終更新:** 2026-05-28
 **対象:** 次セッションで実装を続ける開発者／ Claude Code
 **アプリ:** IT用語ボード（term-board）— IT未経験者・初めてIT業界へ転職する人向けの面接対策学習アプリ
-**本番URL:** https://80-cloud.github.io/hideharu-AI/term-board/ （ログイン不要・無料・GitHub Pages・コスト0円）
+**本番URL:** https://80-cloud.github.io/study-boards/term-board/ （ログイン不要・無料・GitHub Pages・コスト0円）
 
 ---
 
@@ -31,13 +31,13 @@
 | 項目 | 値 |
 |---|---|
 | フォルダ | `/Users/macmini/dev/Cursor/term-board/` |
-| リポジトリ | `80-cloud/hideharu-AI`（モノレポ。task-board/review-board/sns-board 等と同居） |
+| リポジトリ | `80-cloud/study-boards`（モノレポ。task-board/review-board/sns-board 等と同居。旧名 hideharu-AI、#435 でリネーム） |
 | フロント | React 19 / Vite 6 / TypeScript 5.7 / Tailwind CSS v4（@tailwindcss/vite） |
 | 永続化 | localStorage のみ |
 | ホスティング | GitHub Pages（`main` の `term-board/**` 変更で自動デプロイ） |
 | Node | **24 LTS**（`.nvmrc`）。nvm は Homebrew 導入済み・`~/.zshrc` に読込設定済み |
 | dev ポート | **5176**（固定。`vite.config.ts` の `strictPort`） |
-| Pages base | `/hideharu-AI/term-board/`（`vite.config.ts`） |
+| Pages base | `/study-boards/term-board/`（`vite.config.ts`） |
 
 ### bash から npm を使うときの定型（非対話シェルで nvm を読む）
 ```bash
@@ -50,7 +50,7 @@ cd /Users/macmini/dev/Cursor/term-board
 npm install
 npm run dev      # http://localhost:5176/
 npm run build    # tsc -b && vite build（CIと同一・型エラーも検出）
-npm run preview  # 本番ビルドを base 付きで配信 → http://localhost:4173/hideharu-AI/term-board/
+npm run preview  # 本番ビルドを base 付きで配信 → http://localhost:4173/study-boards/term-board/
 npm audit --audit-level=high   # High/Critical 0 を維持（CIでも実行）
 ```
 
@@ -334,7 +334,7 @@ export interface TermRepository {
 
 ### 1機能の標準フロー（このセッションで確立）
 ```
-① gh issue create --repo 80-cloud/hideharu-AI --label enhancement --title "feat: …" --body "…"
+① gh issue create --repo 80-cloud/study-boards --label enhancement --title "feat: …" --body "…"
 ② git checkout main && git pull && git checkout -b feature/#NNN-説明
 ③ 実装：types.ts → api/ → hooks/ → components/ → App.tsx 配線
 ④ npm run build               # 型/ビルド（CIと同じ）
@@ -349,12 +349,12 @@ export interface TermRepository {
 ### よく使うコマンド
 ```bash
 # Issue/PR/マージ
-gh issue create --repo 80-cloud/hideharu-AI --label enhancement --title "…" --body "…"
-gh pr create   --repo 80-cloud/hideharu-AI --base main --head <branch> --label enhancement --title "…" --body "…"
-gh pr checks <PR> --repo 80-cloud/hideharu-AI
-gh pr merge  <PR> --repo 80-cloud/hideharu-AI --squash --delete-branch
+gh issue create --repo 80-cloud/study-boards --label enhancement --title "…" --body "…"
+gh pr create   --repo 80-cloud/study-boards --base main --head <branch> --label enhancement --title "…" --body "…"
+gh pr checks <PR> --repo 80-cloud/study-boards
+gh pr merge  <PR> --repo 80-cloud/study-boards --squash --delete-branch
 # Pages デプロイ状況
-gh run list --repo 80-cloud/hideharu-AI --workflow "term-board-pages.yml" --branch main --limit 1
+gh run list --repo 80-cloud/study-boards --workflow "term-board-pages.yml" --branch main --limit 1
 ```
 
 ---

--- a/term-board/e2e/playwright.config.js
+++ b/term-board/e2e/playwright.config.js
@@ -2,11 +2,11 @@ import { defineConfig, devices } from '@playwright/test';
 
 // term-board E2E 設定。
 // - サーバー無しの静的SPA（React+Vite）。backend/DB は無く、Vite dev だけを起動する。
-// - dev は base パス（/hideharu-AI/term-board/）で配信され、root(/) は 302 で base へ誘導される。
+// - dev は base パス（/study-boards/term-board/）で配信され、root(/) は 302 で base へ誘導される。
 //   baseURL は origin のみとし、各テストは goto('/') でリダイレクトを追従する。
 // - smoke / a11y はどちらも chromium-desktop で PR 自動実行（外部依存が無く安定）。
 const ORIGIN = process.env.E2E_BASE_URL || 'http://localhost:5176';
-const APP_URL = `${ORIGIN}/hideharu-AI/term-board/`;
+const APP_URL = `${ORIGIN}/study-boards/term-board/`;
 
 export default defineConfig({
   testDir: './tests',

--- a/term-board/index.html
+++ b/term-board/index.html
@@ -15,17 +15,17 @@
     <meta property="og:site_name" content="IT用語ボード" />
     <meta property="og:title" content="IT用語ボード｜IT未経験者の面接対策クイズ" />
     <meta property="og:description" content="IT用語を4択クイズで定着させ、面接で言えるまで練習。ログイン不要・無料・ブラウザだけで今すぐ。" />
-    <meta property="og:url" content="https://80-cloud.github.io/hideharu-AI/term-board/" />
+    <meta property="og:url" content="https://80-cloud.github.io/study-boards/term-board/" />
     <meta property="og:locale" content="ja_JP" />
     <!-- OGP 画像（1200x630・#433）。Discord/Slack/Twitter で大きなサムネ付きカードに展開される。 -->
-    <meta property="og:image" content="https://80-cloud.github.io/hideharu-AI/term-board/ogp.png" />
+    <meta property="og:image" content="https://80-cloud.github.io/study-boards/term-board/ogp.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="IT用語ボード — IT用語を「面接で言える」まで。4択クイズで覚えて、自分の言葉に。" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="IT用語ボード｜IT未経験者の面接対策クイズ" />
     <meta name="twitter:description" content="IT用語を4択クイズで定着させ、面接で言えるまで練習。ログイン不要・無料・ブラウザだけで今すぐ。" />
-    <meta name="twitter:image" content="https://80-cloud.github.io/hideharu-AI/term-board/ogp.png" />
+    <meta name="twitter:image" content="https://80-cloud.github.io/study-boards/term-board/ogp.png" />
   </head>
   <body>
     <div id="root"></div>

--- a/term-board/vite.config.ts
+++ b/term-board/vite.config.ts
@@ -7,11 +7,11 @@ import tailwindcss from "@tailwindcss/vite";
 // 別ポートでの代替起動は禁止のため strictPort: true で競合時はエラーにする。
 //
 // base: GitHub Pages のサブパス配信用（Issue #285）。
-// 公開URL = https://80-cloud.github.io/hideharu-AI/term-board/ なので、
-// 本番ビルドのアセット参照を "/hideharu-AI/term-board/" 起点にする。
+// 公開URL = https://80-cloud.github.io/study-boards/term-board/ なので、
+// 本番ビルドのアセット参照を "/study-boards/term-board/" 起点にする（#435 でリネーム）。
 // dev（npm run dev）では base は "/" 相当で問題なく動く（プロダクションビルドのみ影響）。
 export default defineConfig({
-  base: "/hideharu-AI/term-board/",
+  base: "/study-boards/term-board/",
   plugins: [react(), tailwindcss()],
   server: {
     port: 5176,


### PR DESCRIPTION
## 関連 Issue

Closes #435

---

## 変更の概要

term-board の公開URLにリポ名 `hideharu-AI` が露出して個人名が漏れていたため、リポを **`study-boards`** にリネーム（既に gh repo rename 実施済み）し、関連の path / URL を新名へ更新。旧URLは GitHub の 301 リダイレクトで生き続けるため既存 Discord/X リンクは壊れない。

- `vite.config.ts`: `base: "/study-boards/term-board/"` へ
- `index.html`: og:url / og:image / twitter:image を新URLへ
- `README.md`: 公開URL リンクと preview 説明
- `docs/引き継ぎ書.md`: 本番URL / リポジトリ / Pages base / コマンド例
- `.github/workflows/term-board-pages.yml`: コメント内のパス表記

## 範囲外（別Issue 化）

- 他PJ (slack-board / sns-board / TripDiary) docs 内の `hideharu-AI` 表記
- ルート `CLAUDE.md` / `README.md` / `.gitleaks.toml` の表記
- 各 docs author 名（"作成者: hideharu-AI"）

## 変更の種別

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] style
- [ ] refactor
- [ ] test
- [x] chore（リネーム反映）

---

## 動作確認チェックリスト

- [x] `npm run build` green
- [x] `dist/index.html` の og:url / og:image / twitter:image / assets パスが `/study-boards/term-board/` で始まる
- [x] `npm run test` 33/33 green
- [ ] マージ後、`https://80-cloud.github.io/study-boards/term-board/` にデプロイ反映
- [ ] 旧URL `https://80-cloud.github.io/hideharu-AI/term-board/` が 301 リダイレクト

---

## レビュー時に特に確認してほしい点

- GitHub Pages の deploy workflow が新リポ名で正しく走るか（artifact upload, Pages deployment）
- og:image の絶対URL（Discord 側のキャッシュは数日残る可能性。OGP デバッガで再取得可）