### PR TITLE
feat: Empty State / 404 / Error Boundary を整備（未完成感の除去）

### DIFF
--- a/review-board/frontend/src/App.jsx
+++ b/review-board/frontend/src/App.jsx
@@ -19,6 +19,7 @@ import ReviewsPage from './pages/ReviewsPage';
 import ProfilePage from './pages/ProfilePage';
 import NotificationsPage from './pages/NotificationsPage';
 import DashboardPage from './pages/DashboardPage';
+import NotFoundPage from './pages/NotFoundPage';
 
 // ページ（パス）が切り替わったらスクロール位置を先頭へ戻す。
 // React Router は既定でスクロールを復元しないため、長いページから遷移すると
@@ -66,6 +67,8 @@ export default function App() {
         <Route path="/notifications" element={<Shell><NotificationsPage /></Shell>} />
         {/* 運営ダッシュボード（講師/管理者専用・#275）。真の防御は backend 403。 */}
         <Route path="/dashboard" element={<Shell><DashboardPage /></Shell>} />
+        {/* 存在しないパスは 404 ページへ（ブラウザ既定の白画面を防ぐ）。 */}
+        <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </AuthProvider>
   );

--- a/review-board/frontend/src/components/EmptyState.jsx
+++ b/review-board/frontend/src/components/EmptyState.jsx
@@ -1,0 +1,39 @@
+import { Link } from 'react-router-dom';
+
+// リスト系ページが空のときに「未完成感」を出さないための共通コンポーネント。
+// 文字 1 行だけの empty 表示を、アイコン＋見出し＋説明＋次アクションの導線に置き換える。
+export default function EmptyState({
+  icon = '📭',
+  title,
+  description,
+  ctaLabel,
+  ctaHref,
+  ctaOnClick,
+}) {
+  return (
+    <div className="mx-auto flex max-w-md flex-col items-center px-4 py-16 text-center">
+      <div className="mb-4 text-5xl" aria-hidden="true">
+        {icon}
+      </div>
+      <h2 className="mb-2 text-lg font-semibold text-gray-700">{title}</h2>
+      {description && <p className="mb-5 text-sm text-gray-500">{description}</p>}
+      {ctaLabel && ctaHref && (
+        <Link
+          to={ctaHref}
+          className="rounded-xl bg-navy-700 px-4 py-2 text-sm font-semibold text-white shadow-mac-sm transition hover:bg-navy-700/90"
+        >
+          {ctaLabel}
+        </Link>
+      )}
+      {ctaLabel && !ctaHref && ctaOnClick && (
+        <button
+          type="button"
+          onClick={ctaOnClick}
+          className="rounded-xl bg-navy-700 px-4 py-2 text-sm font-semibold text-white shadow-mac-sm transition hover:bg-navy-700/90"
+        >
+          {ctaLabel}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/review-board/frontend/src/components/ErrorBoundary.jsx
+++ b/review-board/frontend/src/components/ErrorBoundary.jsx
@@ -1,0 +1,52 @@
+import { Component } from 'react';
+
+// 子ツリーで未捕捉の例外が出たときに白画面ではなく可読のフォールバックを描く。
+// main.jsx で <App /> をラップする。将来 Sentry 等の通知フックを onCatch に挟める。
+export default class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    // 将来：Sentry.captureException(error, { extra: info }) などへ差し替え。
+    console.error('[ErrorBoundary]', error, info);
+  }
+
+  handleReload = () => {
+    this.setState({ hasError: false });
+    if (typeof window !== 'undefined') {
+      window.location.reload();
+    }
+  };
+
+  render() {
+    if (!this.state.hasError) return this.props.children;
+    return (
+      <main className="flex min-h-screen items-center justify-center px-4">
+        <div className="mx-auto max-w-md text-center">
+          <div className="mb-4 text-5xl" aria-hidden="true">
+            ⚠️
+          </div>
+          <h1 className="mb-3 text-xl font-extrabold tracking-tight text-navy-700">
+            予期しないエラーが発生しました
+          </h1>
+          <p className="mb-6 text-sm text-gray-500">
+            一時的な問題の可能性があります。ページを再読み込みしてやり直してください。
+          </p>
+          <button
+            type="button"
+            onClick={this.handleReload}
+            className="rounded-xl bg-navy-700 px-5 py-2.5 text-sm font-semibold text-white shadow-mac-sm transition hover:bg-navy-700/90"
+          >
+            再読み込み
+          </button>
+        </div>
+      </main>
+    );
+  }
+}

--- a/review-board/frontend/src/components/WorksList.jsx
+++ b/review-board/frontend/src/components/WorksList.jsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import ReviewPrefBadges from './ReviewPrefBadges';
 import Avatar from './Avatar';
+import EmptyState from './EmptyState';
 
 // スクショ未登録カードのサムネ：id から決め打ちのグラデーション（装飾プレースホルダ）。
 // 実スクショ（post.screenshotUrl）がある投稿はそちらを優先表示する。
@@ -65,7 +66,13 @@ export default function WorksList({ posts, loading, error, applied, setFilter, o
         ) : error ? (
           <p className="py-16 text-center text-red-500">{error}</p>
         ) : posts.length === 0 ? (
-          <p className="py-16 text-center text-gray-400">該当する成果物がありません。</p>
+          <EmptyState
+            icon="📝"
+            title="まだ投稿がありません"
+            description="最初の投稿を作って、cohort のレビューを集めましょう。"
+            ctaLabel="最初の投稿を書く"
+            ctaHref="/posts/new"
+          />
         ) : (
           <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
             {posts.map((p) => (

--- a/review-board/frontend/src/main.jsx
+++ b/review-board/frontend/src/main.jsx
@@ -3,11 +3,14 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import App from './App.jsx';
+import ErrorBoundary from './components/ErrorBoundary';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <ErrorBoundary>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </ErrorBoundary>
   </StrictMode>,
 );

--- a/review-board/frontend/src/pages/InvitesPage.jsx
+++ b/review-board/frontend/src/pages/InvitesPage.jsx
@@ -3,6 +3,7 @@ import { createInvite, fetchInvites, revokeInvite } from '../api/invites';
 import { fetchMembers, disableMember, enableMember } from '../api/members';
 import { ROLE_LABEL } from '../constants';
 import Avatar from '../components/Avatar';
+import EmptyState from '../components/EmptyState';
 
 // 招待コード管理（講師/管理者・Issue #165）。発行→受講生に共有→失効まで。
 // 生コードは発行直後の 1 度しか表示できないため、発行時に共有リンクを目立たせる。
@@ -141,7 +142,11 @@ export default function InvitesPage() {
       {loading ? (
         <p className="py-8 text-center text-gray-400">読み込み中…</p>
       ) : invites.length === 0 ? (
-        <p className="py-8 text-center text-gray-400">まだ招待はありません。</p>
+        <EmptyState
+          icon="✉️"
+          title="まだ招待はありません"
+          description="招待コードを発行して、受講生を cohort に招きましょう。"
+        />
       ) : (
         <ul className="space-y-2">
           {invites.map((inv) => {

--- a/review-board/frontend/src/pages/NotFoundPage.jsx
+++ b/review-board/frontend/src/pages/NotFoundPage.jsx
@@ -1,0 +1,30 @@
+import { Link } from 'react-router-dom';
+import DolphinIcon from '../components/DolphinIcon';
+import { APP_NAME } from '../constants';
+
+// SPA の存在しないパスに到達したときの 404 ページ。
+// App.jsx の path="*" route で割り当て、ブラウザ既定の白画面を防ぐ。
+export default function NotFoundPage() {
+  return (
+    <main className="flex min-h-screen items-center justify-center px-4">
+      <div className="mx-auto max-w-md text-center">
+        <div className="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-[24px] bg-[#e8f3ff] shadow-mac ring-1 ring-black/5">
+          <DolphinIcon className="h-14 w-14" />
+        </div>
+        <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-gray-400">404</p>
+        <h1 className="mb-3 text-2xl font-extrabold tracking-tight text-navy-700">
+          ページが見つかりませんでした
+        </h1>
+        <p className="mb-6 text-sm text-gray-500">
+          お探しのページは移動または削除された可能性があります。
+        </p>
+        <Link
+          to="/"
+          className="inline-flex items-center justify-center rounded-xl bg-navy-700 px-5 py-2.5 text-sm font-semibold text-white shadow-mac-sm transition hover:bg-navy-700/90"
+        >
+          {APP_NAME} のトップへ
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/review-board/frontend/src/pages/NotificationsPage.jsx
+++ b/review-board/frontend/src/pages/NotificationsPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { fetchNotifications, markNotificationRead, markAllNotificationsRead } from '../api/notifications';
 import Avatar from '../components/Avatar';
+import EmptyState from '../components/EmptyState';
 
 // F-NOTIF-01 通知センター（S-03）。新着順に並べ、クリックで既読化＋該当投稿へ遷移。
 const MESSAGE = {
@@ -64,7 +65,11 @@ export default function NotificationsPage() {
       </div>
 
       {items.length === 0 ? (
-        <p className="text-gray-500">通知はまだありません。</p>
+        <EmptyState
+          icon="🔔"
+          title="通知はありません"
+          description="新しいレビューや返信が届くと、ここに表示されます。"
+        />
       ) : (
         <ul className="space-y-2">
           {items.map((n) => (

--- a/review-board/frontend/src/pages/ReviewsPage.jsx
+++ b/review-board/frontend/src/pages/ReviewsPage.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { fetchCohortReviews } from '../api/reviews';
 import MarkdownText from '../components/MarkdownText';
 import Avatar from '../components/Avatar';
+import EmptyState from '../components/EmptyState';
 
 // 投稿日の簡易フォーマット（YYYY/MM/DD）。
 const fmtDate = (iso) => {
@@ -39,7 +40,13 @@ export default function ReviewsPage() {
         ) : error ? (
           <p className="py-16 text-center text-red-500">{error}</p>
         ) : reviews.length === 0 ? (
-          <p className="py-16 text-center text-gray-400">まだレビューがありません。</p>
+          <EmptyState
+            icon="💬"
+            title="まだレビューがありません"
+            description="他の人の投稿を見て、最初のレビューを書いてみましょう。"
+            ctaLabel="他の人の投稿を見る"
+            ctaHref="/"
+          />
         ) : (
           <ul className="space-y-4">
             {reviews.map((r) => (


### PR DESCRIPTION
## 関連 Issue

Closes #476

---

## 変更の概要

リスト系の空表示・存在しないルート・実行時例外がブラウザ既定のままだと「未完成感」が出るため、3 種類のフォールバックを整える。引き継ぎ書 #2 に対応。

### 新規ファイル

| ファイル | 役割 |
|---|---|
| [components/EmptyState.jsx](review-board/frontend/src/components/EmptyState.jsx) | icon / title / description / CTA(href\|onClick) を取る共通 Empty 表示 |
| [pages/NotFoundPage.jsx](review-board/frontend/src/pages/NotFoundPage.jsx) | SPA の存在しないパス用 404 ページ（DolphinIcon + 404 ラベル + トップ導線） |
| [components/ErrorBoundary.jsx](review-board/frontend/src/components/ErrorBoundary.jsx) | 未捕捉例外の白画面化を防ぐクラスコンポーネント（再読み込みボタン + 将来の Sentry フック） |

### 適用箇所

| 場所 | 変更 |
|---|---|
| `App.jsx` | `Route path="*" element={<NotFoundPage />}` を追加 |
| `main.jsx` | `<App />` を `<ErrorBoundary>` でラップ |
| `WorksList.jsx`（PostsPage 内 WORKS / WorksPage の本体） | 空時 → EmptyState（📝・「最初の投稿を書く」CTA → `/posts/new`） |
| `ReviewsPage.jsx` | 空時 → EmptyState（💬・「他の人の投稿を見る」CTA → `/`） |
| `NotificationsPage.jsx` | 空時 → EmptyState（🔔・CTA なし） |
| `InvitesPage.jsx` | 空時 → EmptyState（✉️・CTA なし。発行フォームが既に上部にあるため CTA 重複回避） |

## 変更の種別

- [x] feat（新機能の追加）

## 動作確認チェックリスト

- [x] `npm run lint` → 既存 warning 1 件のみ（AuthContext の react-refresh、無関係）
- [x] `npm run build` → 既存と同じ成果物で成功
- [x] PostsPage 内 WORKS が EmptyState の場合、CTA「最初の投稿を書く」が表示される
- [x] `/no-such-path` で NotFoundPage が描画される
- [x] ErrorBoundary が未捕捉例外をキャッチし「再読み込み」ボタンを出す

## レビュー時に特に確認してほしい点

- 引き継ぎ書は「PostsPage」「WorksPage」を別々に書いていますが、実装上は **両ページとも `WorksList.jsx` を介して** 一覧を出しているため、`WorksList.jsx` 1 箇所の変更で両ページの empty が改善されます
- ProfilePage の「まだ投稿がありません」（line 78）は user の投稿が 0 件の場合に出る別表示で、本 PR スコープ外。必要なら follow-up で追加
- ErrorBoundary は本番 Sentry 連携を見据えて `componentDidCatch` に `console.error` を残しています（PR コメントで Sentry 連携を別 Issue 化する想定）