### PR TITLE
chore: 必須チェックのパスフィルタ・デッドロックを解消（全PRで必ず走る）

### DIFF
--- a/.github/workflows/term-board-blackbox.yml
+++ b/.github/workflows/term-board-blackbox.yml
@@ -4,10 +4,10 @@ name: term-board Blackbox Check
 # 内部用語・固有フレーズがコミットに混入していないことを scripts/blackbox-check.sh で検証する。
 
 on:
+  # #525: Blackbox Check は必須チェック。全PRで必ず報告される必要があるため
+  #       pull_request の paths フィルタを外す（term-board 非対象PRでも term-board スコープを
+  #       検査して green になり、必須条件のデッドロックを防ぐ）。
   pull_request:
-    paths:
-      - "term-board/**"
-      - ".github/workflows/term-board-blackbox.yml"
   push:
     branches: [main]
     paths:

--- a/.github/workflows/term-board-ci.yml
+++ b/.github/workflows/term-board-ci.yml
@@ -4,10 +4,10 @@ name: term-board CI
 # 型チェック＋本番ビルドの成功、単体テスト（Vitest）、依存脆弱性 High/Critical 0件を常設で担保する。
 
 on:
+  # #525: build-and-audit は必須チェック。全PRで必ず報告される必要があるため
+  #       pull_request の paths フィルタを外す（term-board 非対象PRでも term-board を
+  #       ビルドして green になり、必須条件が満たされずマージ不可になるデッドロックを防ぐ）。
   pull_request:
-    paths:
-      - "term-board/**"
-      - ".github/workflows/term-board-ci.yml"
   push:
     branches: [main]
     paths:

--- a/.github/workflows/term-board-gitleaks.yml
+++ b/.github/workflows/term-board-gitleaks.yml
@@ -1,4 +1,4 @@
-name: term-board Secret Scan (gitleaks / S軸)
+name: term-board Secret Scan (gitleaks)
 
 # ============================================================
 # 機密情報の server-side スキャン（最後の防衛線）。
@@ -6,18 +6,17 @@ name: term-board Secret Scan (gitleaks / S軸)
 #
 # 目的: GitHub Web 編集 / `git commit --no-verify` 等、ローカル hook を
 #       バイパスする経路を塞ぐ。task-board の平文パスワード Public コミット
-#       事故（不可逆）と同型の再発防止（S軸の核）。
+#       事故（不可逆）と同型の再発防止（安全性の核）。
 #
 # 方式: バージョン固定の gitleaks で term-board ツリーを走査。設定は
 #       リポジトリルートの .gitleaks.toml を review-board と共用する。
 # ============================================================
 
 on:
+  # #525: secret-scan は必須チェック。全PRで必ず報告される必要があるため
+  #       pull_request の paths フィルタを外す（非対象PRでも走って green になり、
+  #       必須条件が満たされずマージ不可になるデッドロックを防ぐ）。
   pull_request:
-    paths:
-      - 'term-board/**'
-      - '.gitleaks.toml'
-      - '.github/workflows/term-board-gitleaks.yml'
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## 関連 Issue

Closes #525

## 変更の概要

必須チェック `build-and-audit` / `secret-scan` / `Blackbox Check` は全て term-board パス専用だったため、**term-board を触らない PR（review-board・workflow のみ等）では1つも起動せず、必須条件が永久に満たされずマージ不可（デッドロック）**になっていた（PR #524 は admin マージを強いられた）。

3ワークフロー（term-board-ci / term-board-blackbox / term-board-gitleaks）の `pull_request` パスフィルタを外し、**全PRで必ず走って報告**されるようにする。

- public リポなので Actions の分は無料。各ジョブは無関係PRでも term-board をビルド/検査して green になる。
- これで admin バイパス無しで通常マージできる。
- `push` トリガのパスは据え置き（PR チェックが満たされれば十分）。

あわせて、検知の作動により判明した `term-board-gitleaks.yml` の内部語「S軸」を一般化（#528 の一部）。

## 検証

- 3ファイルとも `pull_request.paths` を除去（YAMLパースで確認）
- pre-commit blackbox-check 通過（quotepath修正後のフックが S軸 を検出→一般化で解消）

## 変更の種別

- [x] chore（設定・ツールの変更）

## 確認してほしい点

- このPR自体が「workflow のみ変更」だが、新設定により必須3チェックが起動し **admin 無しで通常マージできる**ことの実証になる。
