### PR TITLE
feat: P9 アクセシビリティ強化（aria-current / aria-live / role=alert）

### DIFF
--- a/review-board/docs/品質判定表.md
+++ b/review-board/docs/品質判定表.md
@@ -91,7 +91,7 @@
 | P-6 コネクションプール | MUST | A | HikariCP 既定。常時接続なし |
 | P-7 検索の段階最適化 | SHOULD | A | **#266 で実装**。migration V22 で `CREATE EXTENSION pg_trgm` + `posts(lower(title))` / `posts(lower(description))` の **GIN 索引（gin_trgm_ops）**を投入。クエリ不変（既存 ILIKE が planner で索引活用）、挙動不変＝既存検索テストで非回帰。tsvector('simple') は日本語の部分一致に弱く不採用。RDS pg16 で本番反映済 |
 | P-8 楽観的UI更新 | SHOULD | N/A | フロント実装済だが楽観更新は未採用（再取得方式）。SHOULD のため品質低下は起きない。フロント深掘り時に検討 |
-| P-9 アクセシビリティ WCAG A | MUST | A | #183 コントラストAA/select-name＋#202 で Lighthouse 実機監査（ログイン/投稿フォーム **100**）。フォームラベル `htmlFor` 関連付け・`<main>` landmark・プロフィールリンク `aria-label` を修正。残：一覧の装飾 `AppShot`（aria-hidden 済＝SR 実害なし）の contrast は実スクショ差し替えで解消予定 |
+| P-9 アクセシビリティ WCAG A | MUST | A | #183 コントラストAA/select-name＋#202 で Lighthouse 実機監査（ログイン/投稿フォーム **100**）。フォームラベル `htmlFor` 関連付け・`<main>` landmark・プロフィールリンク `aria-label` を修正。**#490 で Header ナビ `NavLink` 化（aria-current=page）＋ 通知一覧 `role=region aria-live=polite` ＋ 9 箇所のフォームエラー `role=alert` を追加（見た目変化ゼロ・実機 Chrome で aria-current 動作確認済）**。残：一覧の装飾 `AppShot`（aria-hidden 済＝SR 実害なし）の contrast は実スクショ差し替えで解消予定 |
 | P-10 画像は外部ストレージ | SHOULD | A | `screenshot_key` で外部参照（MinIO/S3）。バイナリを DB に保存しない設計 |
 
 ---

--- a/review-board/frontend/src/components/EvaluationPanel.jsx
+++ b/review-board/frontend/src/components/EvaluationPanel.jsx
@@ -42,7 +42,7 @@ export default function EvaluationPanel({ postId, evaluation, isTeacher, onEvalu
 
       {isTeacher && (
         <form onSubmit={submit} className="border-t border-black/5 pt-3">
-          {error && <p className="mb-2 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+          {error && <p role="alert" className="mb-2 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
           <div className="mb-2 flex gap-4 text-sm">
             {['APPROVED', 'RETURNED'].map((r) => (
               <label key={r} className="flex items-center gap-1">

--- a/review-board/frontend/src/components/Header.jsx
+++ b/review-board/frontend/src/components/Header.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { fetchUnreadCount } from '../api/notifications';
 import Avatar from './Avatar';
@@ -57,21 +57,21 @@ export default function Header() {
               />
               <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">🔍</span>
             </form>
-            <Link to="/posts/new" className="hidden shrink-0 whitespace-nowrap rounded-lg bg-wrblue-500 px-3.5 py-2 text-sm font-bold text-white shadow-sm transition hover:bg-wrblue-600 sm:inline-flex">＋ 投稿する</Link>
+            <NavLink to="/posts/new" className="hidden shrink-0 whitespace-nowrap rounded-lg bg-wrblue-500 px-3.5 py-2 text-sm font-bold text-white shadow-sm transition hover:bg-wrblue-600 sm:inline-flex">＋ 投稿する</NavLink>
             {(user.role === 'TEACHER' || user.role === 'ADMIN') && (
               <>
-                <Link to="/dashboard" className="hidden shrink-0 whitespace-nowrap text-sm font-medium text-gray-600 transition hover:text-navy-700 lg:inline">ダッシュボード</Link>
-                <Link to="/invites" className="hidden shrink-0 whitespace-nowrap text-sm font-medium text-gray-600 transition hover:text-navy-700 lg:inline">招待</Link>
+                <NavLink to="/dashboard" className="hidden shrink-0 whitespace-nowrap text-sm font-medium text-gray-600 transition hover:text-navy-700 lg:inline">ダッシュボード</NavLink>
+                <NavLink to="/invites" className="hidden shrink-0 whitespace-nowrap text-sm font-medium text-gray-600 transition hover:text-navy-700 lg:inline">招待</NavLink>
               </>
             )}
-            <Link to="/notifications" className="relative text-gray-500 transition hover:text-navy-700" aria-label={`通知${unread > 0 ? `（未読 ${unread} 件）` : ''}`}>
+            <NavLink to="/notifications" className="relative text-gray-500 transition hover:text-navy-700" aria-label={`通知${unread > 0 ? `（未読 ${unread} 件）` : ''}`}>
               <span className="inline-block text-xl leading-none">🔔</span>
               {unread > 0 && (
                 <span className="absolute -right-2 -top-1 rounded-full bg-cherry-500 px-1.5 text-xs font-bold text-white shadow-sm">
                   {unread > 99 ? '99+' : unread}
                 </span>
               )}
-            </Link>
+            </NavLink>
             <Link to={`/users/${user.id}/profile`} aria-label={`${user.displayName} のプロフィール`} className="flex shrink-0 items-center gap-2 text-sm text-gray-700 hover:text-navy-700">
               <Avatar url={user.avatarUrl} name={user.displayName} size="md" />
               <span className="hidden font-medium xl:inline">{user.displayName}</span>

--- a/review-board/frontend/src/components/ReviewForm.jsx
+++ b/review-board/frontend/src/components/ReviewForm.jsx
@@ -58,7 +58,7 @@ export default function ReviewForm({ postId, onCreated }) {
     <form onSubmit={submit} className="mac-card p-5">
       <h3 className="mac-h mb-3 text-base">レビューを書く <span className="text-xs font-normal text-gray-400">（マークダウン記法が使えます）</span></h3>
       {restored && <DraftNotice onDiscard={discardDraft} />}
-      {error && <p className="mb-3 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+      {error && <p role="alert" className="mb-3 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
       <label htmlFor="review-good" className="mac-label">✅ 良かった点（必須）</label>
       <textarea
         id="review-good"

--- a/review-board/frontend/src/pages/InvitesPage.jsx
+++ b/review-board/frontend/src/pages/InvitesPage.jsx
@@ -102,7 +102,7 @@ export default function InvitesPage() {
       <h2 className="mac-h mb-1 text-2xl">受講生を招待</h2>
       <p className="mb-5 text-sm text-gray-500">招待リンクを受講生に共有すると、各自でアカウント登録できます（あなたの期に参加）。</p>
 
-      {error && <p className="mb-3 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+      {error && <p role="alert" className="mb-3 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
 
       {/* 発行フォーム */}
       <div className="mac-card mb-5 p-6">

--- a/review-board/frontend/src/pages/LoginPage.jsx
+++ b/review-board/frontend/src/pages/LoginPage.jsx
@@ -85,7 +85,7 @@ export default function LoginPage() {
           </div>
           <form onSubmit={onSubmitMfa} className="mac-card p-7">
             {error && (
-              <p className="mb-4 rounded-xl border border-red-100 bg-red-50/80 px-3.5 py-2.5 text-sm text-red-600">
+              <p role="alert" className="mb-4 rounded-xl border border-red-100 bg-red-50/80 px-3.5 py-2.5 text-sm text-red-600">
                 {error}
               </p>
             )}
@@ -126,7 +126,7 @@ export default function LoginPage() {
         {/* ログインカード */}
         <form onSubmit={onSubmit} className="mac-card p-7">
           {error && (
-            <p className="mb-4 rounded-xl border border-red-100 bg-red-50/80 px-3.5 py-2.5 text-sm text-red-600">
+            <p role="alert" className="mb-4 rounded-xl border border-red-100 bg-red-50/80 px-3.5 py-2.5 text-sm text-red-600">
               {error}
             </p>
           )}

--- a/review-board/frontend/src/pages/NewPostPage.jsx
+++ b/review-board/frontend/src/pages/NewPostPage.jsx
@@ -60,7 +60,7 @@ export default function NewPostPage() {
       <h2 className="mac-h mb-5 text-2xl">成果物を投稿</h2>
       <form onSubmit={submit} className="mac-card p-6 sm:p-7">
         {restored && <DraftNotice onDiscard={discardDraft} />}
-        {error && <p className="mb-3 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+        {error && <p role="alert" className="mb-3 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
         <label htmlFor="post-title" className="mac-label">タイトル（必須）</label>
         <input id="post-title" required value={form.title} onChange={set('title')} className="mac-input mb-4" />
         <label htmlFor="post-description" className="mac-label">説明（必須）<span className="ml-1 text-xs text-gray-400">・マークダウン可</span></label>

--- a/review-board/frontend/src/pages/NotificationsPage.jsx
+++ b/review-board/frontend/src/pages/NotificationsPage.jsx
@@ -71,7 +71,7 @@ export default function NotificationsPage() {
           description="新しいレビューや返信が届くと、ここに表示されます。"
         />
       ) : (
-        <ul className="space-y-2">
+        <ul className="space-y-2" role="region" aria-live="polite" aria-label="通知一覧">
           {items.map((n) => (
             <li key={n.id}>
               <button

--- a/review-board/frontend/src/pages/PasswordResetPage.jsx
+++ b/review-board/frontend/src/pages/PasswordResetPage.jsx
@@ -130,7 +130,7 @@ function ConfirmForm({ token }) {
   return (
     <form onSubmit={onSubmit} className="mac-card p-7">
       {error && (
-        <p className="mb-4 rounded-xl border border-red-100 bg-red-50/80 px-3.5 py-2.5 text-sm text-red-600">
+        <p role="alert" className="mb-4 rounded-xl border border-red-100 bg-red-50/80 px-3.5 py-2.5 text-sm text-red-600">
           {error}
         </p>
       )}

--- a/review-board/frontend/src/pages/PostEditPage.jsx
+++ b/review-board/frontend/src/pages/PostEditPage.jsx
@@ -65,7 +65,7 @@ export default function PostEditPage() {
       <p className="mac-eyebrow text-left">EDIT</p>
       <h2 className="mac-h mb-5 text-2xl">投稿を編集</h2>
       <form onSubmit={submit} className="mac-card p-6 sm:p-7">
-        {error && <p className="mb-3 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+        {error && <p role="alert" className="mb-3 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
         <label htmlFor="edit-title" className="mac-label">タイトル（必須）</label>
         <input id="edit-title" required value={form.title} onChange={set('title')} className="mac-input mb-4" />
         <label htmlFor="edit-description" className="mac-label">説明（必須）</label>

--- a/review-board/frontend/src/pages/RegisterPage.jsx
+++ b/review-board/frontend/src/pages/RegisterPage.jsx
@@ -45,7 +45,7 @@ export default function RegisterPage() {
 
         <form onSubmit={onSubmit} className="mac-card p-7">
           {error && (
-            <p className="mb-4 rounded-xl border border-red-100 bg-red-50/80 px-3.5 py-2.5 text-sm text-red-600">
+            <p role="alert" className="mb-4 rounded-xl border border-red-100 bg-red-50/80 px-3.5 py-2.5 text-sm text-red-600">
               {error}
             </p>
           )}


### PR DESCRIPTION
## 概要

引き継ぎ書「もう一段の作り込み」Day 1 午前タスク。
**見た目を 1 ピクセルも変えずに** ARIA 属性のみ追加して、スクリーンリーダ読み上げを自然にする。

## 変更点

| 範囲 | 変更 |
|---|---|
| `Header.jsx` | ナビ系 `Link` を `NavLink` に置換し `aria-current="page"` を自動付与 |
| `NotificationsPage.jsx` | 通知一覧 `<ul>` に `role="region" aria-live="polite" aria-label="通知一覧"` |
| 9 ファイル | フォームのインラインエラー `<p>` に `role="alert"` を付与（Login / Register / PasswordReset / NewPost / PostEdit / Invites / ReviewForm / EvaluationPanel） |

## 既存 UI 影響

**ゼロ**。NavLink がアクティブ時に追加する `active` className は、`index.css` に該当セレクタが無いため視覚変化なし（Tailwind の `active:` 接頭辞は別物）。

## 検証

- [x] `npm run build` 成功（403 modules transformed）
- [x] `npm test` 28/28 pass
- [x] 実機 Chrome で `/notifications` を開き `<a href="/notifications" aria-current="page">` を確認
- [x] トップ・通知ページのスクリーンショットで崩れゼロを目視確認
- [x] コンソールエラー 0 件

## 品質判定表

**P-9 アクセシビリティ WCAG A** の根拠欄に本 PR 番号と「NavLink化＋aria-live＋role=alert」を追記。

Closes #490