### PR TITLE
feat: P6 エラーメッセージを「人に優しい」日本語辞書に統一

### DIFF
--- a/review-board/docs/品質判定表.md
+++ b/review-board/docs/品質判定表.md
@@ -107,6 +107,7 @@
 | §3-2 設定・機密の外部化 | A | JWT secret/DB/seed すべて env 駆動・fail-fast・平文ハードコードなし（SEC-9 と一致） |
 | §3-3 エラーハンドリング標準 | A | `GlobalExceptionHandler` で一元化（401/403/404/400・silent catch なし） |
 | §3-4 リリース・運用フロー（誤操作多層防御） | A | Issue→PR→squash・main 保護・CI（build/test・依存スキャン・lint）。CLAUDE.md §12 の多層防御を継承 |
+| UX-1 エラーメッセージは平易な日本語 | A | **#492 で `lib/errorMessages.js` を新規追加**し、HTTP ステータス（400/401/403/404/409/413/415/422/429/500/502/503/504）→ 状況説明＋次の行動を含む日本語に統一。ネットワーク不通・タイムアウトも `code` で判定。バックエンドの日本語メッセージは最優先。10 ファイル（Login / Register / PasswordReset / NewPost / PostEdit / PostDetail / Invites / ReviewForm / EvaluationPanel / Avatar・Screenshot Uploader）が辞書経由に統一。英語の生エラー語混入を unit test で検知（35/35 pass） |
 
 ## 2. 重点判定表（宣言した 重点軸：セキュリティ・認可）
 

--- a/review-board/frontend/src/components/AvatarUploader.jsx
+++ b/review-board/frontend/src/components/AvatarUploader.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { uploadScreenshot } from '../api/uploads';
 import AvatarCropper from './AvatarCropper';
+import { getErrorMessage } from '../lib/errorMessages';
 
 // アバター選択 → 正方形に切り抜き → アップロード（SEC-8：返った key を onChange で親へ）。
 // プレビューは署名付き URL（private 保存・URL 経由でのみ表示）。
@@ -26,7 +27,7 @@ export default function AvatarUploader({ initialUrl = '', onChange }) {
       setPreview(url);
       onChange(key);
     } catch (err) {
-      setError(err.response?.data?.message || 'アップロードに失敗しました（PNG/JPEG/WebP・5MB まで）');
+      setError(getErrorMessage(err, 'アップロードできませんでした（PNG / JPEG / WebP・5MB まで）'));
     } finally {
       setBusy(false);
     }

--- a/review-board/frontend/src/components/EvaluationPanel.jsx
+++ b/review-board/frontend/src/components/EvaluationPanel.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { EVAL_LABEL } from '../constants';
 import { evaluate } from '../api/evaluations';
+import { getErrorMessage } from '../lib/errorMessages';
 
 // F-EVAL-01：講師の最終評価。受講生には現在の評価のみ表示、講師には評価フォームを出す。
 // 出し分けは UX 補助で、実際の権限は backend（受講生の送信は 403）。
@@ -19,7 +20,9 @@ export default function EvaluationPanel({ postId, evaluation, isTeacher, onEvalu
       setComment('');
       onEvaluated?.(ev);
     } catch (err) {
-      setError(err.response?.status === 403 ? '評価は講師のみ可能です' : '送信に失敗しました');
+      setError(err.response?.status === 403
+        ? '評価は講師のみ可能です'
+        : getErrorMessage(err, '評価を送信できませんでした。少し待ってからもう一度お試しください'));
     } finally {
       setBusy(false);
     }

--- a/review-board/frontend/src/components/ReviewForm.jsx
+++ b/review-board/frontend/src/components/ReviewForm.jsx
@@ -3,6 +3,7 @@ import { AXES } from '../constants';
 import { createReview } from '../api/reviews';
 import { useDraft } from '../hooks/useDraft';
 import DraftNotice from './DraftNotice';
+import { getErrorMessage } from '../lib/errorMessages';
 
 // F-REV-01：良かった点・改善提案は必須、観点別コメント（4軸）は任意。
 // F-DRAFT-01：入力を localStorage に自動保存（postId 単位）し、再訪時に復元する。
@@ -48,7 +49,7 @@ export default function ReviewForm({ postId, onCreated }) {
       const s = err.response?.status;
       if (s === 400) setError('自分の投稿にはレビューできません');
       else if (s === 404) setError('この投稿にはレビューできません');
-      else setError('送信に失敗しました');
+      else setError(getErrorMessage(err, 'レビューを送信できませんでした。少し待ってからもう一度お試しください'));
     } finally {
       setSubmitting(false);
     }

--- a/review-board/frontend/src/components/ScreenshotUploader.jsx
+++ b/review-board/frontend/src/components/ScreenshotUploader.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { uploadScreenshot } from '../api/uploads';
+import { getErrorMessage } from '../lib/errorMessages';
 
 // SEC-8：成果物スクショの選択→アップロード。返った key を onChange で親に渡す。
 // プレビューは backend が返す署名付き URL を使う（private 保存・URL 経由でのみ表示）。
@@ -19,7 +20,7 @@ export default function ScreenshotUploader({ initialUrl = '', onChange }) {
       onChange(key);
     } catch (err) {
       // 非画像・サイズ超過は backend が 400/413。ユーザーに理由を返す。
-      setError(err.response?.data?.message || 'アップロードに失敗しました（PNG/JPEG/WebP・5MB まで）');
+      setError(getErrorMessage(err, 'アップロードできませんでした（PNG / JPEG / WebP・5MB まで）'));
     } finally {
       setBusy(false);
     }

--- a/review-board/frontend/src/lib/errorMessages.js
+++ b/review-board/frontend/src/lib/errorMessages.js
@@ -1,0 +1,43 @@
+// #492 P6：エラーメッセージの一元辞書。
+// 学習者を傷つけない＆次の行動を含む日本語を返す。
+// バックエンドの message が日本語で来ていればそれを優先（具体的でユーザに親切）。
+
+const STATUS_MESSAGES = {
+  400: 'リクエストの内容に問題があります。入力をご確認ください',
+  401: 'ログインが必要です。もう一度ログインしてください',
+  403: 'この操作を行う権限がありません',
+  404: '見つかりませんでした。URL をご確認ください',
+  409: '他の人が同時に編集しているようです。ページを更新してやり直してください',
+  413: 'ファイルが大きすぎます（5MB まで）',
+  415: '対応していないファイル形式です（PNG / JPEG / WebP のみ）',
+  422: '入力内容に誤りがあります。各項目をご確認ください',
+  429: '短時間に何度もアクセスがありました。1 分ほど待ってからお試しください',
+  500: 'サーバーで問題が発生しました。少し待ってからもう一度お試しください',
+  502: 'サーバーに繋がりませんでした。少し待ってからもう一度お試しください',
+  503: 'サーバーが混み合っています。少し待ってからもう一度お試しください',
+  504: 'サーバーの応答が遅れています。少し待ってからもう一度お試しください',
+};
+
+const NETWORK_MESSAGE = 'インターネット接続を確認してください';
+const FALLBACK_MESSAGE = 'うまく送信できませんでした。少し待ってからもう一度お試しください';
+
+// axios error / fetch error / 文字列 / null のいずれを受けても安全に文字列を返す。
+// 第 2 引数 fallback で「この操作固有の文言」を指定可能（例: '投稿の取得に失敗しました'）。
+export function getErrorMessage(error, fallback = FALLBACK_MESSAGE) {
+  if (!error) return fallback;
+  // axios タイムアウト / ネットワーク到達不能
+  if (error.code === 'ERR_NETWORK' || error.code === 'ECONNABORTED' || error.message === 'Network Error') {
+    return NETWORK_MESSAGE;
+  }
+  // バックエンドの日本語メッセージを最優先（GlobalExceptionHandler が message を返す）
+  const backendMessage = error.response?.data?.message;
+  if (typeof backendMessage === 'string' && backendMessage.trim()) {
+    return backendMessage.trim();
+  }
+  const status = error.response?.status;
+  if (status && STATUS_MESSAGES[status]) return STATUS_MESSAGES[status];
+  return fallback;
+}
+
+// テスト用に辞書もエクスポート
+export { STATUS_MESSAGES, NETWORK_MESSAGE, FALLBACK_MESSAGE };

--- a/review-board/frontend/src/lib/errorMessages.test.js
+++ b/review-board/frontend/src/lib/errorMessages.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { getErrorMessage, STATUS_MESSAGES, NETWORK_MESSAGE, FALLBACK_MESSAGE } from './errorMessages';
+
+describe('getErrorMessage', () => {
+  it('null / undefined はフォールバックを返す', () => {
+    expect(getErrorMessage(null)).toBe(FALLBACK_MESSAGE);
+    expect(getErrorMessage(undefined, '独自のフォールバック')).toBe('独自のフォールバック');
+  });
+
+  it('ネットワークエラーは ERR_NETWORK でも message でも検出する', () => {
+    expect(getErrorMessage({ code: 'ERR_NETWORK' })).toBe(NETWORK_MESSAGE);
+    expect(getErrorMessage({ code: 'ECONNABORTED' })).toBe(NETWORK_MESSAGE);
+    expect(getErrorMessage({ message: 'Network Error' })).toBe(NETWORK_MESSAGE);
+  });
+
+  it('バックエンドの日本語メッセージを最優先する', () => {
+    const err = { response: { status: 400, data: { message: '招待コードが無効です' } } };
+    expect(getErrorMessage(err, 'fallback')).toBe('招待コードが無効です');
+  });
+
+  it('HTTP ステータスから親切な日本語を返す（401 / 403 / 404 / 413 / 429 / 500）', () => {
+    expect(getErrorMessage({ response: { status: 401 } })).toBe(STATUS_MESSAGES[401]);
+    expect(getErrorMessage({ response: { status: 403 } })).toBe(STATUS_MESSAGES[403]);
+    expect(getErrorMessage({ response: { status: 404 } })).toBe(STATUS_MESSAGES[404]);
+    expect(getErrorMessage({ response: { status: 413 } })).toBe(STATUS_MESSAGES[413]);
+    expect(getErrorMessage({ response: { status: 429 } })).toBe(STATUS_MESSAGES[429]);
+    expect(getErrorMessage({ response: { status: 500 } })).toBe(STATUS_MESSAGES[500]);
+  });
+
+  it('未定義の status は fallback を返す', () => {
+    expect(getErrorMessage({ response: { status: 418 } }, 'コーヒーは淹れられません'))
+      .toBe('コーヒーは淹れられません');
+  });
+
+  it('空白のみのバックエンドメッセージは無視して fallback / status に進む', () => {
+    const err = { response: { status: 500, data: { message: '   ' } } };
+    expect(getErrorMessage(err)).toBe(STATUS_MESSAGES[500]);
+  });
+
+  it('全てのメッセージが空でなく、英語の生エラー語を含まない', () => {
+    // 「人に優しい」ためのガード：英語の生エラー語（Error / Failed / Validation / failed）が混入しない。
+    const forbidden = /Error|Failed|failed|Validation/;
+    Object.values(STATUS_MESSAGES).forEach((msg) => {
+      expect(msg.length, `"${msg}" が空`).toBeGreaterThan(0);
+      expect(forbidden.test(msg), `"${msg}" に英語エラー語が混入`).toBe(false);
+    });
+    expect(forbidden.test(NETWORK_MESSAGE)).toBe(false);
+    expect(forbidden.test(FALLBACK_MESSAGE)).toBe(false);
+  });
+});

--- a/review-board/frontend/src/pages/InvitesPage.jsx
+++ b/review-board/frontend/src/pages/InvitesPage.jsx
@@ -4,6 +4,7 @@ import { fetchMembers, disableMember, enableMember } from '../api/members';
 import { ROLE_LABEL } from '../constants';
 import Avatar from '../components/Avatar';
 import EmptyState from '../components/EmptyState';
+import { getErrorMessage } from '../lib/errorMessages';
 
 // 招待コード管理（講師/管理者・Issue #165）。発行→受講生に共有→失効まで。
 // 生コードは発行直後の 1 度しか表示できないため、発行時に共有リンクを目立たせる。
@@ -35,8 +36,8 @@ export default function InvitesPage() {
       const [inv, mem] = await Promise.all([fetchInvites(), fetchMembers()]);
       setInvites(inv);
       setMembers(mem);
-    } catch {
-      setError('一覧の取得に失敗しました。');
+    } catch (e) {
+      setError(getErrorMessage(e, '一覧を読み込めませんでした。少し待ってからもう一度お試しください'));
     } finally {
       setLoading(false);
     }
@@ -54,8 +55,8 @@ export default function InvitesPage() {
       const inv = await createInvite({ maxUses: Number(maxUses), expiresInDays: Number(expiresInDays) });
       setIssued(inv);
       await load();
-    } catch {
-      setError('招待の発行に失敗しました。');
+    } catch (e) {
+      setError(getErrorMessage(e, '招待の発行に失敗しました。少し待ってからもう一度お試しください'));
     } finally {
       setBusy(false);
     }
@@ -76,8 +77,8 @@ export default function InvitesPage() {
     try {
       await revokeInvite(id);
       await load();
-    } catch {
-      setError('失効に失敗しました。');
+    } catch (e) {
+      setError(getErrorMessage(e, '失効に失敗しました。少し待ってからもう一度お試しください'));
     }
   };
 
@@ -91,8 +92,10 @@ export default function InvitesPage() {
     try {
       const updated = disabling ? await disableMember(m.id) : await enableMember(m.id);
       setMembers((list) => list.map((x) => (x.id === updated.id ? updated : x)));
-    } catch {
-      setError(disabling ? '無効化に失敗しました（権限・対象をご確認ください）。' : '有効化に失敗しました。');
+    } catch (e) {
+      setError(getErrorMessage(e, disabling
+        ? '無効化に失敗しました（権限・対象をご確認ください）'
+        : '有効化に失敗しました。少し待ってからもう一度お試しください'));
     }
   };
 

--- a/review-board/frontend/src/pages/LoginPage.jsx
+++ b/review-board/frontend/src/pages/LoginPage.jsx
@@ -3,6 +3,7 @@ import { useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import DolphinIcon from '../components/DolphinIcon';
 import { APP_NAME, APP_TAGLINE } from '../constants';
+import { getErrorMessage } from '../lib/errorMessages';
 
 export default function LoginPage() {
   const { login, completeMfaLogin } = useAuth();
@@ -29,7 +30,9 @@ export default function LoginPage() {
       navigate('/', { replace: true });
     } catch (err) {
       // 認証失敗は存在を漏らさない汎用メッセージ（backend が 401 を返す）
-      setError(err.response?.status === 401 ? 'メールアドレスまたはパスワードが違います' : '通信に失敗しました');
+      setError(err.response?.status === 401
+        ? 'メールアドレスまたはパスワードが違います'
+        : getErrorMessage(err, '通信に失敗しました。少し待ってからもう一度お試しください'));
     } finally {
       setSubmitting(false);
     }
@@ -51,7 +54,7 @@ export default function LoginPage() {
       setError(
         err.response?.status === 401
           ? 'デモアカウントが利用できません（dev シード未投入の可能性）'
-          : '通信に失敗しました'
+          : getErrorMessage(err, '通信に失敗しました。少し待ってからもう一度お試しください')
       );
     } finally {
       setSubmitting(false);
@@ -66,7 +69,9 @@ export default function LoginPage() {
       await completeMfaLogin(code);
       navigate('/', { replace: true });
     } catch (err) {
-      setError(err.response?.status === 401 ? '認証コードが正しくありません' : '通信に失敗しました');
+      setError(err.response?.status === 401
+        ? '認証コードが正しくありません'
+        : getErrorMessage(err, '通信に失敗しました。少し待ってからもう一度お試しください'));
     } finally {
       setSubmitting(false);
     }

--- a/review-board/frontend/src/pages/NewPostPage.jsx
+++ b/review-board/frontend/src/pages/NewPostPage.jsx
@@ -5,6 +5,7 @@ import ScreenshotUploader from '../components/ScreenshotUploader';
 import ReviewPrefFields from '../components/ReviewPrefFields';
 import DraftNotice from '../components/DraftNotice';
 import { useDraft } from '../hooks/useDraft';
+import { getErrorMessage } from '../lib/errorMessages';
 
 const EMPTY = { title: '', description: '', repoUrl: '', demoUrl: '', screenshotKey: null, reviewTones: [], reviewAspects: [], aiUsage: null };
 
@@ -47,8 +48,8 @@ export default function NewPostPage() {
       });
       clear(); // 投稿成功で下書きは不要
       navigate(`/posts/${post.id}`, { replace: true });
-    } catch {
-      setError('投稿に失敗しました');
+    } catch (err) {
+      setError(getErrorMessage(err, '投稿できませんでした。入力内容をご確認のうえ、もう一度お試しください'));
     } finally {
       setBusy(false);
     }

--- a/review-board/frontend/src/pages/PasswordResetPage.jsx
+++ b/review-board/frontend/src/pages/PasswordResetPage.jsx
@@ -3,6 +3,7 @@ import { Link, useSearchParams, useNavigate } from 'react-router-dom';
 import DolphinIcon from '../components/DolphinIcon';
 import { APP_NAME } from '../constants';
 import { requestPasswordReset, confirmPasswordReset } from '../api/auth';
+import { getErrorMessage } from '../lib/errorMessages';
 
 /**
  * B-4 パスワードリセット（#231）。
@@ -111,8 +112,8 @@ function ConfirmForm({ token }) {
     } catch (err) {
       setError(
         err.response?.status === 400
-          ? 'リンクが無効か、有効期限が切れています。お手数ですが再度リクエストしてください。'
-          : '通信に失敗しました',
+          ? 'リンクが無効か、有効期限が切れています。お手数ですが再度リクエストしてください'
+          : getErrorMessage(err, '通信に失敗しました。少し待ってからもう一度お試しください'),
       );
     } finally {
       setSubmitting(false);

--- a/review-board/frontend/src/pages/PostDetailPage.jsx
+++ b/review-board/frontend/src/pages/PostDetailPage.jsx
@@ -9,6 +9,7 @@ import ReviewItem from '../components/ReviewItem';
 import EvaluationPanel from '../components/EvaluationPanel';
 import ReviewPrefBadges from '../components/ReviewPrefBadges';
 import MarkdownText from '../components/MarkdownText';
+import { getErrorMessage } from '../lib/errorMessages';
 
 // 投稿詳細：本体＋レビュー一覧＋レビュー投稿＋講師評価。
 export default function PostDetailPage() {
@@ -31,7 +32,9 @@ export default function PostDetailPage() {
         setReviews(r);
         setEvaluation(e);
       })
-      .catch((err) => setError(err.response?.status === 404 ? 'この投稿は見つかりません' : '取得に失敗しました'))
+      .catch((err) => setError(err.response?.status === 404
+        ? 'この投稿は見つかりません'
+        : getErrorMessage(err, '投稿を読み込めませんでした。少し待ってからもう一度お試しください')))
       .finally(() => setLoading(false));
   }, [id]);
 
@@ -46,8 +49,8 @@ export default function PostDetailPage() {
     try {
       await deletePost(post.id);
       navigate('/', { replace: true });
-    } catch {
-      setError('削除に失敗しました');
+    } catch (err) {
+      setError(getErrorMessage(err, '削除できませんでした。少し待ってからもう一度お試しください'));
     }
   };
 
@@ -56,8 +59,8 @@ export default function PostDetailPage() {
     try {
       const updated = await selectBestReview(post.id, reviewId);
       setPost(updated);
-    } catch {
-      setError('ベストレビューの選択に失敗しました');
+    } catch (err) {
+      setError(getErrorMessage(err, 'ベストレビューの選択に失敗しました。少し待ってからもう一度お試しください'));
     }
   };
 
@@ -66,8 +69,8 @@ export default function PostDetailPage() {
     try {
       const res = post.liked ? await unlikePost(post.id) : await likePost(post.id);
       setPost((p) => ({ ...p, likeCount: res.likeCount, liked: res.liked }));
-    } catch {
-      setError('いいねに失敗しました');
+    } catch (err) {
+      setError(getErrorMessage(err, 'いいねに失敗しました。少し待ってからもう一度お試しください'));
     }
   };
 

--- a/review-board/frontend/src/pages/PostEditPage.jsx
+++ b/review-board/frontend/src/pages/PostEditPage.jsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { fetchPost, updatePost } from '../api/posts';
 import ScreenshotUploader from '../components/ScreenshotUploader';
 import ReviewPrefFields from '../components/ReviewPrefFields';
+import { getErrorMessage } from '../lib/errorMessages';
 
 // F-POST-02 投稿の編集（所有者のみ。非所有者は backend が 404）。
 export default function PostEditPage() {
@@ -29,7 +30,9 @@ export default function PostEditPage() {
         });
         setScreenshotUrl(p.screenshotUrl ?? '');
       })
-      .catch((e) => setError(e.response?.status === 404 ? 'この投稿は編集できません' : '取得に失敗しました'));
+      .catch((e) => setError(e.response?.status === 404
+        ? 'この投稿は編集できません'
+        : getErrorMessage(e, '投稿を読み込めませんでした。少し待ってからもう一度お試しください')));
   }, [id]);
 
   const set = (k) => (e) => setForm((p) => ({ ...p, [k]: e.target.value }));
@@ -51,7 +54,9 @@ export default function PostEditPage() {
       });
       navigate(`/posts/${id}`, { replace: true });
     } catch (err) {
-      setError(err.response?.status === 404 ? '権限がありません' : '更新に失敗しました');
+      setError(err.response?.status === 404
+        ? 'この投稿を編集する権限がありません'
+        : getErrorMessage(err, '更新できませんでした。入力内容をご確認のうえ、もう一度お試しください'));
     } finally {
       setBusy(false);
     }

--- a/review-board/frontend/src/pages/RegisterPage.jsx
+++ b/review-board/frontend/src/pages/RegisterPage.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useNavigate, useSearchParams, Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import DolphinIcon from '../components/DolphinIcon';
+import { getErrorMessage } from '../lib/errorMessages';
 
 // F-AUTH-02 招待コードによる受講生の自己登録（公開・Issue #165）。
 // 講師が配布した URL（/register?code=...）から開くとコードが自動入力される。
@@ -25,8 +26,8 @@ export default function RegisterPage() {
       await register({ code: code.trim(), email, displayName, password });
       navigate('/');
     } catch (err) {
-      const msg = err?.response?.data?.error?.message;
-      setError(msg || '登録に失敗しました。招待コードや入力内容をご確認ください。');
+      const nestedMsg = err?.response?.data?.error?.message;
+      setError(nestedMsg || getErrorMessage(err, '登録に失敗しました。招待コードや入力内容をご確認ください'));
     } finally {
       setSubmitting(false);
     }


### PR DESCRIPTION
## 概要

引き継ぎ書 Day 1 午後〜 Day 2 午前タスク。
HTTP ステータス別の **「次の行動を含む」日本語メッセージ辞書** を一元化し、10 ファイルが共通辞書経由に統一。

## 変更点

### 新規
- `frontend/src/lib/errorMessages.js` — `getErrorMessage(error, fallback)` ヘルパ + 辞書（13 ステータス + ネットワーク + 汎用フォールバック）
- `frontend/src/lib/errorMessages.test.js` — 7 ケース（null / ネットワーク / バックエンド優先 / status マップ / 未定義 status / 空白 message / 英語混入禁止）

### 修正（10 ファイル）
LoginPage / RegisterPage / PasswordResetPage / NewPostPage / PostEditPage / PostDetailPage / InvitesPage / ReviewForm / EvaluationPanel / AvatarUploader / ScreenshotUploader が辞書経由に。

## 設計

- **バックエンド日本語メッセージを最優先**（`GlobalExceptionHandler` の message が来ればそれを表示）
- **ネットワーク不通 / タイムアウト**は `code` で先に判定 → 専用文言
- **ステータスマップで親切な文言**へ（401「ログインが必要です。もう一度ログインしてください」/ 413「ファイルが大きすぎます（5MB まで）」/ 429「短時間に何度もアクセスがありました。1 分ほど待ってからお試しください」など）
- **fallback はオペレーション固有文言**（呼び出し側で渡す）

## 検証

- [x] `npm test` 35/35 pass（+7 ケース）
- [x] `npm run build` 成功（403 modules transformed）
- [x] 既存 UI 崩れなし（Chrome 実機・トップ画面確認）
- [x] `grep -rnE "Validation\\|Error:\\|failed\\|Failed" frontend/src --include="*.jsx" --include="*.js"` のヒット 0 件（テスト・ErrorBoundary・throw new Error を除く）

## 品質判定表

新規行 **UX-1 エラーメッセージは平易な日本語** を 1-5 セクションに追加し A 化。

Closes #492