### PR TITLE
feat: 暗記カードのレイアウト改善（PCで適度に拡大・モバイルに学習サポート）

### DIFF
--- a/term-board/src/App.tsx
+++ b/term-board/src/App.tsx
@@ -159,8 +159,9 @@ export default function App() {
           </div>
           <CardView level={levelState.level} />
           {/* #519: 暗記カードの学習サポート（進捗・苦手）はカードの「下」に配置。
-              横サイドパネル案は読みづらく却下されたため下配置に変更（モバイル体験は変えず PC 限定）。 */}
-          <div className="mt-6 hidden lg:block">
+              横サイドパネル案は読みづらく却下されたため下配置に。
+              モバイルでも表示（縦積み）／PC は3枚を横並び。 */}
+          <div className="mt-6">
             <StudyProgressPanel layout="row" />
           </div>
         </>
@@ -186,10 +187,14 @@ export default function App() {
     </>
   );
 
-  // PC で横幅を活かすビュー：ホーム（4列カンバン）と4択クイズ（質問＝左／解説＝右の2カラム）。
+  // PC で横幅を活かすビュー：ホーム（4列カンバン）・4択クイズ（質問＝左／解説＝右の2カラム）・
+  // 暗記カード（余白を抑えてカードを大きく見せる）。
   // 他ビュー（辞典・面接練習など）は本文の可読幅を優先して従来の max-w-2xl を維持。
-  const wideView = view === "home" || view === "quiz";
-  const mainWidth = view === "home" ? "max-w-6xl" : wideView ? "max-w-5xl" : "max-w-2xl";
+  const mainWidth =
+    view === "home" ? "max-w-6xl"
+    : view === "quiz" ? "max-w-5xl"
+    : view === "card" ? "max-w-4xl"
+    : "max-w-2xl";
   // ヘッダーはビュー切替で幅が動くと違和感が出るため、常に広い幅で固定。
   const headerWidth = sidebar ? "max-w-5xl" : "max-w-6xl";
 

--- a/term-board/src/components/CardView.tsx
+++ b/term-board/src/components/CardView.tsx
@@ -165,11 +165,13 @@ export function CardView({ level }: Props) {
           </p>
 
           {/* カード本体（クリックで裏返す） */}
+          {/* PC では横幅（max-w-4xl）と表面の文字を拡大して余白を活かす。
+              高さは控えめ（lg:min-h-72）にして、下の学習サポートまでスクロールせず収まるようにする。 */}
           <button
             type="button"
             onClick={() => setFlipped((f) => !f)}
             aria-pressed={flipped}
-            className="hig-card min-h-56 w-full p-6 text-left transition hover:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            className="hig-card flex min-h-56 w-full flex-col p-6 text-left transition hover:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent lg:min-h-72 lg:p-8"
           >
             <div className="flex items-center gap-2">
               <span className="text-sm font-medium text-accent">{current.category}</span>
@@ -178,26 +180,27 @@ export function CardView({ level }: Props) {
               )}
             </div>
             {!flipped ? (
-              <div className="mt-6 flex flex-col items-center justify-center gap-2 text-center">
-                <p className="text-3xl font-bold text-label">{current.term}</p>
-                <p className="text-xs text-label-2">タップで意味を見る</p>
+              // flex-1 で縦方向に中央寄せし、大きくなったカードの中心に用語を据える。
+              <div className="flex flex-1 flex-col items-center justify-center gap-3 text-center">
+                <p className="text-3xl font-bold text-label lg:text-5xl">{current.term}</p>
+                <p className="text-xs text-label-2 lg:text-sm">タップで意味を見る</p>
               </div>
             ) : (
-              <div className="mt-3 flex flex-col gap-2">
-                <p className="text-lg font-bold text-label">{current.term}</p>
+              <div className="mt-4 flex flex-col gap-2 lg:mt-6 lg:gap-3">
+                <p className="text-lg font-bold text-label lg:text-2xl">{current.term}</p>
                 {current.plainMeaning && (
-                  <p className="text-sm leading-relaxed text-label">
+                  <p className="text-sm leading-relaxed text-label lg:text-base">
                     <span className="font-semibold text-accent">かんたんに：</span>
                     {current.plainMeaning}
                   </p>
                 )}
-                <p className="text-sm leading-relaxed text-label-2">
+                <p className="text-sm leading-relaxed text-label-2 lg:text-base">
                   <span className="font-semibold text-label">意味：</span>
                   {current.meaning}
                 </p>
                 {/* Flashcard は interview を持たない（空文字）ため、ある時だけ表示。 */}
                 {current.interview && (
-                  <p className="text-sm leading-relaxed text-label-2">
+                  <p className="text-sm leading-relaxed text-label-2 lg:text-base">
                     <span className="font-semibold text-label">面接での言い方：</span>
                     {current.interview}
                   </p>

--- a/term-board/src/components/SidePanels.tsx
+++ b/term-board/src/components/SidePanels.tsx
@@ -5,7 +5,7 @@ import { repository } from "../api";
 // #519: 暗記カードの「下」に置く学習サポート（進捗・苦手）。
 // 横サイドパネル案（クイズ深掘り・辞典ナビ）は「読みづらい」と却下されたため、
 // 暗記カードのサポートのみ採用し、配置は右側ではなくカード下に変更した。
-// PC（lg+）限定で表示し、モバイル体験は変えない。
+// モバイル・PC とも表示する（モバイルは縦積み、PC は3枚を横並び）。
 
 // 連続学習日数（DashboardView と同じロジックの軽量版）。
 function calcStreak(days: string[]): number {
@@ -65,8 +65,8 @@ export function StudyProgressPanel({ layout = "column" }: { layout?: "column" | 
       .slice(0, 3);
   }, [terms, progress]);
 
-  // 下配置（row）では3枚を横並び、サイド配置（column）では縦積み。
-  const cardsCls = layout === "row" ? "grid grid-cols-3 gap-3" : "flex flex-col gap-3";
+  // 下配置（row）はモバイルで縦積み・PC（sm+）で3枚を横並び。column は常に縦積み。
+  const cardsCls = layout === "row" ? "grid grid-cols-1 gap-3 sm:grid-cols-3" : "flex flex-col gap-3";
 
   return (
     <div className="flex flex-col gap-3">


### PR DESCRIPTION
## 関連 Issue

Closes #543

---

## 変更の概要

暗記カードを2点改善した。

1. **PC の余白過多を解消**：コンテンツ幅を `max-w-2xl` → `max-w-4xl` に拡張し、カードを `lg:min-h-72`・`lg:p-8`・表面の用語を `lg:text-5xl` に拡大。**高さは控えめにして、下の学習サポートまでノースクロールで収まる範囲**に調整（当初 `lg:min-h-[26rem]` は大きすぎてスクロールが必要だったため縮小）。モバイルのカードサイズは不変。
2. **モバイルに学習サポートを追加**：これまで `hidden lg:block` で PC 限定だった学習サポート（連続学習／カバレッジ／苦手な用語）をモバイルでも表示。`SidePanels` の row レイアウトを **モバイル＝縦積み（`grid-cols-1`）／PC＝3枚横並び（`sm:grid-cols-3`）** に。

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（Chrome DevTools：PC 1280×860 でカード＋学習サポートが**スクロールなしで全表示**／モバイル 390px で学習サポートが縦積み表示・カードは従来サイズ）
- [x] 既存の機能が壊れていないことを確認した（lint 0/0・build green）
- [x] `.env` ファイルやパスワードをコミットしていない