### PR TITLE
chore: ブラックボックス検知の基盤強化（quotepath修正＋リポ全体監査の常設）

### DIFF
--- a/.github/workflows/repo-blackbox-audit.yml
+++ b/.github/workflows/repo-blackbox-audit.yml
@@ -1,0 +1,44 @@
+name: repo-wide Blackbox Audit
+
+# リポ全体（全アプリ）のブラックボックス化規律を監査する。
+# 既存の term-board 限定 `Blackbox Check`（必須）と違い、本ワークフローは
+# review-board・他アプリも含めて走査する。
+#
+# 段階移行中は「非ブロッキング（情報提供）」。違反があっても job は失敗させず、
+# 検出結果を Step Summary に出すだけにする（必須チェックには含めない）。
+# review-board 等の既存違反を 0 に潰したら、本 job を fail させ必須へ昇格する（#526）。
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Blackbox Audit (repo-wide, 非ブロッキング)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: リポ全体のブラックボックス監査（検知のみ・段階移行中）
+        run: |
+          set -uo pipefail
+          if bash term-board/scripts/blackbox-check.sh > audit.log 2>&1; then
+            echo "## ✅ リポ全体クリーン（ブラックボックス違反なし）" >> "$GITHUB_STEP_SUMMARY"
+            cat audit.log
+          else
+            COUNT=$(grep -c '✘' audit.log || true)
+            {
+              echo "## ⚠️ ブラックボックス違反を検知（段階移行中・非ブロッキング）"
+              echo ""
+              echo "**検出 ${COUNT} 件**。マージはブロックしない（必須チェックは別）。順次解消し、0 になったら本監査を必須へ昇格する（#526）。"
+              echo ""
+              echo '```'
+              grep '✘' audit.log | head -100
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            cat audit.log
+          fi

--- a/term-board/scripts/blackbox-check.sh
+++ b/term-board/scripts/blackbox-check.sh
@@ -69,16 +69,19 @@ fi
 
 # 検査対象ファイル一覧を取得
 # ※ scripts/blackbox-* と *-blackbox.yml はツール自身なので除外（自己参照防止）
+# 注: `-c core.quotepath=false` が必須。これが無いと git は非ASCIIパスを
+#     `"...\350\246\201...md"` とクォート出力し、末尾が `"` になるため拡張子フィルタ
+#     `\.md$` に外れ、日本語名ファイル（要件定義書.md 等）がサイレントに検査対象外になる。
 if [ "$MODE" = "--staged" ]; then
   # pre-commit: ステージ済みかつテキストファイルのみ
-  FILES=$(git diff --cached --name-only --diff-filter=ACM \
+  FILES=$(git -c core.quotepath=false diff --cached --name-only --diff-filter=ACM \
     | grep -E '\.(md|txt|yml|yaml|json|js|ts|tsx|jsx|py|java|gradle|sh|html|css)$' \
     | grep -v 'scripts/blackbox' \
     | grep -v '\-blackbox\.yml' \
     || true)
 else
   # 全体検査: 追跡対象のテキストファイル
-  FILES=$(git ls-files \
+  FILES=$(git -c core.quotepath=false ls-files \
     | grep -E '\.(md|txt|yml|yaml|json|js|ts|tsx|jsx|py|java|gradle|sh|html|css)$' \
     | grep -v 'scripts/blackbox' \
     | grep -v '\-blackbox\.yml' \


### PR DESCRIPTION
## 関連 Issue

Closes #526

## 変更の概要

ブラックボックス検知の2つの穴を塞ぐ基盤強化。

1. **quotepath バグ修正**：`blackbox-check.sh` の git 呼び出しを `git -c core.quotepath=false` に。非ASCIIパスがクォートされ拡張子フィルタに外れることで、**日本語名ファイル（要件定義書.md 等29件）がサイレントに未検査**だったのを修正。
2. **リポ全体監査を新設**（`repo-blackbox-audit.yml`）：term-board 限定だった検査を**全アプリへ拡張**。段階移行のため**非ブロッキング（情報提供）**で常設し、違反一覧を Step Summary に出す。

## なぜ非ブロッキングか

既存の必須 `Blackbox Check`（term-board・green）をいきなり全リポ走査にすると、review-board の既存違反 約95件で即赤→全PRブロックになる。まず検知を常設し、95件を順次解消（別Issue）→ 0 になったら本監査を必須へ昇格する段階移行。

## 検証

- term-board スコープ：clean（必須 Blackbox Check は green 維持）
- リポ全体：95件を検知（非ブロッキングで可視化）
- 日本語名 .md 29件が検査対象に復帰
- 新 workflow YAML 構文 OK

## 変更の種別

- [x] chore（設定・ツールの変更）
