### PR TITLE
feat: 「覚える」グループ共通の学習レベルフィルタを追加

### DIFF
--- a/term-board/src/App.tsx
+++ b/term-board/src/App.tsx
@@ -4,10 +4,12 @@ import { usePendingImport } from "./hooks/usePendingImport";
 import type { PendingImport } from "./hooks/usePendingImport";
 import { useBookmarks } from "./hooks/useBookmarks";
 import { useTheme } from "./hooks/useTheme";
+import { useLevel } from "./hooks/useLevel";
 import { useNavLayout } from "./hooks/useNavLayout";
 import type { NavLayout } from "./hooks/useNavLayout";
 import { useViewHistory } from "./hooks/useViewHistory";
 import { CategoryFilter } from "./components/CategoryFilter";
+import { LevelSelector } from "./components/LevelSelector";
 import { QuizView } from "./components/QuizView";
 import { InterviewView } from "./components/InterviewView";
 import { MockInterviewView } from "./components/MockInterviewView";
@@ -93,8 +95,11 @@ export default function App() {
   const bookmarks = useBookmarks();
   // #431: ?import=... を踏んで開いた場合のプレビュー（受信側のワンクリック共有）
   const pendingImport = usePendingImport();
+  // #437: 覚える系3ビュー共通の学習レベルフィルタ
+  const levelState = useLevel();
   // ユーザー作問の件数を渡し、追加・取り込みで出題に即反映する（F-USER）。
-  const quiz = useQuiz(user.content.quizTerms.length);
+  // #437: 学習レベルでも出題プールを絞れるよう level を引き渡す。
+  const quiz = useQuiz(user.content.quizTerms.length, levelState.level);
   const rate =
     quiz.answeredCount > 0
       ? Math.round((quiz.correctCount / quiz.answeredCount) * 100)
@@ -139,8 +144,8 @@ export default function App() {
         </>
       )}
 
-      {view === "card" && <CardView />}
-      {view === "dictionary" && <DictionaryView bookmarks={bookmarks} />}
+      {view === "card" && <CardView level={levelState.level} />}
+      {view === "dictionary" && <DictionaryView bookmarks={bookmarks} level={levelState.level} />}
       {view === "learn" && <LearnView />}
       {view === "dashboard" && <DashboardView bookmarks={bookmarks} />}
       {view === "review" && <ReviewView />}
@@ -184,13 +189,17 @@ export default function App() {
               </div>
               <ThemeToggle theme={theme.theme} onToggle={theme.toggle} className="flex sm:hidden" />
             </div>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2">
               {view === "quiz" && quiz.status === "ready" && (
                 <CategoryFilter
                   categories={quiz.categories}
                   value={quiz.category}
                   onChange={quiz.setCategory}
                 />
+              )}
+              {/* #437: 覚える系3ビュー共通の学習レベル選択（4チップ） */}
+              {(view === "quiz" || view === "card" || view === "dictionary") && (
+                <LevelSelector value={levelState.level} onChange={levelState.setLevel} />
               )}
               {/* PCナビ様式トグル（desktop のみ・#381 の2案比較用）。 */}
               <LayoutToggle layout={nav.layout} onToggle={nav.toggle} className="hidden lg:flex" />

--- a/term-board/src/App.tsx
+++ b/term-board/src/App.tsx
@@ -123,6 +123,10 @@ export default function App() {
           )}
           {quiz.status === "ready" && (
             <>
+              {/* #437: 学習レベル選択（解答数バーの上に配置）。 */}
+              <div className="mb-3">
+                <LevelSelector value={levelState.level} onChange={levelState.setLevel} />
+              </div>
               <div className="hig-card mb-5 flex items-center justify-between px-4 py-3 text-sm">
                 <span className="text-label-2">解答数 <span className="font-bold text-label">{quiz.answeredCount}</span></span>
                 <span className="text-label-2">正答 <span className="font-bold text-emerald-700 dark:text-emerald-400">{quiz.correctCount}</span></span>
@@ -144,8 +148,24 @@ export default function App() {
         </>
       )}
 
-      {view === "card" && <CardView level={levelState.level} />}
-      {view === "dictionary" && <DictionaryView bookmarks={bookmarks} level={levelState.level} />}
+      {view === "card" && (
+        <>
+          {/* #437: 学習レベル選択（カード上部に配置・分野フィルタの上で見つけやすく） */}
+          <div className="mb-3">
+            <LevelSelector value={levelState.level} onChange={levelState.setLevel} />
+          </div>
+          <CardView level={levelState.level} />
+        </>
+      )}
+      {view === "dictionary" && (
+        <>
+          {/* #437: 学習レベル選択（辞典上部に配置） */}
+          <div className="mb-3">
+            <LevelSelector value={levelState.level} onChange={levelState.setLevel} />
+          </div>
+          <DictionaryView bookmarks={bookmarks} level={levelState.level} />
+        </>
+      )}
       {view === "learn" && <LearnView />}
       {view === "dashboard" && <DashboardView bookmarks={bookmarks} />}
       {view === "review" && <ReviewView />}
@@ -196,10 +216,6 @@ export default function App() {
                   value={quiz.category}
                   onChange={quiz.setCategory}
                 />
-              )}
-              {/* #437: 覚える系3ビュー共通の学習レベル選択（4チップ） */}
-              {(view === "quiz" || view === "card" || view === "dictionary") && (
-                <LevelSelector value={levelState.level} onChange={levelState.setLevel} />
               )}
               {/* PCナビ様式トグル（desktop のみ・#381 の2案比較用）。 */}
               <LayoutToggle layout={nav.layout} onToggle={nav.toggle} className="hidden lg:flex" />

--- a/term-board/src/components/CardView.tsx
+++ b/term-board/src/components/CardView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import type { Term, Progress, LearningSession } from "../types";
+import type { LevelFilter } from "../hooks/useLevel";
 import { repository } from "../api";
 import { pickWeighted } from "../utils/shuffle";
 import { srsWeight } from "../utils/srs";
@@ -10,7 +11,9 @@ import { newId } from "../utils/share";
 // 「覚えた/まだ」をカード専用の習熟度に記録し、SRS(srsWeight)で苦手・未学習カードを
 // 優先出題する。4択(再認)・辞典(参照)と差別化した「思い出して答える」学習。
 
-export function CardView() {
+type Props = { level: LevelFilter };
+
+export function CardView({ level }: Props) {
   const [terms, setTerms] = useState<Term[]>([]);
   const [cardProgress, setCardProgress] = useState<Progress>({});
   const [current, setCurrent] = useState<Term | null>(null);
@@ -49,10 +52,11 @@ export function CardView() {
     () =>
       terms.filter((t) => {
         if (category && t.category !== category) return false;
+        if (level !== "all" && t.level !== level) return false; // #437
         if (onlyWeak && !isWeak(t.id)) return false;
         return true;
       }),
-    [terms, category, onlyWeak, cardProgress],
+    [terms, category, level, onlyWeak, cardProgress],
   );
 
   // SRS 重み付きで次のカードを選ぶ（直前と同じは避ける）。

--- a/term-board/src/components/DictionaryView.tsx
+++ b/term-board/src/components/DictionaryView.tsx
@@ -2,8 +2,9 @@ import { useEffect, useMemo, useState } from "react";
 import type { Term } from "../types";
 import { repository } from "../api";
 import type { UseBookmarks } from "../hooks/useBookmarks";
+import type { LevelFilter } from "../hooks/useLevel";
 
-type Props = { bookmarks: UseBookmarks };
+type Props = { bookmarks: UseBookmarks; level: LevelFilter };
 
 const levelClass: Record<string, string> = {
   初級: "bg-emerald-100 text-emerald-800",
@@ -11,8 +12,8 @@ const levelClass: Record<string, string> = {
   上級: "bg-rose-100 text-rose-800",
 };
 
-// B1: 用語辞典（IT用語辞典・カテゴリ別・検索・ブックマーク・レベル表示）。
-export function DictionaryView({ bookmarks }: Props) {
+// B1: 用語辞典（IT用語辞典・カテゴリ別・検索・ブックマーク・レベル表示／レベル絞り#437）。
+export function DictionaryView({ bookmarks, level }: Props) {
   const [terms, setTerms] = useState<Term[]>([]);
   const [query, setQuery] = useState("");
   const [category, setCategory] = useState("");
@@ -49,6 +50,7 @@ export function DictionaryView({ bookmarks }: Props) {
     const q = query.trim().toLowerCase();
     const list = terms.filter((t) => {
       if (category && t.category !== category) return false;
+      if (level !== "all" && t.level !== level) return false; // #437
       if (onlyBookmarked && !bookmarks.isBookmarked(t.id)) return false;
       if (q && !`${t.term} ${t.meaning} ${t.plainMeaning ?? ""}`.toLowerCase().includes(q)) {
         return false;
@@ -61,7 +63,7 @@ export function DictionaryView({ bookmarks }: Props) {
       return sort === "desc" ? sorted.reverse() : sorted;
     }
     return list;
-  }, [terms, query, category, onlyBookmarked, bookmarks, sort]);
+  }, [terms, query, category, level, onlyBookmarked, bookmarks, sort]);
 
   return (
     <section className="flex flex-col gap-4">

--- a/term-board/src/components/LevelSelector.tsx
+++ b/term-board/src/components/LevelSelector.tsx
@@ -1,0 +1,46 @@
+import type { LevelFilter, Level } from "../hooks/useLevel";
+import { LEVELS } from "../hooks/useLevel";
+
+// #437: 学習レベル選択チップ（全レベル / 初級 / 中級 / 上級）。
+// 覚える系3ビュー（4択クイズ・暗記カード・用語辞典）共通で使う。
+
+type Props = {
+  value: LevelFilter;
+  onChange: (next: LevelFilter) => void;
+  /** 各レベルの該当件数を表示する場合に渡す（任意・undefined なら件数非表示） */
+  counts?: { all: number } & Partial<Record<Level, number>>;
+  className?: string;
+};
+
+export function LevelSelector({ value, onChange, counts, className = "" }: Props) {
+  const items: { key: LevelFilter; label: string; count?: number }[] = [
+    { key: "all", label: "全レベル", count: counts?.all },
+    ...LEVELS.map((lv) => ({ key: lv as LevelFilter, label: lv, count: counts?.[lv] })),
+  ];
+  return (
+    <div className={`flex flex-wrap items-center gap-1.5 ${className}`} role="group" aria-label="学習レベル">
+      <span className="text-sm font-medium text-label-2">レベル</span>
+      {items.map(({ key, label, count }) => {
+        const active = value === key;
+        return (
+          <button
+            key={key}
+            type="button"
+            onClick={() => onChange(key)}
+            aria-pressed={active}
+            className={`rounded-full px-3 py-1 text-xs font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+              active
+                ? "bg-accent-fill text-white"
+                : "bg-fill-quaternary text-label-2 hover:text-label"
+            }`}
+          >
+            {label}
+            {typeof count === "number" && (
+              <span className={`ml-1 ${active ? "opacity-90" : "opacity-70"}`}>({count})</span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/term-board/src/hooks/useLevel.ts
+++ b/term-board/src/hooks/useLevel.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+
+// #437: 学習レベルフィルタ（覚える系3ビュー共通）。
+// 用語の Term.level（初級/中級/上級）に対応する選択値で、表示と出題を絞る。
+// "all" は全レベルを意味し、覚える系の初回起動時のデフォルト。
+
+const LEVEL_KEY = "term-board:level:v1";
+export const LEVELS = ["初級", "中級", "上級"] as const;
+export type Level = (typeof LEVELS)[number];
+export type LevelFilter = "all" | Level;
+
+function isLevelFilter(v: unknown): v is LevelFilter {
+  return v === "all" || (typeof v === "string" && (LEVELS as readonly string[]).includes(v));
+}
+
+function initial(): LevelFilter {
+  try {
+    const saved = localStorage.getItem(LEVEL_KEY);
+    if (isLevelFilter(saved)) return saved;
+  } catch {
+    // localStorage 不可でも続行
+  }
+  return "all";
+}
+
+export function useLevel() {
+  const [level, setLevel] = useState<LevelFilter>(initial);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(LEVEL_KEY, level);
+    } catch {
+      // 保存失敗でも継続（次回起動で "all" に戻るだけ）
+    }
+  }, [level]);
+
+  return { level, setLevel };
+}

--- a/term-board/src/hooks/useQuiz.ts
+++ b/term-board/src/hooks/useQuiz.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Term, Progress } from "../types";
+import type { LevelFilter } from "./useLevel";
 import { repository } from "../api";
 import { shuffle, pickWeighted } from "../utils/shuffle";
 import { srsWeight } from "../utils/srs";
@@ -34,7 +35,8 @@ export type UseQuiz = {
 };
 
 // reloadKey: ユーザー作問の件数などを渡すと、変化時に用語を再読込して出題に反映する（F-USER）。
-export function useQuiz(reloadKey: number | string = 0): UseQuiz {
+// level: "all" 以外なら、その難易度の用語のみで出題プールを構成する（#437）。
+export function useQuiz(reloadKey: number | string = 0, level: LevelFilter = "all"): UseQuiz {
   const [terms, setTerms] = useState<Term[]>([]);
   // 進捗は SRS の出題優先度に使う。再レンダーを誘発せず常に最新を読むため ref で保持する。
   const progressRef = useRef<Progress>({});
@@ -74,10 +76,15 @@ export function useQuiz(reloadKey: number | string = 0): UseQuiz {
     [terms],
   );
 
-  // 現在の分野で出題可能な用語（F-QUIZ-04 分野別・全分野ランダム）。
+  // 現在の分野・レベルで出題可能な用語（F-QUIZ-04 分野別・全分野ランダム / #437 レベル絞り込み）。
   const pool = useMemo(
-    () => (category ? terms.filter((t) => t.category === category) : terms),
-    [terms, category],
+    () =>
+      terms.filter((t) => {
+        if (category && t.category !== category) return false;
+        if (level !== "all" && t.level !== level) return false;
+        return true;
+      }),
+    [terms, category, level],
   );
 
   // 次の問題を出す。SRS の重み付き選択で苦手・未出題を優先しつつ、


### PR DESCRIPTION
## 関連 Issue

Closes #437

---

## 変更の概要

Term.level（初級/中級/上級）は既にデータ側に付与済み（初級67/中級134/上級17）だが、これまでは用語辞典のバッジ表示に使われるだけだった。覚える系3ビュー共通の **単一 state** で扱い、選んだレベルに応じて **4択クイズ・暗記カード・用語辞典の表示と出題を絞れる** ようにする。

- `useLevel` フック新設：`localStorage` `term-board:level:v1` で永続化
- `LevelSelector` コンポーネント：4チップ（全レベル/初級/中級/上級、aria-pressed/focus-ring 完備）
- `App.tsx`：useLevel を呼び、覚える系3ビューに level を伝播。**ヘッダー右側に LevelSelector**（quiz/card/dictionary 時のみ表示・flex-wrap でモバイル対応）
- `useQuiz`：引数に level を追加、出題プールから level 不一致を除外。`pool` 変化で `next()` 自動再出題
- `DictionaryView` / `CardView`：level prop を受け取りフィルタに反映

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] 4択クイズで「中級」選択 → 6問連続で全て中級語（props / ORM / デジタル署名 / NOT NULL / GitHub Actions / レイヤード）
- [x] 暗記カードで「初級」選択 → 5枚連続で全て初級（テストケース / カンバン / PR / HTTP / 要件定義）
- [x] 用語辞典で「上級」選択 → 件数「17件」（terms.json 上級語数と一致）、全件上級バッジ
- [x] 選択は画面切替・リロード後も保持（localStorage 永続）
- [x] `npm run build` green / `npm run test` 33/33 green
- [x] Light/Dark 両対応・モバイルでチップ折り返し

---

## レビュー時に特に確認してほしい点

- ヘッダーに LevelSelector を載せた配置（CategoryFilter と並ぶ）。モバイルで2段になるが許容範囲か。
- レベル切替時に `pool` 変化 → 自動で次の問題/カードへ遷移する挙動（既存 `useEffect` を活用）。