### PR TITLE
docs: 品質判定表 N/A → A 化（マージ済 PR の達成を反映）

### DIFF
--- a/review-board/docs/品質判定表.md
+++ b/review-board/docs/品質判定表.md
@@ -9,7 +9,7 @@
 > - **N/A**：SHOULD で未実施。品質低下は起きないが将来リスクとして残す（理由を記す）。
 > - **対象外（簡素化）**：学習スコープで現フェーズ対象外。簡素化の事実・理由・本実装時の論点を記す（要件 §2-2）。
 >
-> **判定時点：2026-05-23 / Phase 1（バックエンド MVP）。フロントエンド・AWS デプロイは未実装。**
+> **判定時点：2026-05-29 / Phase 3（AWS デプロイ稼働中）。バックエンド・フロントエンド・AWS デプロイ実装済。**
 
 ---
 
@@ -22,7 +22,7 @@
 | 保守性・拡張性 | **MUST 全達成**（CI 常設＝M-6 A・実ブラウザ検証＝M-13 A） | SHOULD の一部が N/A |
 | 性能・UX | **MUST 全達成**（P-9 a11y を #202 で Lighthouse 監査・A 化） | P-1 目標値定義＋実測済。P-2/P-3/P-5 も達成 |
 
-> **正直な現状認識（2026-05-25 更新）**：重点軸（セキュリティ）は MUST 全達成で S 基準も満たし **S を名乗れる**。保守性は CI・実ブラウザ検証で MUST 全達成。性能/UX は P-1 を #127 で定義・実測し、**P-9 a11y を #202 で Lighthouse 実機監査して A 化**（ログイン/投稿フォーム 100・ラベル関連付け/main/リンク名を修正）→ MUST 全達成。安定性は **S-2 を #189 で本番デプロイし稼働実証**（AWS 36/36・自己署名HTTPS・§8-2 認可マトリクス/合格バッジ/S3画像 全 pass・CD 自動化実証）。**→ 純粋な未達 MUST（P-9）は解消。S-2 の『未デプロイ』ブロッカーも解消した。** ただし S-2 が指す**冗長化（Multi-AZ/ALB）は無料枠で意図的に Single-AZ＝対象外（簡素化）**のままで、これを有効化して初めて S-2 を A と呼べる。よって「全軸ベースライン以上床」とは**まだ宣言しない**（残＝冗長化の有効化・正規ドメイン＋Let's Encrypt・装飾 AppShot の実スクショ差し替え〔aria-hidden 済で実害なし〕）。本表は実装進捗に応じて更新する（生きた文書）。
+> **正直な現状認識（2026-05-29 更新）**：重点軸（セキュリティ）は MUST 全達成で S 基準も満たし **S を名乗れる**。保守性は CI（lint→test→build・Issue #484 / PR #486 で **FE unit カバレッジ閾値 + CI 組込** を整備）と実ブラウザ検証（E2E smoke 11 本）で **MUST 全達成・M-9 も A 化**。性能/UX は P-1 を #127 で定義・実測し、P-9 a11y を #202 で Lighthouse 監査して A 化、P-7 を #266 で **pg_trgm GIN 索引** 投入し A 化 → MUST 全達成。SEC は **SEC-12（#228 レートリミット）と SEC-13（#226 セキュリティヘッダ）も A 化**で SHOULD まで概ね埋まった。安定性は **S-2 を #189 で本番デプロイし稼働実証**（AWS 36/36・自己署名 HTTPS・§8-2 認可マトリクス / 合格バッジ / S3 画像 全 pass・CD 自動化実証）。**横断 §3-1 も Issue #480 / PR #481 で CloudWatch 5 アラーム + SNS 通知配線（IaC 完備・設計書 §7-1 実装対応表）を整え完全 A 化**。**→ 純粋な未達 MUST は無し**。残るは **S-2 の冗長化（Multi-AZ/ALB）が無料枠で意図的に Single-AZ＝対象外（簡素化）** のみで、これを有効化して初めて S-2 を A と呼べる。よって「全軸ベースライン以上床」とは**まだ宣言しない**（残＝冗長化の有効化・正規ドメイン＋Let's Encrypt の apply 実行）。本表は実装進捗に応じて更新する（生きた文書）。
 
 ---
 
@@ -56,8 +56,8 @@
 | SEC-9 機密は env 駆動・平文禁止 | MUST | A | JWT secret／DB／seed すべて env・fail-fast。平文ハードコードなし（機密スキャン済） |
 | SEC-10 DTO で Entity を直接出さない | SHOULD | A | 全レスポンスは `*Response` DTO（UserResponse/PostResponse/ReviewResponse/…） |
 | SEC-11 CORS は自オリジンのみ | MUST | A | `CorsConfig` が単一オリジン（env `CORS_ALLOWED_ORIGIN`＝localhost:5175）のみ許可 |
-| SEC-12 危険操作にレートリミット | SHOULD | N/A | 未実装。ログイン試行のレート制限は本実装時に検討（脅威モデリング §7） |
-| SEC-13 セキュリティヘッダ | SHOULD | N/A | CSP/HSTS/X-Frame-Options 未付与。本番 HTTPS 終端時に付与 |
+| SEC-12 危険操作にレートリミット | SHOULD | A | **#228 で実装**。`RateLimitFilter`（OncePerRequestFilter・@Order=HIGHEST_PRECEDENCE）が `/api/auth/{login,register,refresh}` に IP 単位上限（login 20 / register 10 / refresh 60・窓 60s）。超過で 429 + Retry-After。`/api/auth/password-reset/request` も #232 で対象化（5/分）。#268 で **Postgres 共有ストア化**（V23 `rate_limit_buckets`）し多インスタンスでも安全 |
+| SEC-13 セキュリティヘッダ | SHOULD | A | **#226 で実装**。`SecurityConfig.headers` に HSTS（1 年）/ Referrer-Policy / Permissions-Policy を無条件付与。nginx vhost にも CSP/HSTS/X-Frame-Options/nosniff/Referrer/Permissions を付与。`SecurityHeadersIntegrationTest` で回帰。**nginx HSTS は #244 の正規 TLS（DuckDNS + Let's Encrypt）切替で実効化** |
 
 ### 1-3. 保守性・拡張性
 
@@ -71,7 +71,7 @@
 | M-6 CI は Fail Fast（lint→build→test） | MUST | A | backend CI（#108・build→test／Testcontainers）＋frontend CI（#114・lint→build）＋依存脆弱性スキャン（Trivy）の3本を常設。すべて Fail Fast・paths で review-board 配下に限定 |
 | M-7 テストピラミッド | MUST | A | 結合テスト（Testcontainers）中心。ロジックが単純なため単体は最小限 |
 | M-8 テスト状態分離 | MUST | A | Testcontainers で本番同等 DB・`AbstractIntegrationTest` が毎回 FK 順クリーンアップ |
-| M-9 カバレッジ目安＋境界値 | SHOULD | N/A | JaCoCo はレポートのみ（ゲートなし・テスト計画書 §5）。認可の境界（ロール×所有者×cohort）は網羅 |
+| M-9 カバレッジ目安＋境界値 | SHOULD | A | **#252 で backend JaCoCo ゲート**（INSTRUCTION ≥ 0.75 / BRANCH ≥ 0.50）を `jacocoTestCoverageVerification` で CI に組込。**#486 で frontend Vitest カバレッジ閾値**（lines 75 / branches 65 / functions 50 / statements 75）を `vite.config.js` に追加し `review-board-frontend-ci.yml` の `Unit Test + Coverage` ステップで守る。認可の境界（ロール×所有者×cohort）も `*AuthorizationIntegrationTest` で網羅 |
 | M-10 flaky 対策（条件待ち） | SHOULD | A | 固定 sleep なし（MockMvc 同期実行） |
 | M-11 抽象化で交換可能 | SHOULD | N/A | S3/MinIO は AWS SDK 直利用。抽象化層は本実装時に検討 |
 | M-12 AI レビューは補完＋型 | MUST | A | `claude-code-review.yml`＋Java の静的型 |
@@ -89,7 +89,7 @@
 | P-4 しおり集計 | SHOULD | N/A | 未読等の機能なし |
 | P-5 キャッシュ規律 | MUST | A | キャッシュ未使用（認可情報をキャッシュしない＝規律遵守） |
 | P-6 コネクションプール | MUST | A | HikariCP 既定。常時接続なし |
-| P-7 検索の段階最適化 | SHOULD | N/A | 検索は Phase2 |
+| P-7 検索の段階最適化 | SHOULD | A | **#266 で実装**。migration V22 で `CREATE EXTENSION pg_trgm` + `posts(lower(title))` / `posts(lower(description))` の **GIN 索引（gin_trgm_ops）**を投入。クエリ不変（既存 ILIKE が planner で索引活用）、挙動不変＝既存検索テストで非回帰。tsvector('simple') は日本語の部分一致に弱く不採用。RDS pg16 で本番反映済 |
 | P-8 楽観的UI更新 | SHOULD | N/A | フロント実装済だが楽観更新は未採用（再取得方式）。SHOULD のため品質低下は起きない。フロント深掘り時に検討 |
 | P-9 アクセシビリティ WCAG A | MUST | A | #183 コントラストAA/select-name＋#202 で Lighthouse 実機監査（ログイン/投稿フォーム **100**）。フォームラベル `htmlFor` 関連付け・`<main>` landmark・プロフィールリンク `aria-label` を修正。残：一覧の装飾 `AppShot`（aria-hidden 済＝SR 実害なし）の contrast は実スクショ差し替えで解消予定 |
 | P-10 画像は外部ストレージ | SHOULD | A | `screenshot_key` で外部参照（MinIO/S3）。バイナリを DB に保存しない設計 |
@@ -103,7 +103,7 @@
 
 | 横断要件 | 判定 | 根拠・備考 |
 |---|---|---|
-| §3-1 ログ・監視・オブザーバビリティ | **A**（自動アラートのみ Phase3） | 監査ログ（誰が・何を）は audit_logs で **A**。構造化ログ/MDC（requestId/userId）・Micrometer 4ゴールデンシグナル（`/actuator/prometheus`・運用ロール限定）を **#121 で実装済＝A**。閾値超の自動アラート連携のみ Phase3（AWS）で追加 |
+| §3-1 ログ・監視・オブザーバビリティ | **完全 A** | 監査ログ（誰が・何を）は audit_logs で **A**（#248 で hash-chain 改ざん検知も追加）。構造化ログ/MDC（requestId/userId）・Micrometer 4ゴールデンシグナル（`/actuator/prometheus`・運用ロール限定）を #121 で **A**。**#481 で CloudWatch アラーム 5 種（EC2 status-check / EC2 CPU / RDS CPU / RDS FreeStorageSpace / RDS DatabaseConnections）+ SNS メール通知配線（IaC 完備・terraform validate PASS）を整備**し、[ログ・監視・障害対応設計書.md §7-1](./ログ・監視・障害対応設計書.md) に **実装対応表**（設計シグナル × CloudWatch alarm の 1 対 1）を追加。**閾値超の自動アラート連携も IaC で完備**＝設計と実装の乖離解消 |
 | §3-2 設定・機密の外部化 | A | JWT secret/DB/seed すべて env 駆動・fail-fast・平文ハードコードなし（SEC-9 と一致） |
 | §3-3 エラーハンドリング標準 | A | `GlobalExceptionHandler` で一元化（401/403/404/400・silent catch なし） |
 | §3-4 リリース・運用フロー（誤操作多層防御） | A | Issue→PR→squash・main 保護・CI（build/test・依存スキャン・lint）。CLAUDE.md §12 の多層防御を継承 |
@@ -131,11 +131,12 @@
 
 | 項目 | 要件 | 対応フェーズ |
 |---|---|---|
-| 冗長化・ゼロダウンタイム | S-2/S-7 | 本番デプロイは #189 で実証済。冗長化（Multi-AZ/ALB）有効化は本格運用フェーズ（無料枠脱却時） |
-| 正規ドメイン＋Let's Encrypt | （運用） | 現状は自己署名 HTTPS。外部レジストラでドメイン取得後 `certbot` で差し替え |
-| 装飾 AppShot を実スクショに | （磨き込み） | 一覧サムネを `post.screenshotUrl` の実画像へ。aria-hidden 済で a11y 実害なし |
+| 冗長化（Multi-AZ / ALB） | S-2 | 本番デプロイは #189 で実証済。冗長化有効化は本格運用フェーズ（無料枠脱却時）＝**意図的に Single-AZ** |
+| 正規ドメイン＋Let's Encrypt | （運用） | **PR #244 で DuckDNS + certbot の IaC 完備**（provision.sh DOMAIN モード・[docs/正規TLS手順（DuckDNS＋LetsEncrypt）.md](./正規TLS手順（DuckDNS＋LetsEncrypt）.md)）。**残＝実行（人間が外部 Terminal で 30 分手順）** |
+| CloudWatch アラート apply | （運用） | **PR #481 で 5 alarm + SNS の IaC 完備**（[docs/ログ・監視・障害対応設計書.md §7-1](./ログ・監視・障害対応設計書.md)）。**残＝terraform apply + 発火テスト**（人間が外部 Terminal） |
+| FE unit カバレッジ目標 | M-9 | **PR #486 で床（lines 75 / branches 65 / functions 50 / statements 75）+ CI 組込済**。**残＝四半期で 5% 引き上げ・計測対象を `pages/` 全体に拡大** |
 
-> **済**：M-6（CI Fail Fast）＝常設で A。M-13（実ブラウザ検証）＝通し e2e で A。P-1（性能目標値）＝#127 で定義・実測で A。S-3（再計算バッチ）＝#129 で実装で A。**P-9（a11y WCAG）＝#202 で Lighthouse 監査・A。S-2（本番デプロイ）＝#189 で稼働実証**（冗長化のみ意図的に Single-AZ＝対象外）。
+> **済**：M-6（CI Fail Fast）＝常設で A。**M-9（カバレッジゲート）＝#252/#486 で backend/frontend 両方の閾値を CI 守りで A**。M-13（実ブラウザ検証）＝通し e2e + smoke 11 本（#479 含む）で A。P-1（性能目標値）＝#127 で定義・実測で A。S-3（再計算バッチ）＝#129 で実装で A。P-9（a11y WCAG）＝#202 で Lighthouse 監査・A。S-2（本番デプロイ）＝#189 で稼働実証（冗長化のみ意図的に Single-AZ＝対象外）。**SEC-12（#228 レートリミット）/ SEC-13（#226 セキュリティヘッダ）/ P-7（#266 pg_trgm GIN）/ §3-1（#481 CloudWatch + SNS）すべて A 化**。**装飾 AppShot は #206 で削除済＝解消**（実スクショは demo_url + 自動サムネ #218 / #219 で実画像表示・本セッションで dev DB に 22 投稿でサムネ生成実証）。
 
 ---
 


### PR DESCRIPTION
## 関連 Issue

Closes #488

---

## 変更の概要

引き継ぎ書 #4 に対応。実装が進んだ項目を **N/A → A** に書き換え、自己採点と実装の乖離を解消する。これにより品質判定表が「絵に描いた餅」から「実装の進捗計器」に格上げされる（review-board の最大の競争優位）。

### A 化した項目

| 要件 ID | 現判定 | 達成 PR | 新判定 |
|---|---|---|---|
| SEC-12 危険操作にレートリミット | N/A | #228 + #268 | **A** |
| SEC-13 セキュリティヘッダ | N/A | #226 | **A** |
| M-9 カバレッジ目安＋境界値 | N/A | #252 (backend JaCoCo) + #486 (frontend Vitest) | **A** |
| P-7 検索の段階最適化 | N/A | #266 (pg_trgm GIN) | **A** |
| §3-1 横断（自動アラート連携） | A（Phase3 残） | #481 (CloudWatch + SNS IaC) | **完全 A** |

### 残課題セクションの更新

- 装飾 AppShot → #206 で削除済として「解消」表記
- 正規ドメイン + Let's Encrypt → PR #244 で IaC 完備・実行待ちに改訂
- CloudWatch アラート apply → PR #481 で IaC 完備・apply 待ちに改訂
- 冗長化 Multi-AZ → 意図的 Single-AZ で据え置き（変更なし）

### 総括の更新

「正直な現状認識」を **2026-05-29 時点** に更新し、純粋な未達 MUST が無いことを明記。S-2 の冗長化（Multi-AZ/ALB）が無料枠で意図的に Single-AZ である点だけが残課題。

## 変更の種別

- [x] docs（ドキュメントのみの変更）

## 動作確認チェックリスト

- [x] 全行の判定列が PR 番号と実装ファイルパスで根拠付け済み
- [x] 残課題リストにマージ済 PR を反映（IaC 完備・実行待ち の状態を明示）
- [x] 総括が現実と整合（判定時点 2026-05-29 / Phase 3）

## レビュー時に特に確認してほしい点

- 「§3-1 完全 A」とした根拠は **CloudWatch alarm の terraform validate PASS まで** で、`terraform apply` 実行はまだです。引き継ぎ書 #6 が「IaC + 設計対応表まで」をスコープとしているため、IaC 完備で完全 A と判定しました（apply 実行 → 発火テストは別 follow-up）
- 引き継ぎ書 #4 の「P-2 cursor ページネーション」は **既に Slice + cohort_created index で実装済（P-2: A）** のため対象外。新たに実装が必要な N/A 項目は本 PR では無し