### PR TITLE
feat: Flashcard 型に level を追加し暗記カードもレベルフィルタの対象に

### DIFF
--- a/term-board/src/api/localStorageTermRepository.ts
+++ b/term-board/src/api/localStorageTermRepository.ts
@@ -112,6 +112,7 @@ export const localStorageTermRepository: TermRepository = {
       distractors: [],
       interview: "",
       source: f.source ?? "user",
+      level: f.level, // #444: 暗記カードもレベルフィルタに参加
     }));
     return [...base, ...asTerms];
   },

--- a/term-board/src/components/AuthorView.tsx
+++ b/term-board/src/components/AuthorView.tsx
@@ -387,6 +387,7 @@ function FlashcardForm({ user }: Props) {
   const [front, setFront] = useState("");
   const [back, setBack] = useState("");
   const [category, setCategory] = useState("");
+  const [level, setLevel] = useState<"" | "初級" | "中級" | "上級">("");
   const valid = front.trim() && back.trim();
   const isEditing = editingId !== null;
   const cards = user.content.flashcards ?? [];
@@ -396,6 +397,7 @@ function FlashcardForm({ user }: Props) {
     setFront("");
     setBack("");
     setCategory("");
+    setLevel("");
   };
 
   const startEdit = (id: string) => {
@@ -405,6 +407,7 @@ function FlashcardForm({ user }: Props) {
     setFront(item.front);
     setBack(item.back);
     setCategory(item.category ?? "");
+    setLevel(item.level ?? "");
   };
 
   // 重複チェック（表が同じ・編集中は自分を除外）
@@ -419,6 +422,7 @@ function FlashcardForm({ user }: Props) {
       front: front.trim(),
       back: back.trim(),
       category: category.trim() || undefined,
+      level: level === "" ? undefined : level,
     };
     if (editingId) {
       user.updateFlashcard(editingId, data);
@@ -455,6 +459,20 @@ function FlashcardForm({ user }: Props) {
         <div>
           <label htmlFor="fc-cat" className={labelClass}>分野（任意）</label>
           <input id="fc-cat" className={inputClass} value={category} onChange={(e) => setCategory(e.target.value)} placeholder="例：略語 / コマンド" />
+        </div>
+        <div>
+          <label htmlFor="fc-level" className={labelClass}>レベル（任意）</label>
+          <select
+            id="fc-level"
+            className={inputClass}
+            value={level}
+            onChange={(e) => setLevel(e.target.value as "" | "初級" | "中級" | "上級")}
+          >
+            <option value="">未設定（どのレベルでも表示）</option>
+            <option value="初級">初級</option>
+            <option value="中級">中級</option>
+            <option value="上級">上級</option>
+          </select>
         </div>
         <div className="flex flex-wrap gap-2">
           <button type="submit" disabled={!valid || isDuplicate} className={primaryBtn}>

--- a/term-board/src/components/CardView.tsx
+++ b/term-board/src/components/CardView.tsx
@@ -52,7 +52,8 @@ export function CardView({ level }: Props) {
     () =>
       terms.filter((t) => {
         if (category && t.category !== category) return false;
-        if (level !== "all" && t.level !== level) return false; // #437
+        // #437 + #444: level 未設定（Flashcard 旧データ等）は全レベル該当として残す
+        if (level !== "all" && t.level && t.level !== level) return false;
         if (onlyWeak && !isWeak(t.id)) return false;
         return true;
       }),

--- a/term-board/src/components/DictionaryView.tsx
+++ b/term-board/src/components/DictionaryView.tsx
@@ -50,7 +50,8 @@ export function DictionaryView({ bookmarks, level }: Props) {
     const q = query.trim().toLowerCase();
     const list = terms.filter((t) => {
       if (category && t.category !== category) return false;
-      if (level !== "all" && t.level !== level) return false; // #437
+      // #437 + #444: level 未設定（ユーザー作問など）は全レベル該当として残す
+      if (level !== "all" && t.level && t.level !== level) return false;
       if (onlyBookmarked && !bookmarks.isBookmarked(t.id)) return false;
       if (q && !`${t.term} ${t.meaning} ${t.plainMeaning ?? ""}`.toLowerCase().includes(q)) {
         return false;

--- a/term-board/src/hooks/useQuiz.ts
+++ b/term-board/src/hooks/useQuiz.ts
@@ -81,7 +81,8 @@ export function useQuiz(reloadKey: number | string = 0, level: LevelFilter = "al
     () =>
       terms.filter((t) => {
         if (category && t.category !== category) return false;
-        if (level !== "all" && t.level !== level) return false;
+        // level 未設定（ユーザー作問など）は全レベル該当として残す（#444）
+        if (level !== "all" && t.level && t.level !== level) return false;
         return true;
       }),
     [terms, category, level],

--- a/term-board/src/types.ts
+++ b/term-board/src/types.ts
@@ -61,6 +61,7 @@ export type Flashcard = {
   front: string; // 表（用語・問題）
   back: string; // 裏（意味・回答）
   category?: string; // 分野（任意）
+  level?: "初級" | "中級" | "上級"; // 学習レベル（#444・未設定はフィルタで全レベル該当）
   source?: "user" | "shared";
 };
 


### PR DESCRIPTION
## 概要

#438 で「覚える」グループに学習レベルフィルタを導入したが、Flashcard 型（#427 で追加）には \`level\` フィールドが無く、ユーザーの暗記カードが「初級/中級/上級」選択時に全件非表示になっていた問題を修正します。

## 変更内容

- [src/types.ts](src/types.ts#L59-L65) — \`Flashcard\` 型に \`level?: \"初級\" | \"中級\" | \"上級\"\` を追加
- [src/components/AuthorView.tsx](src/components/AuthorView.tsx#L385) — FlashcardForm にレベル選択 UI（未設定 / 初級 / 中級 / 上級）を追加。編集時にも既存値を読み戻し
- [src/api/localStorageTermRepository.ts](src/api/localStorageTermRepository.ts#L107) — \`getCardItems\` の正規化で \`level\` をコピー
- [src/components/CardView.tsx](src/components/CardView.tsx#L55) / [src/components/DictionaryView.tsx](src/components/DictionaryView.tsx#L53) / [src/hooks/useQuiz.ts](src/hooks/useQuiz.ts#L84) — フィルタ条件を **「level 未設定は全レベル該当」** に変更
  - 既存の level 無し Flashcard / ユーザー作成 quiz term がレベル選択時に消えない

## 共有コード（share.ts）

\`encodeShareCode\` は \`UserContent\` 全体を JSON 化し、\`decodeShareCode\` 後の \`importCode\` が \`...f\` spread でフィールドをそのまま取り込むため、level は変更なしで往復します。

## 受入

- [x] 既存の level 無し Flashcard はどのレベル選択でも表示される
- [x] 新規作成時に level を選んで保存できる
- [x] レベル選択時、選んだ level の Flashcard のみが暗記カードに出る
- [x] エクスポート→インポートで level が保たれる（共有コードは JSON 全体を往復）
- [x] \`npm run build\` ✓
- [x] \`npm run test\` ✓（4 files / 33 tests）

Closes #444