### PR TITLE
feat: 4択クイズを PC で質問＝左／解説＝右の2カラムにする

### DIFF
--- a/term-board/src/App.tsx
+++ b/term-board/src/App.tsx
@@ -130,7 +130,7 @@ export default function App() {
               <div className="mb-3">
                 <LevelSelector value={levelState.level} onChange={levelState.setLevel} />
               </div>
-              <div className="hig-card mb-5 flex items-center justify-between px-4 py-3 text-sm">
+              <div className="hig-card mb-5 flex items-center justify-between gap-4 px-4 py-3 text-sm lg:justify-center lg:gap-12">
                 <span className="text-label-2">解答数 <span className="font-bold text-label">{quiz.answeredCount}</span></span>
                 <span className="text-label-2">正答 <span className="font-bold text-emerald-700 dark:text-emerald-400">{quiz.correctCount}</span></span>
                 <span className="text-label-2">正答率 <span className="font-bold text-accent">{rate}%</span></span>
@@ -186,10 +186,10 @@ export default function App() {
     </>
   );
 
-  // ホームのみ PC で広いコンテンツ幅にして、4列カンバンの横レイアウトを活かす。
+  // PC で横幅を活かすビュー：ホーム（4列カンバン）と4択クイズ（質問＝左／解説＝右の2カラム）。
   // 他ビュー（辞典・面接練習など）は本文の可読幅を優先して従来の max-w-2xl を維持。
-  const wideHome = view === "home";
-  const mainWidth = wideHome ? "max-w-6xl" : "max-w-2xl";
+  const wideView = view === "home" || view === "quiz";
+  const mainWidth = view === "home" ? "max-w-6xl" : wideView ? "max-w-5xl" : "max-w-2xl";
   // ヘッダーはビュー切替で幅が動くと違和感が出るため、常に広い幅で固定。
   const headerWidth = sidebar ? "max-w-5xl" : "max-w-6xl";
 

--- a/term-board/src/components/QuizView.tsx
+++ b/term-board/src/components/QuizView.tsx
@@ -67,82 +67,103 @@ export function QuizView({ question, selected, isCorrect, onAnswer, onNext }: Pr
   const answered = selected !== null;
 
   return (
-    <section className="flex flex-col gap-5" aria-live="polite">
-      <div className="hig-card p-6">
-        <p className="text-sm font-medium text-accent">{question.term.category}</p>
-        <h2 className="mt-1 text-2xl font-bold tracking-tight text-label">
-          「{question.term.term}」の意味は？
-        </h2>
+    // PC（lg〜）は「左＝質問＋選択肢／右＝正解＋解説」の2カラムにして、
+    // 回答後に下までスクロールせず横並びで読めるようにする。モバイルは従来どおり縦積み。
+    <section
+      className="flex flex-col gap-5 lg:grid lg:grid-cols-2 lg:items-start lg:gap-6"
+      aria-live="polite"
+    >
+      {/* 左：質問＋選択肢 */}
+      <div className="flex flex-col gap-5">
+        <div className="hig-card p-6">
+          <p className="text-sm font-medium text-accent">{question.term.category}</p>
+          <h2 className="mt-1 text-2xl font-bold tracking-tight text-label">
+            「{question.term.term}」の意味は？
+          </h2>
+        </div>
+
+        <ul className="flex flex-col gap-3">
+          {question.options.map((opt) => {
+            const isThisCorrect = opt === question.answer;
+            const isThisSelected = opt === selected;
+            return (
+              <li key={opt}>
+                <button
+                  type="button"
+                  disabled={answered}
+                  onClick={() => onAnswer(opt)}
+                  className={optionClass({ answered, isThisCorrect, isThisSelected })}
+                >
+                  {answered && (
+                    <span aria-hidden="true" className="shrink-0 text-lg font-bold">
+                      {isThisCorrect ? "◯" : isThisSelected ? "✕" : "　"}
+                    </span>
+                  )}
+                  <span>{opt}</span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
       </div>
 
-      <ul className="flex flex-col gap-3">
-        {question.options.map((opt) => {
-          const isThisCorrect = opt === question.answer;
-          const isThisSelected = opt === selected;
-          return (
-            <li key={opt}>
-              <button
-                type="button"
-                disabled={answered}
-                onClick={() => onAnswer(opt)}
-                className={optionClass({ answered, isThisCorrect, isThisSelected })}
-              >
-                {answered && (
-                  <span aria-hidden="true" className="shrink-0 text-lg font-bold">
-                    {isThisCorrect ? "◯" : isThisSelected ? "✕" : "　"}
-                  </span>
-                )}
-                <span>{opt}</span>
-              </button>
-            </li>
-          );
-        })}
-      </ul>
-
-      {answered && (
-        <div className="hig-card p-6">
-          <p
-            className={`text-lg font-bold ${
-              isCorrect ? "text-emerald-700 dark:text-emerald-400" : "text-rose-700 dark:text-rose-400"
-            }`}
-          >
-            {isCorrect ? "◯ 正解！" : "✕ 不正解"}
-          </p>
-          {question.term.plainMeaning && (
-            <div className="mt-3 rounded-xl bg-sky-50 p-3 ring-1 ring-sky-100 dark:bg-sky-950 dark:ring-sky-900">
-              <p className="text-sm leading-relaxed text-label">
-                <span className="font-semibold text-accent">かんたんに言うと：</span>
-                {question.term.plainMeaning}
-              </p>
-            </div>
-          )}
-          <p className="mt-2 text-sm leading-relaxed text-label-2">
-            <span className="font-semibold text-label">正しい意味：</span>
-            {question.answer}
-          </p>
-          <p className="mt-2 text-sm leading-relaxed text-label-2">
-            <span className="font-semibold text-label">面接での言い方：</span>
-            {question.term.interview}
-          </p>
-          {question.term.scene && (
-            <p className="mt-2 text-sm leading-relaxed text-label-2">
-              <span className="font-semibold text-label">現場では：</span>
-              {question.term.scene}
+      {/* 右：正解＋解説。モバイルは回答後にこの下段が現れる。
+          PC は回答前から枠を確保（レイアウトが飛ばない）＋スクロール追従。 */}
+      <div className={`${answered ? "" : "hidden lg:block"} lg:sticky lg:top-4`}>
+        {answered ? (
+          <div className="hig-card p-6">
+            <p
+              className={`text-lg font-bold ${
+                isCorrect ? "text-emerald-700 dark:text-emerald-400" : "text-rose-700 dark:text-rose-400"
+              }`}
+            >
+              {isCorrect ? "◯ 正解！" : "✕ 不正解"}
             </p>
-          )}
-          {question.term.followUps && question.term.followUps.length > 0 && (
-            <FollowUpChain key={question.term.id} items={question.term.followUps} />
-          )}
-          <button
-            type="button"
-            onClick={onNext}
-            autoFocus
-            className="hig-btn-primary mt-4 px-5 py-2.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-          >
-            次の問題 →
-          </button>
-        </div>
-      )}
+            {question.term.plainMeaning && (
+              <div className="mt-3 rounded-xl bg-sky-50 p-3 ring-1 ring-sky-100 dark:bg-sky-950 dark:ring-sky-900">
+                <p className="text-sm leading-relaxed text-label">
+                  <span className="font-semibold text-accent">かんたんに言うと：</span>
+                  {question.term.plainMeaning}
+                </p>
+              </div>
+            )}
+            <p className="mt-2 text-sm leading-relaxed text-label-2">
+              <span className="font-semibold text-label">正しい意味：</span>
+              {question.answer}
+            </p>
+            <p className="mt-2 text-sm leading-relaxed text-label-2">
+              <span className="font-semibold text-label">面接での言い方：</span>
+              {question.term.interview}
+            </p>
+            {question.term.scene && (
+              <p className="mt-2 text-sm leading-relaxed text-label-2">
+                <span className="font-semibold text-label">現場では：</span>
+                {question.term.scene}
+              </p>
+            )}
+            {question.term.followUps && question.term.followUps.length > 0 && (
+              <FollowUpChain key={question.term.id} items={question.term.followUps} />
+            )}
+            <button
+              type="button"
+              onClick={onNext}
+              autoFocus
+              className="hig-btn-primary mt-4 px-5 py-2.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              次の問題 →
+            </button>
+          </div>
+        ) : (
+          // PC のみ：回答前のプレースホルダ（右カラムの枠を確保し、回答時のガタつきを防ぐ）。
+          <div className="hig-card flex min-h-[16rem] items-center justify-center p-6 text-center">
+            <p className="text-sm leading-relaxed text-label-3">
+              選択肢を選ぶと、ここに
+              <br />
+              正解と解説が表示されます。
+            </p>
+          </div>
+        )}
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## 関連 Issue

Closes #541

---

## 変更の概要

4択クイズは回答後の解説が選択肢の下に出るため、PC では下までスクロールが必要だった。横幅を活かして **PC（lg〜）で「左＝質問＋選択肢／右＝正解・解説」の2カラム**に分割し、深掘りチェーンまで1画面で読めるようにした（ノースクロール）。

- `QuizView`：`lg` 以上で2カラム grid 化。回答前は右側にガイド枠（「選択肢を選ぶと、ここに正解と解説が表示されます。」）を出してレイアウトのガタつきを防止。解説は `lg:sticky` でスクロール追従。
- モバイル：従来どおり縦積み（質問→選択肢→回答後に解説）。**体験は不変**。
- `App`：クイズ画面の幅を PC で `max-w-5xl` に拡張。解答数バーは PC で中央寄せ。

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（Chrome DevTools：PC 1280px で横並び・1画面に収まる／モバイル 390px で従来の縦積み）
- [x] 既存の機能が壊れていないことを確認した（lint 0/0・test 33件・build green）
- [x] `.env` ファイルやパスワードをコミットしていない

---

## スクリーンショット

- PC（回答後）：左に質問＋選択肢（正解を緑でハイライト）、右に「正解！」＋かんたんに言うと／正しい意味／面接での言い方／現場では／深掘りチェーン／次の問題。スクロールなしで収まる。
- モバイル：従来どおり縦1カラム。