### PR TITLE
feat: 用語辞典を PC で2カラム表示にしてスクロールを短縮

### DIFF
--- a/term-board/src/App.tsx
+++ b/term-board/src/App.tsx
@@ -188,12 +188,13 @@ export default function App() {
   );
 
   // PC で横幅を活かすビュー：ホーム（4列カンバン）・4択クイズ（質問＝左／解説＝右の2カラム）・
-  // 暗記カード（余白を抑えてカードを大きく見せる）。
-  // 他ビュー（辞典・面接練習など）は本文の可読幅を優先して従来の max-w-2xl を維持。
+  // 暗記カード（余白を抑えてカードを大きく見せる）・用語辞典（2カラムでスクロールを短縮）。
+  // 他ビュー（面接練習など）は本文の可読幅を優先して従来の max-w-2xl を維持。
   const mainWidth =
     view === "home" ? "max-w-6xl"
     : view === "quiz" ? "max-w-5xl"
     : view === "card" ? "max-w-4xl"
+    : view === "dictionary" ? "max-w-5xl"
     : "max-w-2xl";
   // ヘッダーはビュー切替で幅が動くと違和感が出るため、常に広い幅で固定。
   const headerWidth = sidebar ? "max-w-5xl" : "max-w-6xl";

--- a/term-board/src/components/DictionaryView.tsx
+++ b/term-board/src/components/DictionaryView.tsx
@@ -137,11 +137,13 @@ export function DictionaryView({ bookmarks, level }: Props) {
         )}
       </div>
 
-      <ul className="flex flex-col gap-2">
+      {/* PC（md〜）は2カラムにして縦スクロールを約半分に。展開時の高さ差で
+          隣のカードが伸びないよう items-start（自然な高さ）にする。 */}
+      <ul className="grid grid-cols-1 gap-2 md:grid-cols-2 md:items-start">
         {filtered.map((t) => {
           const open = isOpen(t.id);
           return (
-            <li key={t.id} className="hig-card">
+            <li key={t.id} className="hig-card self-start">
               <div className="flex items-center gap-2 p-3">
                 <button
                   type="button"


### PR DESCRIPTION
## 関連 Issue

Closes #545

---

## 変更の概要

用語辞典は多数の用語が縦1列のアコーディオンで、PC では長いスクロールが必要だった。横幅を活かして **PC（md〜）で2カラム**にし、縦スクロールを約半分に短縮した。

- `App`：用語辞典画面の幅を `max-w-2xl` → `max-w-5xl` に拡張。
- `DictionaryView`：リストを `grid grid-cols-1 md:grid-cols-2` に。展開時に隣のカードが伸びないよう `items-start` / `self-start`。
- モバイルは従来どおり1カラム。検索・分野/レベル絞り込み・並び替え・ブックマーク・個別展開は不変。

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（Chrome DevTools：PC 1280px で2カラム・スクロール短縮／左右隣接カードを同時展開しても伸びない／モバイルは1カラム）
- [x] 既存の機能が壊れていないことを確認した（lint 0/0・build green）
- [x] `.env` ファイルやパスワードをコミットしていない