### PR TITLE
feat: P10 ヘルプ / FAQ ページを追加（/help・9 セクション）

### DIFF
--- a/review-board/docs/品質判定表.md
+++ b/review-board/docs/品質判定表.md
@@ -108,6 +108,7 @@
 | §3-3 エラーハンドリング標準 | A | `GlobalExceptionHandler` で一元化（401/403/404/400・silent catch なし） |
 | §3-4 リリース・運用フロー（誤操作多層防御） | A | Issue→PR→squash・main 保護・CI（build/test・依存スキャン・lint）。CLAUDE.md §12 の多層防御を継承 |
 | UX-1 エラーメッセージは平易な日本語 | A | **#492 で `lib/errorMessages.js` を新規追加**し、HTTP ステータス（400/401/403/404/409/413/415/422/429/500/502/503/504）→ 状況説明＋次の行動を含む日本語に統一。ネットワーク不通・タイムアウトも `code` で判定。バックエンドの日本語メッセージは最優先。10 ファイル（Login / Register / PasswordReset / NewPost / PostEdit / PostDetail / Invites / ReviewForm / EvaluationPanel / Avatar・Screenshot Uploader）が辞書経由に統一。英語の生エラー語混入を unit test で検知（35/35 pass） |
+| UX-3 ヘルプ / FAQ ページ提供 | A | **#494 で `/help` を新設**（`HelpPage.jsx`・9 セクション：はじめて / 投稿 / レビュー / 多軸評価 / 招待 / パスワード / 通知 / 削除 / 問い合わせ）。ネイティブ `<details>` で aria 対応＆ライブラリ追加なし。Shell に小フッターを追加し全認証ページから到達可能。`LoginPage` / `RegisterPage` / `LegalLayout` からもリンク。実機 Chrome で 9 セクション開閉確認済 |
 
 ## 2. 重点判定表（宣言した 重点軸：セキュリティ・認可）
 

--- a/review-board/frontend/src/App.jsx
+++ b/review-board/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Routes, Route, useLocation } from 'react-router-dom';
+import { Routes, Route, useLocation, Link } from 'react-router-dom';
 import { AuthProvider } from './context/AuthContext';
 import ProtectedRoute from './components/ProtectedRoute';
 import Header from './components/Header';
@@ -9,6 +9,7 @@ import RegisterPage from './pages/RegisterPage';
 import PasswordResetPage from './pages/PasswordResetPage';
 import TermsPage from './pages/TermsPage';
 import PrivacyPage from './pages/PrivacyPage';
+import HelpPage from './pages/HelpPage';
 import InvitesPage from './pages/InvitesPage';
 import PostsPage from './pages/PostsPage';
 import NewPostPage from './pages/NewPostPage';
@@ -31,13 +32,23 @@ function ScrollToTop() {
   return null;
 }
 
-// 認証必須ページの共通レイアウト（ヘッダー＋本文）。
+// 認証必須ページの共通レイアウト（ヘッダー＋本文＋小フッター）。
+// #494 P10：全画面から /help・/terms・/privacy に到達できる小フッター。
 function Shell({ children }) {
   return (
     <ProtectedRoute>
-      <div className="min-h-screen">
+      <div className="flex min-h-screen flex-col">
         <Header />
-        {children}
+        <div className="flex-1">{children}</div>
+        <footer className="border-t border-black/5 bg-white/60">
+          <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-center gap-x-4 gap-y-1 px-6 py-3 text-xs text-gray-400">
+            <Link to="/help" className="hover:text-navy-700 hover:underline">ヘルプ / FAQ</Link>
+            <span>·</span>
+            <Link to="/terms" className="hover:text-navy-700 hover:underline">利用規約</Link>
+            <span>·</span>
+            <Link to="/privacy" className="hover:text-navy-700 hover:underline">プライバシー</Link>
+          </div>
+        </footer>
       </div>
     </ProtectedRoute>
   );
@@ -56,6 +67,7 @@ export default function App() {
         {/* 公開（ログイン不要）の法務ページ（#258） */}
         <Route path="/terms" element={<TermsPage />} />
         <Route path="/privacy" element={<PrivacyPage />} />
+        <Route path="/help" element={<HelpPage />} />
         <Route path="/" element={<Shell><PostsPage /></Shell>} />
         <Route path="/invites" element={<Shell><InvitesPage /></Shell>} />
         <Route path="/posts/new" element={<Shell><NewPostPage /></Shell>} />

--- a/review-board/frontend/src/pages/HelpPage.jsx
+++ b/review-board/frontend/src/pages/HelpPage.jsx
@@ -1,0 +1,109 @@
+import LegalLayout from './LegalLayout';
+import { APP_NAME } from '../constants';
+
+// #494 P10：ヘルプ / FAQ。`<details>` でネイティブ折りたたみ（aria-expanded 不要）。
+// 既存の LegalLayout を流用しログイン不要で閲覧可能（評価者の「使い方」確認導線）。
+function Faq({ q, children }) {
+  return (
+    <details className="group rounded-xl border border-black/5 bg-white px-4 py-3 transition open:shadow-mac-sm">
+      <summary className="cursor-pointer list-none font-semibold text-navy-700 marker:hidden">
+        <span className="mr-2 text-brand-500 transition group-open:rotate-90 inline-block">▶</span>
+        {q}
+      </summary>
+      <div className="mt-3 space-y-2 text-sm leading-relaxed text-gray-700">{children}</div>
+    </details>
+  );
+}
+
+export default function HelpPage() {
+  return (
+    <LegalLayout title="ヘルプ / FAQ" lastUpdated="2026-05-29">
+      <p>
+        {APP_NAME} の使い方や、よくあるご質問への回答をまとめています。
+        各セクションをクリックすると詳細が開きます。
+      </p>
+
+      <div className="space-y-3">
+        <Faq q="1. はじめての方へ（3 分で始める）">
+          <ol className="ml-5 list-decimal space-y-1">
+            <li>講師から招待リンク（`/register?code=...`）を受け取ります。</li>
+            <li>リンクを開き、表示名・メールアドレス・パスワードを入力して登録します。</li>
+            <li>ログイン後、トップで「成果物を投稿する」または「成果物を見る」から始められます。</li>
+          </ol>
+          <p className="text-xs text-gray-500">
+            体験用には、ログイン画面の「デモで試す」ボタンも利用できます（dev シードが投入されている環境のみ）。
+          </p>
+        </Faq>
+
+        <Faq q="2. 投稿のしかた">
+          <p>ヘッダー右上の「＋ 投稿する」から作成します。</p>
+          <ul className="ml-5 list-disc space-y-1">
+            <li><strong>タイトル・説明</strong>は必須です。説明はマークダウン記法が使えます。</li>
+            <li><strong>リポジトリ URL・デモ URL</strong>は任意。あると講師が動作を確認しやすくなります。</li>
+            <li><strong>スクリーンショット</strong>（PNG / JPEG / WebP・5MB まで）も任意。一覧で目を引きます。</li>
+            <li><strong>レビュー希望タグ</strong>（トーン・観点・AI 利用）を選ぶと、書き手が方針を合わせやすくなります。</li>
+          </ul>
+          <p className="text-xs text-gray-500">下書きはブラウザに自動保存され、ページを離れても入力内容は残ります。</p>
+        </Faq>
+
+        <Faq q="3. レビューの書きかた（テンプレ + 例）">
+          <p>レビューは投稿詳細ページの下部から書けます。型に沿うと書きやすいです：</p>
+          <ul className="ml-5 list-disc space-y-1">
+            <li><strong>✅ 良かった点</strong>（必須）：自分なりに「ここは盗みたい」と思った具体箇所</li>
+            <li><strong>💡 もっと良くなる点</strong>（必須）：人格ではなく成果物の改善余地を、できれば「次の一歩」つきで</li>
+            <li><strong>観点別コメント</strong>（任意）：可読性・性能・テスト・設計など 4 軸で個別に</li>
+          </ul>
+          <p>例：「README に動作スクショがあったので、初見でも実装範囲がすぐ掴めました（良）。一覧 API の N+1 が気になったので、`@EntityGraph` で 1 クエリに寄せると更に良さそうです（改善）」</p>
+        </Faq>
+
+        <Faq q="4. 多軸評価のしくみ">
+          <p>
+            投稿には複数の観点（可読性 / 設計 / テスト など）でレビューが付きます。
+            講師は最終評価として <strong>合格 / 差し戻し</strong> をつけます。
+            合格は <strong>合格バッジ</strong> としてプロフィールに残り、再評価で剥奪されません。
+          </p>
+          <p>「投稿の質」だけでなく「レビューの質」も評価対象です。良いレビューには「ありがとう」を送れます。</p>
+        </Faq>
+
+        <Faq q="5. 招待コードの使い方（講師向け）">
+          <p>講師は「招待」ページから招待リンクを発行できます：</p>
+          <ul className="ml-5 list-disc space-y-1">
+            <li><strong>利用上限</strong>（人数）と <strong>有効日数</strong> を指定して発行</li>
+            <li>発行直後の 1 度だけ生コードが表示されるので、その場で受講生に共有してください</li>
+            <li>不要になった招待は「失効させる」で即時無効化できます</li>
+          </ul>
+        </Faq>
+
+        <Faq q="6. パスワードを忘れたとき">
+          <p>
+            ログイン画面の「パスワードをお忘れですか？」から、登録メールアドレスを入力すると
+            再設定リンクが届きます。リンクの有効期限が切れた場合は、再度リクエストしてください。
+          </p>
+        </Faq>
+
+        <Faq q="7. 通知設定の変更">
+          <p>
+            プロフィールページの「通知設定」から、メール通知の種別ごとに ON / OFF を切り替えられます。
+            通知センターはヘッダーのベルアイコン（🔔）から開けます。未読件数はバッジで表示されます。
+          </p>
+        </Faq>
+
+        <Faq q="8. アカウントの削除">
+          <p>
+            プロフィールページ下部の「退会する」から削除できます。退会すると、あなたが書いた投稿・レビューは
+            匿名化されて履歴は残りますが、ログイン情報・メールアドレス・プロフィールは復元できません。
+          </p>
+          <p className="text-xs text-gray-500">講師・管理者の場合は、cohort の運用引き継ぎが必要なため事前に管理者へご相談ください。</p>
+        </Faq>
+
+        <Faq q="9. お問い合わせ">
+          <p>
+            本サービスは学習目的のため、運用窓口は提供していません。
+            運用上の問題があれば、所属スクールの担当講師にご相談ください。
+          </p>
+          <p className="text-xs text-gray-500">バグや改善提案は GitHub Issues に投稿いただけます（リポジトリにアクセス権がある方）。</p>
+        </Faq>
+      </div>
+    </LegalLayout>
+  );
+}

--- a/review-board/frontend/src/pages/LegalLayout.jsx
+++ b/review-board/frontend/src/pages/LegalLayout.jsx
@@ -12,6 +12,7 @@ export default function LegalLayout({ title, lastUpdated, children }) {
           <nav className="flex gap-3 text-sm">
             <Link to="/terms" className="text-gray-500 hover:text-gray-800">利用規約</Link>
             <Link to="/privacy" className="text-gray-500 hover:text-gray-800">プライバシー</Link>
+            <Link to="/help" className="text-gray-500 hover:text-gray-800">ヘルプ</Link>
             <Link to="/login" className="text-brand-600 hover:underline">ログイン</Link>
           </nav>
         </div>

--- a/review-board/frontend/src/pages/LoginPage.jsx
+++ b/review-board/frontend/src/pages/LoginPage.jsx
@@ -206,6 +206,8 @@ export default function LoginPage() {
           <Link to="/terms" className="hover:underline">利用規約</Link>
           <span className="mx-1.5">·</span>
           <Link to="/privacy" className="hover:underline">プライバシーポリシー</Link>
+          <span className="mx-1.5">·</span>
+          <Link to="/help" className="hover:underline">ヘルプを見る</Link>
         </p>
       </div>
     </main>

--- a/review-board/frontend/src/pages/RegisterPage.jsx
+++ b/review-board/frontend/src/pages/RegisterPage.jsx
@@ -88,6 +88,10 @@ export default function RegisterPage() {
         <p className="mt-6 text-center text-xs text-gray-400">
           すでにアカウントをお持ちの方は <Link to="/login" className="font-semibold text-navy-700 hover:underline">ログイン</Link>
         </p>
+
+        <p className="mt-4 text-center text-xs text-gray-400">
+          <Link to="/help" className="hover:underline">ヘルプを見る</Link>
+        </p>
       </div>
     </main>
   );


### PR DESCRIPTION
## 概要

引き継ぎ書 Day 2 午後〜Day 3 午前タスク。
`/help` に折りたたみ式 FAQ ページを新設し、全画面から到達可能にする。

## 変更点

### 新規
- `frontend/src/pages/HelpPage.jsx` — 9 セクション（はじめて / 投稿 / レビュー / 多軸評価 / 招待 / パスワード / 通知 / 削除 / 問い合わせ）
- App.jsx の Shell に小フッター（ヘルプ / 利用規約 / プライバシー）

### 修正
- `App.jsx` — `/help` ルート + 小フッター
- `LegalLayout.jsx` — 公開ページのヘッダにヘルプリンク追加
- `LoginPage.jsx` — フッターに「ヘルプを見る」追加
- `RegisterPage.jsx` — 下部に「ヘルプを見る」追加

## 設計判断

- **`<details>` でネイティブ折りたたみ** — ライブラリ追加不要、`aria-expanded` も自動付与
- **`LegalLayout` を流用** — 既存の最小ヘッダ + 法務フッターパターンを継承
- **ログイン不要** — 評価者が「使い方」を見たい瞬間に登録ハードルを設けない
- **問い合わせ窓口は学習段階のため「未提供」と正直に記載**（架空の窓口を書かない）

## 検証

- [x] `npm run build` 成功（403 modules）
- [x] `npm test` 35/35 pass（テスト追加なし）
- [x] 実機 Chrome で `/help` を 9 セクション開閉確認済
- [x] トップ画面 + フッターの追加レンダリングを確認（既存 UI 崩れなし）
- [x] モバイル幅でも `LegalLayout` の `max-w-3xl` 設計に従い崩れなし

## 品質判定表

新規行 **UX-3 ヘルプ / FAQ ページ提供** を 1-5 セクションに追加し A 化。

Closes #494