### PR TITLE
chore: review-board CD アーティファクトの storage 肥大を抑制（S3未配線時のみGitHubフォールバック・保持7日）

### DIFF
--- a/.github/workflows/review-board-cd-build.yml
+++ b/.github/workflows/review-board-cd-build.yml
@@ -106,16 +106,8 @@ jobs:
           } > "artifact/$TAG/MANIFEST.txt"
           ls -lR "artifact/$TAG" | head -40
 
-      - name: アーティファクトをアップロード（不変・SHA 名）
-        uses: actions/upload-artifact@v4
-        with:
-          name: review-board-${{ steps.meta.outputs.tag }}
-          path: artifact/${{ steps.meta.outputs.tag }}/
-          retention-days: 30
-          if-no-files-found: error
-
       # AWS 認証とアーティファクトバケットが設定済みなら、S3 にも push（EC2 の deploy.sh が取得）。
-      # 未設定（S-2 前）なら GitHub Artifact のみで、以降の step はスキップする。
+      # 未設定（S-2 前）なら GitHub Artifact をフォールバックとして短期保持する。
       # 注意: `if:` 条件で secrets コンテキストは参照不可（startup_failure になる）。
       #       secret は env へ写してから guard step の出力で判定する（cd-deploy と同方式）。
       - name: 前提チェック（CD 認証が無ければ S3 push をスキップ）
@@ -128,8 +120,20 @@ jobs:
             echo "ready=true" >> "$GITHUB_OUTPUT"
           else
             echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "RB_CD_AWS_ACCESS_KEY_ID または RB_ARTIFACTS_BUCKET 未設定のため S3 push はスキップ（GitHub Artifact のみ）。" >> "$GITHUB_STEP_SUMMARY"
+            echo "RB_CD_AWS_ACCESS_KEY_ID または RB_ARTIFACTS_BUCKET 未設定のため S3 push はスキップ（GitHub Artifact フォールバックのみ）。" >> "$GITHUB_STEP_SUMMARY"
           fi
+
+      # #523 storage 肥大対策：GitHub Artifact は S3 配布が未配線のときだけの「フォールバック」。
+      # デプロイは S3 経由（cd-deploy は GitHub Artifact を download しない）ため、S3 が唯一の不変ソース
+      # になったら GitHub へは upload しない。フォールバック時も保持を 7 日に短縮し storage 累積を抑える。
+      - name: アーティファクトをアップロード（S3未配線時のフォールバック・7日保持）
+        if: steps.guard.outputs.ready != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: review-board-${{ steps.meta.outputs.tag }}
+          path: artifact/${{ steps.meta.outputs.tag }}/
+          retention-days: 7
+          if-no-files-found: error
 
       - name: アーティファクトを S3 に push（認証時のみ）
         if: steps.guard.outputs.ready == 'true'


### PR DESCRIPTION
## 関連 Issue

Closes #523

---

## 変更の概要

GitHub の従量課金（metered usage）の主因だった `review-board-cd-build.yml` の不変アーティファクト `review-board-<sha>`（≈68MB・保持30日）の累積を抑制する。

- GitHub Artifact への upload を **「S3 配布が未配線のときだけのフォールバック」** に条件化（`if: steps.guard.outputs.ready != 'true'`）
- フォールバック時の **保持を 30 → 7 日**に短縮
- そのため guard step を upload の前に移動（step 順序：固める→guard→条件付きupload→S3 push→ドリフト検知）

## なぜ実害がないか

- デプロイ（`review-board-cd-deploy.yml`）は **S3 経由**でビルドを取得し、**GitHub Artifact を一切 download しない**（`download-artifact` 0件）。GitHub 側アーティファクトはデプロイ未使用の冗長コピー。
- テストは `review-board-ci.yml`（PR＋push で `gradlew test`＋jacoco）が別途担保。
- **GitHub Pages（term-board）とは別系統**で無関係。`term-board-pages.yml` は無変更。
- 不変アーティファクト／手動承認ゲート／S3 push／ドリフト検知の思想・挙動は維持。

## 変更の種別

- [x] chore（設定・ツールの変更）

---

## 動作確認チェックリスト

- [x] YAML 構文・step 順序を検証（ruby YAML パース）
- [x] 既存の機能が壊れていないことを確認した（test-gate・S3 push・ドリフト検知の条件は不変）
- [x] `.env` ファイルやパスワードをコミットしていない

---

## レビュー時に特に確認してほしい点（任意）

- S3 を将来配線（`RB_CD_AWS_*` / `RB_ARTIFACTS_BUCKET` 設定）したら、GitHub Artifact upload は自動でスキップされ S3 が唯一の不変ソースになる設計でよいか。
- 既存アーティファクト（約3.7GB）の削除は本 PR の対象外（別途・要承認）。
