### PR TITLE
feat: レビュー「もっと良くなる点」を任意化＋検索クリアで全件表示に戻す

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/review/ReviewService.java
@@ -77,7 +77,8 @@ public class ReviewService {
         review.setPostId(postId);
         review.setReviewerUserId(principal.userId());
         review.setGood(req.good());
-        review.setImprovement(req.improvement());
+        // #503：improvement は任意化。null/空文字いずれも DB の NOT NULL を満たすよう "" に正規化。
+        review.setImprovement(req.improvement() == null ? "" : req.improvement());
         review.setCreatedAt(now);
         review.setUpdatedAt(now);
         reviewRepository.save(review);
@@ -95,7 +96,7 @@ public class ReviewService {
         notificationService.notify(post.getAuthorUserId(), principal.userId(),
                 NotificationType.REVIEW_RECEIVED, postId, review.getId());
         // F-MENTION：レビュー本文（良かった点＋改善点）の @表示名 を同 cohort で解決し通知
-        notificationService.notifyMentions(req.good() + "\n" + req.improvement(),
+        notificationService.notifyMentions(req.good() + "\n" + (req.improvement() == null ? "" : req.improvement()),
                 principal.userId(), principal.cohortId(), postId, review.getId());
 
         User reviewer = userRepository.findById(principal.userId()).orElseThrow();
@@ -164,7 +165,8 @@ public class ReviewService {
     public ReviewResponse update(AuthPrincipal principal, Long reviewId, ReviewCreateRequest req) {
         Review review = ownedReview(principal, reviewId);
         review.setGood(req.good());
-        review.setImprovement(req.improvement());
+        // #503：improvement 任意化に伴い null/空文字を "" 正規化（編集時も同じ）。
+        review.setImprovement(req.improvement() == null ? "" : req.improvement());
         review.setUpdatedAt(OffsetDateTime.now());
 
         axisCommentRepository.deleteAll(axisCommentRepository.findByReviewId(reviewId));

--- a/review-board/backend/src/main/java/com/reviewboard/domain/review/dto/ReviewCreateRequest.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/review/dto/ReviewCreateRequest.java
@@ -9,11 +9,12 @@ import java.util.List;
 
 /**
  * レビュー作成リクエスト（F-REV-01）。
- * 「良かった点」「改善提案」は必須、観点別コメントは任意（初心者が全軸埋めなくてよい）。
+ * 「良かった点」は必須、「改善提案」「観点別コメント」は任意（書くハードルを下げる：#503）。
+ * 改善提案 null/空は Service で空文字に正規化（DB は NOT NULL のまま）。
  */
 public record ReviewCreateRequest(
         @NotBlank String good,
-        @NotBlank String improvement,
+        String improvement,
         @Valid List<AxisCommentInput> axisComments) {
 
     /** 観点別コメント1件。同じ軸は1回まで（Service で重複を弾く）。 */

--- a/review-board/frontend/src/components/ReviewForm.jsx
+++ b/review-board/frontend/src/components/ReviewForm.jsx
@@ -5,7 +5,7 @@ import { useDraft } from '../hooks/useDraft';
 import DraftNotice from './DraftNotice';
 import { getErrorMessage } from '../lib/errorMessages';
 
-// F-REV-01：良かった点・改善提案は必須、観点別コメント（4軸）は任意。
+// F-REV-01：良かった点のみ必須。改善提案・観点別コメント（4軸）は任意（#503：書くハードルを下げる）。
 // F-DRAFT-01：入力を localStorage に自動保存（postId 単位）し、再訪時に復元する。
 export default function ReviewForm({ postId, onCreated }) {
   const [good, setGood] = useState('');
@@ -69,10 +69,9 @@ export default function ReviewForm({ postId, onCreated }) {
         className="mac-input mb-3"
         rows={2}
       />
-      <label htmlFor="review-improvement" className="mac-label">💡 もっと良くなる点（必須）</label>
+      <label htmlFor="review-improvement" className="mac-label">💡 もっと良くなる点（任意）</label>
       <textarea
         id="review-improvement"
-        required
         value={improvement}
         onChange={(e) => setImprovement(e.target.value)}
         className="mac-input mb-3"

--- a/review-board/frontend/src/components/ReviewItem.jsx
+++ b/review-board/frontend/src/components/ReviewItem.jsx
@@ -169,10 +169,12 @@ export default function ReviewItem({ review, canThank, canManageGrowth, isOwner,
               <div className="mb-1 font-bold text-green-700">✅ 良かった点</div>
               <MarkdownText>{review.good}</MarkdownText>
             </div>
-            <div className="rounded-xl bg-gradient-to-br from-sky-50 to-indigo-50 p-4 text-sm leading-relaxed text-gray-700 ring-1 ring-sky-100">
-              <div className="mb-1 font-bold text-sky-700">💡 改善点</div>
-              <MarkdownText>{review.improvement}</MarkdownText>
-            </div>
+            {review.improvement?.trim() && (
+              <div className="rounded-xl bg-gradient-to-br from-sky-50 to-indigo-50 p-4 text-sm leading-relaxed text-gray-700 ring-1 ring-sky-100">
+                <div className="mb-1 font-bold text-sky-700">💡 改善点</div>
+                <MarkdownText>{review.improvement}</MarkdownText>
+              </div>
+            )}
             {review.axisComments?.length > 0 && (
               <ul className="space-y-1 rounded-xl bg-black/[0.02] p-3">
                 {review.axisComments.map((c) => (

--- a/review-board/frontend/src/pages/PostsPage.jsx
+++ b/review-board/frontend/src/pages/PostsPage.jsx
@@ -161,7 +161,12 @@ export default function PostsPage() {
             <input
               type="search"
               value={q}
-              onChange={(e) => setQ(e.target.value)}
+              onChange={(e) => {
+                const v = e.target.value;
+                setQ(v);
+                // #503：input が空になった瞬間に絞り込みを解除して全件表示に戻す
+                if (v === '') setApplied((p) => ({ ...p, q: '' }));
+              }}
               placeholder="作品・技術・観点で探す（例：React, API 設計）"
               style={{ outline: 'none' }}
               className="min-w-0 flex-1 bg-transparent px-3 py-2.5 text-sm text-gray-800 outline-none"


### PR DESCRIPTION
## Summary
- レビュー作成 API の \`improvement\` を任意化（@NotBlank 撤去、Service で null→\"\" に正規化）
- ReviewForm / ReviewItem のラベルを「（任意）」に、required を削除、空時は改善点ブロック非表示
- TOP（PostsPage）の検索 input が空になった瞬間に絞り込みを自動解除して全件表示に戻す

## Test plan
- [x] backend test（ReviewAuthorization / CohortReviewList）pass（ローカル）
- [ ] frontend：レビュー作成で improvement 空 → 201 が返る
- [ ] frontend：TOP の「講師の課題」タグ → 検索入力を空に → 全件（35）表示に戻る
- [ ] frontend：既存レビュー（improvement に文字あり）の表示が変わらない

Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)