### PR TITLE
feat(infra): CloudWatch アラーム 5 種 + SNS メール通知配線（設計と実装の乖離を解消）

### DIFF
--- a/review-board/docs/ログ・監視・障害対応設計書.md
+++ b/review-board/docs/ログ・監視・障害対応設計書.md
@@ -139,6 +139,24 @@ task-board `docs/incidents/` の運用を継承する。**新しい異常に直�
 
 ---
 
+## 7-1. 実装対応表（CloudWatch アラーム × 設計上のシグナル）
+
+Issue #480 / PR で `infra/cloudwatch.tf` と `infra/sns.tf` を整備し、設計と実装の対応を 1 対 1 で明示する。通知先は既存 `var.budget_notify_email`（Budgets と同じ宛先＝運用宛先の単一化）。
+
+| # | 設計シグナル（§5 アラート） | 実装した CloudWatch alarm | メトリクス | 閾値 | 評価期間 |
+|---|---|---|---|---|---|
+| 1 | サービス断（インスタンス障害） | `${name_prefix}-ec2-status-check-failed` | `AWS/EC2 StatusCheckFailed` | > 0 | 1 期間 / 300s |
+| 2 | アプリ過負荷（CPU 飽和） | `${name_prefix}-ec2-cpu-high` | `AWS/EC2 CPUUtilization` | ≥ 80% | 3 期間 / 300s |
+| 3 | DB 過負荷 | `${name_prefix}-rds-cpu-high` | `AWS/RDS CPUUtilization` | ≥ 80% | 3 期間 / 300s |
+| 4 | DB 容量枯渇 | `${name_prefix}-rds-free-storage-low` | `AWS/RDS FreeStorageSpace` | < 1 GB | 1 期間 / 300s |
+| 5 | DB コネクション枯渇予兆 | `${name_prefix}-rds-connections-high` | `AWS/RDS DatabaseConnections` | ≥ 64（t3.micro max ≈ 80 の 80%） | 3 期間 / 300s |
+
+通知先は SNS トピック `${name_prefix}-alerts`（[infra/sns.tf](../infra/sns.tf)）。将来 Slack / PagerDuty を追加する場合は subscription を増やすだけで、各 alarm の `alarm_actions` は不変（`output "alerts_topic_arn"` で公開済み）。
+
+> 引き継ぎ書 #6 の「ALB 5xx」「ECS 健全性」は本構成（EC2 単体・ALB/ECS 無し）にそぐわないため、EC2/RDS 寄りに置換した。冗長化フェーズで ALB / ECS / Auto Scaling を導入する際に「ALB 5xx 率」「ターゲット健全数」「タスク running < desired」を追加する。
+
+---
+
 ## 8. 関連ドキュメント
 
 - [要件定義書.md](./要件定義書.md) §2-2（本実装移行時の再検討）・§4（非機能）

--- a/review-board/infra/cloudwatch.tf
+++ b/review-board/infra/cloudwatch.tf
@@ -1,0 +1,116 @@
+# =====================================================================
+# cloudwatch.tf — 障害検知用 CloudWatch アラーム（EC2 + RDS）
+# =====================================================================
+# Issue #480 / 引き継ぎ書 #6：設計書（ログ・監視・障害対応設計書.md）と
+# 実装の乖離を埋める。本構成は EC2 単体（ALB / ECS 無し）であり、引き継ぎ書の
+# 「ALB 5xx」「ECS 健全性」を EC2/RDS 寄りに置換した 5 アラームを定義する。
+# 通知先は sns.tf の aws_sns_topic.alerts（購読は budget_notify_email）。
+# =====================================================================
+
+# --- EC2: インスタンス自体の障害（ハイパーバイザ／ネット）---
+# StatusCheckFailed は 0/1 で出るので「1 期間中に 1 度でも 1」を異常とする。
+resource "aws_cloudwatch_metric_alarm" "ec2_status_check_failed" {
+  alarm_name          = "${local.name_prefix}-ec2-status-check-failed"
+  alarm_description   = "EC2 インスタンスのステータスチェックが失敗した（ハードウェア／ネット障害）。"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "StatusCheckFailed"
+  namespace           = "AWS/EC2"
+  period              = 300
+  statistic           = "Maximum"
+  threshold           = 0
+  treat_missing_data  = "breaching"
+
+  dimensions = {
+    InstanceId = aws_instance.app.id
+  }
+
+  alarm_actions = [aws_sns_topic.alerts.arn]
+  ok_actions    = [aws_sns_topic.alerts.arn]
+}
+
+# --- EC2: 過負荷の早期検知 ---
+resource "aws_cloudwatch_metric_alarm" "ec2_cpu_high" {
+  alarm_name          = "${local.name_prefix}-ec2-cpu-high"
+  alarm_description   = "EC2 の CPU 使用率が 80% を超過（3 期間連続）。"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 3
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    InstanceId = aws_instance.app.id
+  }
+
+  alarm_actions = [aws_sns_topic.alerts.arn]
+  ok_actions    = [aws_sns_topic.alerts.arn]
+}
+
+# --- RDS: 過負荷の早期検知 ---
+resource "aws_cloudwatch_metric_alarm" "rds_cpu_high" {
+  alarm_name          = "${local.name_prefix}-rds-cpu-high"
+  alarm_description   = "RDS の CPU 使用率が 80% を超過（3 期間連続）。"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 3
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DBInstanceIdentifier = aws_db_instance.main.id
+  }
+
+  alarm_actions = [aws_sns_topic.alerts.arn]
+  ok_actions    = [aws_sns_topic.alerts.arn]
+}
+
+# --- RDS: 残ストレージ枯渇 ---
+# 単位は Byte。1 GB = 1,073,741,824。
+resource "aws_cloudwatch_metric_alarm" "rds_free_storage_low" {
+  alarm_name          = "${local.name_prefix}-rds-free-storage-low"
+  alarm_description   = "RDS の空きストレージが 1GB を下回った（無料枠 20GB の 5% 相当）。"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "FreeStorageSpace"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Minimum"
+  threshold           = 1073741824
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DBInstanceIdentifier = aws_db_instance.main.id
+  }
+
+  alarm_actions = [aws_sns_topic.alerts.arn]
+  ok_actions    = [aws_sns_topic.alerts.arn]
+}
+
+# --- RDS: 接続数の枯渇予兆 ---
+# t3.micro の max_connections は ~80。80% = 64 を閾値にする（インスタンス変更時は要見直し）。
+resource "aws_cloudwatch_metric_alarm" "rds_connections_high" {
+  alarm_name          = "${local.name_prefix}-rds-connections-high"
+  alarm_description   = "RDS の接続数が max_connections の 80% を継続超過（プールリークの可能性）。"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 3
+  metric_name         = "DatabaseConnections"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 64
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DBInstanceIdentifier = aws_db_instance.main.id
+  }
+
+  alarm_actions = [aws_sns_topic.alerts.arn]
+  ok_actions    = [aws_sns_topic.alerts.arn]
+}

--- a/review-board/infra/outputs.tf
+++ b/review-board/infra/outputs.tf
@@ -54,3 +54,9 @@ output "cd_aws_secret_access_key" {
   value       = aws_iam_access_key.github_actions_cd.secret
   sensitive   = true
 }
+
+# --- CloudWatch アラート通知用 SNS トピック ARN（将来の Lambda / Slack 連携用・#480）---
+output "alerts_topic_arn" {
+  description = "CloudWatch アラート通知 SNS トピック ARN（Slack / PagerDuty 連携時の接続先）"
+  value       = aws_sns_topic.alerts.arn
+}

--- a/review-board/infra/sns.tf
+++ b/review-board/infra/sns.tf
@@ -1,0 +1,24 @@
+# =====================================================================
+# sns.tf — CloudWatch アラーム通知トピック
+# =====================================================================
+# Issue #480 / 引き継ぎ書 #6：cloudwatch.tf の alarm_actions の宛先。
+# 購読先は Budgets と同じ `var.budget_notify_email`（運用宛先の単一化）。
+# 将来 Lambda 経由 Slack や PagerDuty 連携に差し替えるとき、
+# 各 alarm の alarm_actions は触らず、購読側だけ追加できる構造。
+# =====================================================================
+
+# tfsec:ignore:aws-sns-enable-topic-encryption トピックは平文の通知メタのみ・KMS は本格運用フェーズで追加
+resource "aws_sns_topic" "alerts" {
+  name = "${local.name_prefix}-alerts"
+
+  tags = {
+    Name    = "${local.name_prefix}-alerts"
+    Purpose = "CloudWatch alerts → email"
+  }
+}
+
+resource "aws_sns_topic_subscription" "alerts_email" {
+  topic_arn = aws_sns_topic.alerts.arn
+  protocol  = "email"
+  endpoint  = var.budget_notify_email
+}


### PR DESCRIPTION
## 関連 Issue

Closes #480

---

## 変更の概要

設計書（ログ・監視・障害対応設計書.md §5）と実装の乖離を解消する。引き継ぎ書 #6 に対応。本構成は **EC2 単体 + RDS（ALB / ECS 無し）**のため、引き継ぎ書の「ALB 5xx」「ECS 健全性」は EC2/RDS 寄りに置換した。

### 新規ファイル

#### `infra/cloudwatch.tf`（5 アラーム）

| # | alarm | メトリクス | 閾値 | 評価期間 | 目的 |
|---|---|---|---|---|---|
| 1 | `…-ec2-status-check-failed` | `AWS/EC2 StatusCheckFailed` | > 0 | 1 期間 / 300s | インスタンス障害自動検知 |
| 2 | `…-ec2-cpu-high` | `AWS/EC2 CPUUtilization` | ≥ 80% | 3 期間 / 300s | アプリ過負荷の早期検知 |
| 3 | `…-rds-cpu-high` | `AWS/RDS CPUUtilization` | ≥ 80% | 3 期間 / 300s | DB 過負荷の早期検知 |
| 4 | `…-rds-free-storage-low` | `AWS/RDS FreeStorageSpace` | < 1 GB | 1 期間 / 300s | DB 容量枯渇 |
| 5 | `…-rds-connections-high` | `AWS/RDS DatabaseConnections` | ≥ 64 | 3 期間 / 300s | プールリーク予兆 |

#### `infra/sns.tf`

- `aws_sns_topic.alerts` + `aws_sns_topic_subscription.alerts_email`
- 購読先：既存 `var.budget_notify_email`（Budgets と同じ宛先＝運用宛先の単一化）

### 追記

- `infra/outputs.tf` に `alerts_topic_arn`（将来の Slack / PagerDuty 連携用）
- [docs/ログ・監視・障害対応設計書.md](review-board/docs/ログ・監視・障害対応設計書.md) §7-1 に **実装対応表**（設計シグナル × 実装した alarm の 1 対 1 表）

## 変更の種別

- [x] feat（インフラ）
- [x] docs（設計対応表）

## 動作確認チェックリスト

- [x] `terraform fmt -check` → PASS（差分なし）
- [x] `terraform validate` → `Success! The configuration is valid.`
- [ ] `terraform plan` → **5 alarm + 1 SNS topic + 1 subscription = 7 add** （apply は人間が外部 Terminal）

## レビュー時に特に確認してほしい点

- RDS の `DatabaseConnections` 閾値 `64` は **t3.micro の max_connections ≈ 80 の 80%** で固定。db_instance_class を変える際は `var.db_max_connections` を新設して計算式化する余地があります（本 PR ではスコープ外）
- alarm の `ok_actions` も `aws_sns_topic.alerts` に向けています（復旧通知も同じメール）。ノイズが気になる場合は subscription 側に SNS filter policy を追加する想定
- 引き継ぎ書 #6 の「アラーム発火テスト」は apply 後のフォローアップ。本 PR は IaC + 設計対応表まで