### PR TITLE
chore: NEW_REPO_CHECKLIST 未完了3項目を整備（Tier移行ログ・Blackbox CI・scripts）

### DIFF
--- a/.github/workflows/term-board-blackbox.yml
+++ b/.github/workflows/term-board-blackbox.yml
@@ -1,0 +1,29 @@
+name: term-board Blackbox Check
+
+# term-board のブラックボックス化規律を CI で常設担保する。
+# 内部用語・固有フレーズがコミットに混入していないことを scripts/blackbox-check.sh で検証する。
+
+on:
+  pull_request:
+    paths:
+      - "term-board/**"
+      - ".github/workflows/term-board-blackbox.yml"
+  push:
+    branches: [main]
+    paths:
+      - "term-board/**"
+      - ".github/workflows/term-board-blackbox.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  blackbox:
+    name: Blackbox Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: ブラックボックス化検証（term-board スコープ）
+        working-directory: term-board
+        run: bash scripts/blackbox-check.sh

--- a/term-board/.gitignore
+++ b/term-board/.gitignore
@@ -13,3 +13,5 @@ npm-debug.log*
 # local env
 .env
 .env.local
+# blackbox ワードリスト（実際の禁止語はリポ外管理）
+scripts/blackbox-words.local.txt

--- a/term-board/docs/Tier移行ログ.md
+++ b/term-board/docs/Tier移行ログ.md
@@ -1,0 +1,52 @@
+# Tier 移行ログ
+
+このアプリのインフラ Tier 変更を時系列で記録する。
+> 関連：インフラ選択ガイド.md（リポジトリ外管理）・../GitHub運用方針.md
+
+---
+
+## 2026-05-27: 初期 Tier 確定
+
+- **採用 Tier**: Tier 0（GitHub Pages 静的配信）
+- **選定理由**: 全データを localStorage で完結させるフロントエンド専用 SPA のため、サーバー不要。GitHub Pages の無料枠で月次コスト 0 円。Node 24 LTS + Vite + React のみで完結。
+- **適用した防御**:
+  - [x] CLAUDE.md にプロジェクト概要・Tier 0・選定理由を記録
+  - [x] study-boards リポを public に固定（GitHub Pages の生命線）
+  - [x] GitHub Actions CI（build / test / gitleaks / CodeQL / E2E）を常設
+  - [x] `npm audit --audit-level=high` を CI に組み込み（依存脆弱性ゼロを担保）
+
+---
+
+## 移行記録テンプレ（コピーして使う）
+
+```markdown
+## YYYY-MM-DD: Tier X → Tier Y
+
+- **変更理由**: （何の要件 / 制約で変わったか）
+- **適用した防御**:
+  - [ ] CLAUDE.md の Tier フィールド更新
+  - [ ] 新 Tier の必須対策を インフラ選択ガイド.md §4 から漏れなく適用
+  - [ ] README の技術スタック更新
+  - [ ] 旧 Tier 固有のリソースを撤収（例：Supabase プロジェクト削除）
+- **追加した GitHub workflow**: （ある場合）
+- **削除した GitHub workflow**: （ある場合）
+- **無料枠への影響**: （新 Tier の上限と現状の見積もり）
+- **次に注意すべきこと**: （新 Tier 特有のリスク）
+```
+
+---
+
+## Tier 変更がよく起こるパターン
+
+機能追加 PR を書くとき、以下に該当しないか確認する：
+
+| 起きがちな変化 | トリガー要件 |
+|---|---|
+| Tier 0 → Tier 1 | 他人とデータ共有・認可が必要に |
+| Tier 1 → Tier 2 | Supabase プロジェクト 2/2 満杯 |
+| Tier 0/1 → Tier 2/3 | リアルタイム通信を入れたい |
+| Tier 0 → Tier 1（R2 併用） | ファイル保存・大容量 |
+| Tier 1/2 → Tier 3/4 | サーバーで定期処理を回したい |
+| Tier 1-3 → Tier 4 | 業務利用・SLA が要る |
+
+→ 該当したら、PR をマージする前にこのログに記録 → Tier 別防御を適用 → CLAUDE.md を更新。

--- a/term-board/scripts/blackbox-check.sh
+++ b/term-board/scripts/blackbox-check.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# ブラックボックス化検証スクリプト
+#
+# 用途:
+#   - ローカル: 任意のタイミングで実行（`bash scripts/blackbox-check.sh`）
+#   - pre-commit hook: `.git/hooks/pre-commit` から呼び出し（ステージ済ファイルのみ検査）
+#   - CI: GitHub Actions から呼び出し（リポ全体を検査）
+#
+# 引数:
+#   --staged  : git add 済みファイルのみ検査（pre-commit hook 用）
+#   （引数なし）: リポ全体の追跡対象 .md を検査
+
+set -euo pipefail
+
+MODE="${1:-all}"
+
+# 禁止語リスト（運用ガイドの対応表と一致させること）
+BANNED=(
+  "オールA"
+  "S軸宣言"
+  "S軸"
+  "PDCAS"
+  "品質4軸"
+  "卓越の戦略"
+  "ハイパワー・マーケティング"
+  "ハイパワー"
+  "庇護者"
+  "S基準"
+  "S判定表"
+  "S判定"
+  "A判定表"
+  "A判定"
+  "A基準"
+  "A床"
+  "弱点ゼロ"
+  "床割れ"
+  "床を割る"
+  "床を割らない"
+  "床は割れない"
+  "不要を持たない"
+  "短所を作らない"
+  "判断カード"
+  "派生元の原典"
+  "付録A_判定表"
+  "付録A判定表"
+  "母要件定義書"
+  "母§"
+  "母 §"
+  "母 S-"
+  "母 P-"
+  "母 M-"
+  "母 SEC-"
+)
+
+# --- 追加禁止語をリポ外管理ファイルから読み込む ---------------------------
+# 仕組み（このスクリプト）はリポに残すが、実際に隠したい語そのものは
+# gitignore 済みの外部ファイルに置く（公開リポに語の一覧を残さないため）。
+# 形式: 1行1語。# はコメント。「禁止語 => 代替表現」も可（=> 左側のみ採用）。
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOCAL_WORDS="${BLACKBOX_WORDS_FILE:-$SCRIPT_DIR/blackbox-words.local.txt}"
+if [ -f "$LOCAL_WORDS" ]; then
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line%%#*}"          # 行内コメントを除去
+    word="${line%%=>*}"         # 「=> 代替」形式は左側のみ
+    word="$(printf '%s' "$word" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    [ -n "$word" ] && BANNED+=("$word")
+  done < "$LOCAL_WORDS"
+fi
+
+# 検査対象ファイル一覧を取得
+# ※ scripts/blackbox-* と *-blackbox.yml はツール自身なので除外（自己参照防止）
+if [ "$MODE" = "--staged" ]; then
+  # pre-commit: ステージ済みかつテキストファイルのみ
+  FILES=$(git diff --cached --name-only --diff-filter=ACM \
+    | grep -E '\.(md|txt|yml|yaml|json|js|ts|tsx|jsx|py|java|gradle|sh|html|css)$' \
+    | grep -v 'scripts/blackbox' \
+    | grep -v '\-blackbox\.yml' \
+    || true)
+else
+  # 全体検査: 追跡対象のテキストファイル
+  FILES=$(git ls-files \
+    | grep -E '\.(md|txt|yml|yaml|json|js|ts|tsx|jsx|py|java|gradle|sh|html|css)$' \
+    | grep -v 'scripts/blackbox' \
+    | grep -v '\-blackbox\.yml' \
+    || true)
+fi
+
+if [ -z "$FILES" ]; then
+  echo "[blackbox-check] 検査対象ファイルなし — OK"
+  exit 0
+fi
+
+FOUND=0
+for kw in "${BANNED[@]}"; do
+  # ファイルごとに grep（バイナリ・存在しないファイル対策）
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    [ ! -f "$f" ] && continue
+    if grep -Fn "${kw}" "$f" >/dev/null 2>&1; then
+      echo "✘ 禁止語「${kw}」を検出: $f"
+      grep -Fn "${kw}" "$f" | head -3 | sed 's/^/    /'
+      FOUND=1
+    fi
+  done <<< "$FILES"
+done
+
+if [ $FOUND -ne 0 ]; then
+  echo ""
+  echo "==================================================================="
+  echo " ブラックボックス化規律違反 — コミット/プッシュをブロックしました"
+  echo "==================================================================="
+  echo " 対処: scripts/blackbox-replace.py で一般化語彙に置換するか、"
+  echo "       README.md の対応表に従って手動で書き換えてください。"
+  echo "==================================================================="
+  exit 1
+fi
+
+echo "[blackbox-check] 禁止語の残存なし — OK"
+exit 0

--- a/term-board/scripts/blackbox-replace.py
+++ b/term-board/scripts/blackbox-replace.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+ブラックボックス化規律違反の一括置換ヘルパー
+
+用途:
+  python3 scripts/blackbox-replace.py <path-or-glob> [<path-or-glob> ...]
+  python3 scripts/blackbox-replace.py docs/        # ディレクトリ再帰
+  python3 scripts/blackbox-replace.py --dry-run docs/要件定義書.md
+
+挙動:
+  - --dry-run: 置換対象を表示するだけ（書き換えない）
+  - 通常: ファイルを上書き
+"""
+
+import os, sys, pathlib
+
+# 置換ルール（長い順に並べる — substring 関係に注意）
+REPLACEMENTS = [
+    # 概念フレーズ（複合・長い順）
+    ("不要を持たない＝床割れリスク回避", "過剰機能を持たない＝品質低下リスク回避"),
+    ("不要を切って短所を作らない", "過剰機能を切って弱点を作らない"),
+    ("不要を持たない＝短所を作らない", "過剰機能を持たない＝弱点を作らない"),
+    ("便利さより安全＝不要を持たない", "便利さより安全＝過剰機能を持たない"),
+    ("床を割らない約束", "品質低下を許さない約束"),
+    ("不要な床割れリスク", "過剰機能による品質低下リスク"),
+    ("不要を持つと床割れリスク", "過剰機能を持つと品質低下リスク"),
+    ("派生元の原典", "共通の設計方針"),
+    # 章節参照
+    ("共通方針の§0-3・§4-1 第0項に従い", "共通方針の品質方針宣言に従い"),
+    ("共通の第2部 MUST 要件", "共通の品質指標群 MUST 要件"),
+    ("第3部 §3-1（ログ・監視・オブザーバビリティ）", "横断要件群 §3-1（ログ・監視・オブザーバビリティ）"),
+    ("「第3部 横断要件」", "「横断要件群」"),
+    ("第3部 横断要件", "横断要件群"),
+    ("第3部", "横断要件群"),
+    ("第2部", "品質指標群"),
+    # ファイル名・付録
+    ("付録A_判定表.md", "品質判定表.md"),
+    ("付録A判定表", "品質判定表"),
+    ("付録A ベースライン判定表／重点判定表", "品質判定表"),
+    ("付録A ベースライン判定表", "品質判定表"),
+    ("付録A 判定表", "品質判定表"),
+    ("付録ベースライン判定表.md", "品質判定表.md"),
+    ("付録ベースライン判定表", "品質判定表"),
+    # 母 → 共通方針
+    ("母要件定義書", "共通の設計方針"),
+    ("母「§", "共通方針「§"),
+    ("母 §", "共通方針 §"),
+    ("母§", "共通方針 §"),
+    # 概念単独
+    ("弱点ゼロの床", "全軸基準達成"),
+    ("弱点ゼロ", "全軸基準達成"),
+    ("床を割る", "品質低下を起こす"),
+    ("床は割れない", "品質低下は起きない"),
+    ("床割れリスク", "品質低下リスク"),
+    ("床割れ", "品質低下"),
+    ("判断カード", "設計判断資料"),
+    # 派生語（長い順）
+    ("S判定表", "重点判定表"),
+    ("A判定表", "ベースライン判定表"),
+    ("A基準", "ベースライン基準"),
+    ("S基準", "重点基準"),
+    ("S判定", "重点判定"),
+    ("A判定", "ベースライン判定"),
+    ("A床", "ベースライン床"),
+    # 大カテゴリ
+    ("S軸宣言", "重点軸宣言"),
+    ("S軸", "重点軸"),
+    ("オールA", "全軸ベースライン以上"),
+    ("PDCAS", "改善サイクル"),
+    ("品質4軸", "品質指標"),
+    ("卓越の戦略", "重点戦略"),
+    # 母 ID 接頭辞（最後）
+    ("母 S-", "S-"),
+    ("母 P-", "P-"),
+    ("母 M-", "M-"),
+    ("母 SEC-", "SEC-"),
+    ("母 F-", "F-"),
+    ("母 R-", "R-"),
+    ("母 C-", "C-"),
+    ("母S-", "S-"),
+    ("母P-", "P-"),
+    ("母M-", "M-"),
+    ("母SEC-", "SEC-"),
+]
+
+TEXT_EXTS = {".md", ".txt", ".yml", ".yaml", ".json", ".js", ".ts", ".tsx",
+             ".jsx", ".py", ".java", ".gradle", ".sh", ".html", ".css"}
+
+
+def collect_files(paths):
+    files = []
+    for p in paths:
+        path = pathlib.Path(p)
+        if path.is_dir():
+            for sub in path.rglob("*"):
+                if sub.is_file() and sub.suffix in TEXT_EXTS:
+                    files.append(sub)
+        elif path.is_file():
+            files.append(path)
+    return files
+
+
+def apply_to_file(path, dry_run=False):
+    try:
+        src = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return None
+    dst = src
+    counts = {}
+    for old, new in REPLACEMENTS:
+        c = dst.count(old)
+        if c:
+            counts[old] = c
+            dst = dst.replace(old, new)
+    if dst != src and not dry_run:
+        path.write_text(dst, encoding="utf-8")
+    return counts
+
+
+def main():
+    args = sys.argv[1:]
+    dry_run = False
+    if "--dry-run" in args:
+        dry_run = True
+        args.remove("--dry-run")
+    if not args:
+        print("usage: blackbox-replace.py [--dry-run] <path-or-dir> [...]")
+        sys.exit(2)
+
+    files = collect_files(args)
+    total_files = 0
+    total_replacements = 0
+    for f in files:
+        result = apply_to_file(f, dry_run)
+        if result:
+            total_files += 1
+            total_replacements += sum(result.values())
+            print(f"{'(dry) ' if dry_run else ''}{f}: {result}")
+
+    print(f"--- {total_files} files, {total_replacements} replacements"
+          f"{' (dry-run)' if dry_run else ''} ---")
+
+
+if __name__ == "__main__":
+    main()

--- a/term-board/scripts/blackbox-words.local.txt.example
+++ b/term-board/scripts/blackbox-words.local.txt.example
@@ -1,0 +1,13 @@
+# blackbox-words.local.txt.example — 形式見本（これはリポに入る・実語は書かない）
+#
+# 使い方:
+#   cp scripts/blackbox-words.local.txt.example scripts/blackbox-words.local.txt
+#   （.local.txt は .gitignore 済み。実際の禁止語はそちらにだけ書く）
+#
+# 形式:
+#   1行1語。空行と # 始まりの行は無視。
+#   「禁止語 => 一般化した代替表現」形式も可（=> の左側だけが検査対象）。
+#
+# 例（ダミー。実語ではない）:
+#   ExampleSecretName => 一般的な呼び方
+#   AnotherInternalTerm

--- a/term-board/scripts/install-hooks.sh
+++ b/term-board/scripts/install-hooks.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# git pre-commit hook をインストール
+#
+# 用途: 新規リポ立ち上げ時、または既存リポでフックを有効化したい時に1回だけ実行
+#       bash scripts/install-hooks.sh
+
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || {
+  echo "✘ git リポジトリではありません。先に 'git init' を実行してください。"
+  exit 1
+})
+
+HOOK_DIR="${REPO_ROOT}/.git/hooks"
+HOOK_FILE="${HOOK_DIR}/pre-commit"
+
+mkdir -p "$HOOK_DIR"
+
+cat > "$HOOK_FILE" <<'EOF'
+#!/usr/bin/env bash
+# ブラックボックス化 pre-commit hook
+# scripts/blackbox-check.sh を --staged モードで実行
+set -e
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+CHECK="${REPO_ROOT}/term-board/scripts/blackbox-check.sh"
+
+if [ -x "$CHECK" ]; then
+  bash "$CHECK" --staged
+else
+  echo "⚠ blackbox-check.sh が見つからない/実行不可。チェックをスキップ。"
+fi
+EOF
+
+chmod +x "$HOOK_FILE"
+chmod +x "${REPO_ROOT}/term-board/scripts/blackbox-check.sh"
+
+echo "✓ pre-commit hook をインストールしました: $HOOK_FILE"
+echo "  以降、'git commit' 時に自動でブラックボックス化検証が走ります。"
+echo "  バイパスする場合は git commit --no-verify （非推奨）"

--- a/term-board/src/api/termRepository.ts
+++ b/term-board/src/api/termRepository.ts
@@ -2,7 +2,7 @@ import type { Term, Progress, UserContent, ProfileDraft, LearningSession } from 
 
 // 要件定義書 §8-4「api/ 層の隔離（育つ設計の核）」。
 // 画面・フックは「データがどこから来るか」を知らず、このインタフェースだけに依存する。
-// MVP は localStorage 実装、Phase4 は http 実装に差し替えるだけで画面は無改修（母 M-11）。
+// MVP は localStorage 実装、Phase4 は http 実装に差し替えるだけで画面は無改修（M-11）。
 export interface TermRepository {
   // 出題用の用語（同梱 builtin ＋ ユーザー作問 quizTerms を統合して返す）。
   getTerms(): Promise<Term[]>;

--- a/term-board/src/components/QuizView.tsx
+++ b/term-board/src/components/QuizView.tsx
@@ -10,7 +10,7 @@ type Props = {
 };
 
 // 選択肢ボタンの見た目を、回答状態に応じて決める。
-// 母 P-9 / 受入条件: 正誤は「色のみに依存しない」ため記号（◯/✕）とテキストでも示す。
+// P-9 / 受入条件: 正誤は「色のみに依存しない」ため記号（◯/✕）とテキストでも示す。
 function optionClass(args: {
   answered: boolean;
   isThisCorrect: boolean;


### PR DESCRIPTION
## 概要

NEW_REPO_CHECKLIST.md の継続運用3項目を検証したところ 0/3 PASS だったため、まとめて整備する。

## 変更内容

### Phase 2: Tier移行ログ（❌ → ✅）

- `term-board/docs/Tier移行ログ.md` を新規作成
- 初期 Tier: **Tier 0（GitHub Pages 静的配信）**、確定日 2026-05-27
- Tier 変更パターン表・移行記録テンプレを同梱

### Phase 4: Blackbox Check CI（❌ → ✅）

- `term-board/scripts/blackbox-check.sh` を配置（--staged / 全体検査の2モード対応）
- `term-board/scripts/blackbox-replace.py` を配置（一括置換ヘルパー）
- `term-board/scripts/install-hooks.sh` を配置（pre-commit フック設置）
- `term-board/scripts/blackbox-words.local.txt.example` を配置（リポ外ワードリストの形式見本）
- `.github/workflows/term-board-blackbox.yml` を追加（term-board スコープで CI 常設）
- `term-board/.gitignore` に `scripts/blackbox-words.local.txt` を追加
- pre-commit フックをインストール済み（コミット前の自動検証が有効化された）

### 既存 term-board ファイルの修正

- `term-board/src/components/QuizView.tsx` 13行目: 内部接頭辞を除去
- `term-board/src/api/termRepository.ts` 5行目: 内部接頭辞を除去

### 自己参照問題の解決

blackbox-check.sh 自体が禁止語リストを含むため、`scripts/blackbox-*` と `*-blackbox.yml` を検査対象から除外するよう修正済み。

## Phase 6（ブランチ保護）について

Blackbox Check CI が本 PR の CI で green になった後、別途 `gh api` コマンドでブランチ保護を設定する（required_status_checks に追加）。

## テスト

- ローカル: `cd term-board && bash scripts/blackbox-check.sh` → OK
- pre-commit: コミット実行時に自動で通過確認済み

Closes #515