### PR TITLE
feat: 成果物棚卸しテンプレモードを追加（静的・記入式・AI不使用）

### DIFF
--- a/term-board/src/api/localStorageTermRepository.ts
+++ b/term-board/src/api/localStorageTermRepository.ts
@@ -34,7 +34,7 @@ const EXPORT_KEYS = [
   MISSES_KEY,
 ] as const;
 
-const EMPTY_USER_CONTENT: UserContent = { quizTerms: [], interviewQuestions: [] };
+const EMPTY_USER_CONTENT: UserContent = { quizTerms: [], interviewQuestions: [], reverseQuestions: [], flashcards: [], portfolioCards: [] };
 
 // 要件定義書 §4-1 / A-4: localStorage の破損・容量超過・未対応でも
 // 「進捗のみ初期化して用語出題は継続する」graceful degradation を守る。
@@ -70,7 +70,8 @@ function readUserContent(): UserContent {
     const fromUserContent = Array.isArray(obj.reverseQuestions) ? obj.reverseQuestions : null;
     const reverseQuestions = fromUserContent ?? readLegacyReverseQuestions();
     const flashcards = Array.isArray(obj.flashcards) ? obj.flashcards : [];
-    return { quizTerms, interviewQuestions, reverseQuestions, flashcards };
+    const portfolioCards = Array.isArray(obj.portfolioCards) ? obj.portfolioCards : [];
+    return { quizTerms, interviewQuestions, reverseQuestions, flashcards, portfolioCards };
   } catch {
     return EMPTY_USER_CONTENT;
   }

--- a/term-board/src/components/AuthorView.tsx
+++ b/term-board/src/components/AuthorView.tsx
@@ -3,7 +3,7 @@ import type { UseUserContent } from "../hooks/useUserContent";
 import { ReverseQuestionStock } from "./ReverseQuestionStock";
 
 type Props = { user: UseUserContent };
-type Tab = "quiz" | "interview" | "card" | "reverse" | "share";
+type Tab = "quiz" | "interview" | "card" | "reverse" | "portfolio" | "share";
 
 const inputClass =
   "w-full rounded-control border border-separator bg-surface px-3 py-2 text-sm text-label focus:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent";
@@ -32,6 +32,9 @@ export function AuthorView({ user }: Props) {
         <SubTab active={tab === "reverse"} onClick={() => setTab("reverse")}>
           逆質問
         </SubTab>
+        <SubTab active={tab === "portfolio"} onClick={() => setTab("portfolio")}>
+          成果物
+        </SubTab>
         <SubTab active={tab === "share"} onClick={() => setTab("share")}>
           共有
         </SubTab>
@@ -41,6 +44,7 @@ export function AuthorView({ user }: Props) {
       {tab === "quiz" && <QuizForm user={user} />}
       {tab === "card" && <FlashcardForm user={user} />}
       {tab === "reverse" && <ReverseQuestionStock user={user} />}
+      {tab === "portfolio" && <PortfolioForm user={user} />}
       {tab === "share" && <SharePanel user={user} />}
     </section>
   );
@@ -503,6 +507,156 @@ function FlashcardForm({ user }: Props) {
   );
 }
 
+// --- 成果物棚卸しテンプレ（追加＋編集・#456） ---
+// 面接の「何作りました？」「工夫した点は？」に本人の言葉で答えられるよう、
+// 制作物を1件1カードで記録する。AI 生成は不採用（ハルシネーション防止）。
+function PortfolioForm({ user }: Props) {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [title, setTitle] = useState("");
+  const [problem, setProblem] = useState("");
+  const [tech, setTech] = useState("");
+  const [effort, setEffort] = useState("");
+  const [difficulty, setDifficulty] = useState("");
+  const [retrospective, setRetrospective] = useState("");
+  const [githubUrl, setGithubUrl] = useState("");
+  const [optionalOpen, setOptionalOpen] = useState(false);
+  const valid = title.trim() && problem.trim() && tech.trim() && effort.trim();
+  const isEditing = editingId !== null;
+  const cards = user.content.portfolioCards ?? [];
+
+  const resetForm = () => {
+    setEditingId(null);
+    setTitle("");
+    setProblem("");
+    setTech("");
+    setEffort("");
+    setDifficulty("");
+    setRetrospective("");
+    setGithubUrl("");
+    setOptionalOpen(false);
+  };
+
+  const startEdit = (id: string) => {
+    const item = cards.find((c) => c.id === id);
+    if (!item) return;
+    setEditingId(id);
+    setTitle(item.title);
+    setProblem(item.problem);
+    setTech(item.tech);
+    setEffort(item.effort);
+    setDifficulty(item.difficulty ?? "");
+    setRetrospective(item.retrospective ?? "");
+    setGithubUrl(item.githubUrl ?? "");
+    setOptionalOpen(!!(item.difficulty || item.retrospective || item.githubUrl));
+  };
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!valid) return;
+    const data = {
+      title: title.trim(),
+      problem: problem.trim(),
+      tech: tech.trim(),
+      effort: effort.trim(),
+      difficulty: difficulty.trim() || undefined,
+      retrospective: retrospective.trim() || undefined,
+      githubUrl: githubUrl.trim() || undefined,
+    };
+    if (editingId) {
+      user.updatePortfolioCard(editingId, data);
+    } else {
+      user.addPortfolioCard(data);
+    }
+    resetForm();
+  };
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="rounded-control bg-sky-50 px-4 py-3 text-sm text-sky-900 ring-1 ring-sky-200 dark:bg-sky-950 dark:text-sky-100 dark:ring-sky-900">
+        <p className="font-semibold">この機能は何のため？</p>
+        <p className="mt-1">
+          面接で「何作りました？」「工夫した点は？」と聞かれた時に、ここで書いたカードを見ながら自分の言葉で答えられる状態を目指します。
+          AI に書いてもらうのではなく、<strong>自分で書く</strong>ことが面接で再現できる素地になります。
+        </p>
+      </div>
+
+      <form onSubmit={submit} className="flex flex-col gap-3 hig-card p-5">
+        {isEditing && (
+          <p className="rounded-control bg-amber-50 px-3 py-2 text-xs font-medium text-amber-800 ring-1 ring-amber-200 dark:bg-amber-950 dark:text-amber-200 dark:ring-amber-900">
+            編集中：{title || "（タイトル未入力）"}
+          </p>
+        )}
+        <div>
+          <label htmlFor="pf-title" className={labelClass}>作ったもの <span className="text-rose-600">*</span></label>
+          <input id="pf-title" className={inputClass} value={title} onChange={(e) => setTitle(e.target.value)} placeholder="例：タスク管理アプリ（Web）" />
+        </div>
+        <div>
+          <label htmlFor="pf-problem" className={labelClass}>解決したい課題 <span className="text-rose-600">*</span></label>
+          <textarea id="pf-problem" className={inputClass} rows={2} value={problem} onChange={(e) => setProblem(e.target.value)} placeholder="例：複数アプリにメモが散らばって締切を見落とすことを解消したい" />
+        </div>
+        <div>
+          <label htmlFor="pf-tech" className={labelClass}>使った技術 <span className="text-rose-600">*</span></label>
+          <input id="pf-tech" className={inputClass} value={tech} onChange={(e) => setTech(e.target.value)} placeholder="例：React, TypeScript, Vite, GitHub Pages" />
+        </div>
+        <div>
+          <label htmlFor="pf-effort" className={labelClass}>工夫した点 <span className="text-rose-600">*</span></label>
+          <textarea id="pf-effort" className={inputClass} rows={3} value={effort} onChange={(e) => setEffort(e.target.value)} placeholder="例：localStorage で永続化するか DB を使うか迷い、無料運用のため前者を選んだ。理由は…" />
+        </div>
+
+        <button
+          type="button"
+          onClick={() => setOptionalOpen(!optionalOpen)}
+          className="self-start text-sm text-accent underline-offset-2 hover:underline"
+        >
+          {optionalOpen ? "▾ 任意項目を閉じる" : "▸ 任意項目を開く（困った点・振り返り・GitHub URL）"}
+        </button>
+
+        {optionalOpen && (
+          <div className="flex flex-col gap-3 rounded-control bg-fill-quaternary p-3">
+            <div>
+              <label htmlFor="pf-difficulty" className={labelClass}>困った点と乗り越え方</label>
+              <textarea id="pf-difficulty" className={inputClass} rows={3} value={difficulty} onChange={(e) => setDifficulty(e.target.value)} placeholder="例：CORS エラーが解消できず、Vite のプロキシ設定で乗り越えた" />
+            </div>
+            <div>
+              <label htmlFor="pf-retro" className={labelClass}>もう一度作るならどう変える</label>
+              <textarea id="pf-retro" className={inputClass} rows={2} value={retrospective} onChange={(e) => setRetrospective(e.target.value)} placeholder="例：状態管理を Context ではなく Zustand にすると見通しが良くなりそう" />
+            </div>
+            <div>
+              <label htmlFor="pf-url" className={labelClass}>GitHub URL</label>
+              <input id="pf-url" className={inputClass} value={githubUrl} onChange={(e) => setGithubUrl(e.target.value)} placeholder="https://github.com/your-name/your-repo" />
+            </div>
+          </div>
+        )}
+
+        <div className="flex flex-wrap gap-2">
+          <button type="submit" disabled={!valid} className={primaryBtn}>
+            {isEditing ? "更新する" : "追加する"}
+          </button>
+          {isEditing && (
+            <button type="button" onClick={resetForm} className={secondaryBtn}>
+              キャンセル
+            </button>
+          )}
+        </div>
+      </form>
+
+      <ItemList
+        title={`登録した成果物（${cards.length}件）`}
+        items={cards.map((c) => ({
+          id: c.id,
+          primary: c.title,
+          secondary: `${c.tech}｜${c.problem}`,
+        }))}
+        onEdit={startEdit}
+        onRemove={(id) => {
+          if (editingId === id) resetForm();
+          user.removePortfolioCard(id);
+        }}
+      />
+    </div>
+  );
+}
+
 // --- 共有（エクスポート/インポート） ---
 function SharePanel({ user }: Props) {
   const [exported, setExported] = useState("");
@@ -510,11 +664,13 @@ function SharePanel({ user }: Props) {
   const [message, setMessage] = useState<{ kind: "ok" | "err"; text: string } | null>(null);
   const reverseCount = user.content.reverseQuestions?.length ?? 0;
   const flashcardCount = user.content.flashcards?.length ?? 0;
+  const portfolioCount = user.content.portfolioCards?.length ?? 0;
   const total =
     user.content.quizTerms.length +
     user.content.interviewQuestions.length +
     reverseCount +
-    flashcardCount;
+    flashcardCount +
+    portfolioCount;
 
   const doExport = () => {
     if (total === 0) {
@@ -529,11 +685,11 @@ function SharePanel({ user }: Props) {
 
   const doImport = () => {
     try {
-      const { quiz, interview, reverse, flashcard } = user.importCode(importText);
+      const { quiz, interview, reverse, flashcard, portfolio } = user.importCode(importText);
       setImportText("");
       setMessage({
         kind: "ok",
-        text: `取り込みました：4択用語 ${quiz}件／面接Q&A ${interview}件／暗記カード ${flashcard}件／逆質問 ${reverse}件。`,
+        text: `取り込みました：4択用語 ${quiz}件／面接Q&A ${interview}件／暗記カード ${flashcard}件／逆質問 ${reverse}件／成果物 ${portfolio}件。`,
       });
     } catch {
       setMessage({ kind: "err", text: "共有コードを読み取れませんでした。コードが正しいか確認してください。" });
@@ -545,7 +701,7 @@ function SharePanel({ user }: Props) {
       <div className="hig-card p-5">
         <h2 className="font-bold text-label">書き出す（共有する）</h2>
         <p className="mt-1 text-sm text-label-2">
-          自分が作った問題（4択 {user.content.quizTerms.length}件・面接 {user.content.interviewQuestions.length}件・暗記カード {flashcardCount}件・逆質問 {reverseCount}件）を
+          自分が作った問題（4択 {user.content.quizTerms.length}件・面接 {user.content.interviewQuestions.length}件・暗記カード {flashcardCount}件・逆質問 {reverseCount}件・成果物 {portfolioCount}件）を
           共有コードにして、Discordなどに貼って渡せます。
         </p>
         <button type="button" onClick={doExport} className={`mt-3 ${primaryBtn}`}>共有コードを作る</button>

--- a/term-board/src/hooks/useUserContent.ts
+++ b/term-board/src/hooks/useUserContent.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import type { Term, InterviewQuestion, UserContent, Flashcard } from "../types";
+import type { Term, InterviewQuestion, UserContent, Flashcard, PortfolioCard } from "../types";
 import { repository } from "../api";
 import { newId, encodeShareCode, decodeShareCode } from "../utils/share";
 
@@ -9,6 +9,7 @@ import { newId, encodeShareCode, decodeShareCode } from "../utils/share";
 export type NewQuizTerm = Omit<Term, "id" | "source">;
 export type NewInterviewQuestion = Omit<InterviewQuestion, "id" | "source">;
 export type NewFlashcard = Omit<Flashcard, "id" | "source">;
+export type NewPortfolioCard = Omit<PortfolioCard, "id" | "source">;
 
 export type UseUserContent = {
   content: UserContent;
@@ -30,9 +31,15 @@ export type UseUserContent = {
   updateFlashcard: (id: string, c: NewFlashcard) => void;
   /** 暗記カードを削除。#427 */
   removeFlashcard: (id: string) => void;
+  /** 成果物カードを追加。#456 */
+  addPortfolioCard: (p: NewPortfolioCard) => void;
+  /** 成果物カードを更新（id・source は保持）。#456 */
+  updatePortfolioCard: (id: string, p: NewPortfolioCard) => void;
+  /** 成果物カードを削除。#456 */
+  removePortfolioCard: (id: string) => void;
   exportCode: () => string;
   /** 共有コードを取り込み、追加件数を返す。失敗時は例外を投げる。 */
-  importCode: (code: string) => { quiz: number; interview: number; reverse: number; flashcard: number };
+  importCode: (code: string) => { quiz: number; interview: number; reverse: number; flashcard: number; portfolio: number };
 };
 
 const EMPTY: UserContent = {
@@ -40,6 +47,7 @@ const EMPTY: UserContent = {
   interviewQuestions: [],
   reverseQuestions: [],
   flashcards: [],
+  portfolioCards: [],
 };
 
 export function useUserContent(): UseUserContent {
@@ -182,6 +190,39 @@ export function useUserContent(): UseUserContent {
     });
   }, []);
 
+  const addPortfolioCard = useCallback((p: NewPortfolioCard) => {
+    setContent((prev) => {
+      const list = prev.portfolioCards ?? [];
+      const next: UserContent = {
+        ...prev,
+        portfolioCards: [...list, { ...p, id: newId(), source: "user" }],
+      };
+      void repository.saveUserContent(next);
+      return next;
+    });
+  }, []);
+
+  const updatePortfolioCard = useCallback((id: string, p: NewPortfolioCard) => {
+    setContent((prev) => {
+      const list = prev.portfolioCards ?? [];
+      const next: UserContent = {
+        ...prev,
+        portfolioCards: list.map((c) => (c.id === id ? { ...c, ...p } : c)),
+      };
+      void repository.saveUserContent(next);
+      return next;
+    });
+  }, []);
+
+  const removePortfolioCard = useCallback((id: string) => {
+    setContent((prev) => {
+      const list = prev.portfolioCards ?? [];
+      const next: UserContent = { ...prev, portfolioCards: list.filter((c) => c.id !== id) };
+      void repository.saveUserContent(next);
+      return next;
+    });
+  }, []);
+
   const exportCode = useCallback(() => encodeShareCode(content), [content]);
 
   // 取り込み時はIDを振り直して衝突を避け、既存に追記する。
@@ -202,6 +243,11 @@ export function useUserContent(): UseUserContent {
         id: newId(),
         source: "shared" as const,
       }));
+      const incomingPortfolio = (incoming.portfolioCards ?? []).map((p) => ({
+        ...p,
+        id: newId(),
+        source: "shared" as const,
+      }));
       let addedReverse = 0;
       setContent((prev) => {
         const prevReverse = prev.reverseQuestions ?? [];
@@ -217,6 +263,7 @@ export function useUserContent(): UseUserContent {
           interviewQuestions: [...prev.interviewQuestions, ...interview],
           reverseQuestions: mergedReverse,
           flashcards: [...(prev.flashcards ?? []), ...incomingFlash],
+          portfolioCards: [...(prev.portfolioCards ?? []), ...incomingPortfolio],
         };
         void repository.saveUserContent(next);
         return next;
@@ -226,6 +273,7 @@ export function useUserContent(): UseUserContent {
         interview: interview.length,
         reverse: addedReverse,
         flashcard: incomingFlash.length,
+        portfolio: incomingPortfolio.length,
       };
     },
     [],
@@ -244,6 +292,9 @@ export function useUserContent(): UseUserContent {
     addFlashcard,
     updateFlashcard,
     removeFlashcard,
+    addPortfolioCard,
+    updatePortfolioCard,
+    removePortfolioCard,
     exportCode,
     importCode,
   };

--- a/term-board/src/types.ts
+++ b/term-board/src/types.ts
@@ -52,6 +52,7 @@ export type UserContent = {
   interviewQuestions: InterviewQuestion[]; // ユーザー作問の面接Q&A
   reverseQuestions?: string[]; // 逆質問（#425・任意フィールドで後方互換）
   flashcards?: Flashcard[]; // 暗記カード（#427・任意フィールドで後方互換）
+  portfolioCards?: PortfolioCard[]; // 成果物棚卸し（#456・任意フィールドで後方互換）
 };
 
 // F-CARD-01 拡張: ユーザー作問の軽量カード（distractors なし）。
@@ -62,6 +63,21 @@ export type Flashcard = {
   back: string; // 裏（意味・回答）
   category?: string; // 分野（任意）
   level?: "初級" | "中級" | "上級"; // 学習レベル（#444・未設定はフィルタで全レベル該当）
+  source?: "user" | "shared";
+};
+
+// #456: 成果物棚卸しテンプレ。面接で「何作りました？」「工夫した点は？」に
+// 答えるための素地を、本人が自分の言葉で言語化して保存する。
+// AI 自動生成は採用しない（ハルシネーションで本人がいない内容を話す事故を防ぐ）。
+export type PortfolioCard = {
+  id: string;
+  title: string; // 必須: 作ったもの（プロダクト名・概要）
+  problem: string; // 必須: 解決したい課題（誰の何を）
+  tech: string; // 必須: 使った技術（言語・FW・インフラ等）
+  effort: string; // 必須: 工夫した点（自分の判断や試行錯誤）
+  difficulty?: string; // 任意: 困った点と乗り越え方
+  retrospective?: string; // 任意: もう一度作るならどう変えるか
+  githubUrl?: string; // 任意: GitHub URL
   source?: "user" | "shared";
 };
 

--- a/term-board/src/utils/share.ts
+++ b/term-board/src/utils/share.ts
@@ -1,4 +1,4 @@
-import type { UserContent, Term, InterviewQuestion, Flashcard } from "../types";
+import type { UserContent, Term, InterviewQuestion, Flashcard, PortfolioCard } from "../types";
 
 // F-USER-02: 作問データを「共有コード」に変換／復元する（サーバー無しのピア共有）。
 // 共有コードは Discord 等に貼れる base64 文字列。Unicode を壊さず往復させる。
@@ -39,6 +39,7 @@ export function decodeShareCode(code: string): UserContent {
     interviewQuestions?: unknown;
     reverseQuestions?: unknown;
     flashcards?: unknown;
+    portfolioCards?: unknown;
   };
   const quizTerms = Array.isArray(o.quizTerms) ? (o.quizTerms as Term[]) : [];
   const interviewQuestions = Array.isArray(o.interviewQuestions)
@@ -55,13 +56,26 @@ export function decodeShareCode(code: string): UserContent {
           typeof f === "object" && f !== null && typeof f.front === "string" && typeof f.back === "string",
       )
     : [];
+  // PortfolioCard は必須4項目が全て文字列のものだけ受理（#456）。
+  const portfolioCards = Array.isArray(o.portfolioCards)
+    ? (o.portfolioCards as PortfolioCard[]).filter(
+        (p): p is PortfolioCard =>
+          typeof p === "object" &&
+          p !== null &&
+          typeof p.title === "string" &&
+          typeof p.problem === "string" &&
+          typeof p.tech === "string" &&
+          typeof p.effort === "string",
+      )
+    : [];
   if (
     quizTerms.length === 0 &&
     interviewQuestions.length === 0 &&
     reverseQuestions.length === 0 &&
-    flashcards.length === 0
+    flashcards.length === 0 &&
+    portfolioCards.length === 0
   ) {
     throw new Error("取り込める問題が含まれていません。");
   }
-  return { quizTerms, interviewQuestions, reverseQuestions, flashcards };
+  return { quizTerms, interviewQuestions, reverseQuestions, flashcards, portfolioCards };
 }


### PR DESCRIPTION
## 概要

第三者再評価で「面接『何作りました？』『工夫した点は？』の素地不足」と指摘された問題に対応。

**AI 自動生成は不採用**（ハルシネーション・コスト恒常発生・「手作り教材」軸との乖離で却下）。代替として **静的な記入式テンプレ** で同じ目的を達成します。

## 新規型と UI

### PortfolioCard 型

| フィールド | 必須/任意 | 内容 |
|---|---|---|
| title | 必須 | 作ったもの（プロダクト名・概要） |
| problem | 必須 | 解決したい課題（誰の何を） |
| tech | 必須 | 使った技術（言語・FW・インフラ等） |
| effort | 必須 | 工夫した点（自分の判断や試行錯誤） |
| difficulty | 任意 | 困った点と乗り越え方 |
| retrospective | 任意 | もう一度作るならどう変えるか |
| githubUrl | 任意 | GitHub URL |

### AuthorView「成果物」タブ

- 必須4項目はテキスト入力／テキストエリア
- 任意3項目は折りたたみで開いてから入力（圧迫感を減らす）
- 各項目にプレースホルダ例（"例：CORS エラーが解消できず..." 等）
- **冒頭ガイド**：「AI に書いてもらうのではなく、自分で書くことが面接で再現できる素地になります」

## 変更ファイル

- `src/types.ts` — `PortfolioCard` 型、`UserContent.portfolioCards` 追加
- `src/hooks/useUserContent.ts` — add/update/removePortfolioCard、EMPTY と importCode 拡張
- `src/utils/share.ts` — 共有コードに含め、必須4項目の型検査で受理
- `src/api/localStorageTermRepository.ts` — readUserContent でリハイドレーション
- `src/components/AuthorView.tsx` — 新タブ「成果物」追加、PortfolioForm 実装、SharePanel の件数表示更新

## 後方互換

- 既存ユーザーの localStorage は壊れない（`portfolioCards?` で任意フィールド）
- 旧共有コード（portfolioCards 無し）はそのまま取り込み可能

## 検証

- `npm run build` ✓
- `npm run test` ✓（4 files / 33 tests）

Closes #456