### PR TITLE
feat: 深掘りQ&Aの拡充（辞典に追加・4択クイズはノースクロール化）

### DIFF
--- a/term-board/src/components/DictionaryView.tsx
+++ b/term-board/src/components/DictionaryView.tsx
@@ -189,6 +189,21 @@ export function DictionaryView({ bookmarks, level }: Props) {
                     <p className="mt-1 text-label-2"><span className="font-semibold text-label">現場では：</span>{t.scene}</p>
                   )}
                   <p className="mt-1 text-label-2"><span className="font-semibold text-label">面接での言い方：</span>{t.interview}</p>
+                  {/* 深掘り「なぜ?」チェーン（4択クイズと同じ followUps）。
+                      辞典は参照用途のため、段階開示せず Q/A を最初から表示する。 */}
+                  {t.followUps && t.followUps.length > 0 && (
+                    <div className="mt-3 rounded-xl bg-amber-50 p-3 ring-1 ring-amber-100 dark:bg-amber-950 dark:ring-amber-900">
+                      <p className="text-xs font-semibold text-amber-800 dark:text-amber-300">深掘り：面接ではこう重ねられます</p>
+                      <ol className="mt-1.5 flex flex-col gap-2">
+                        {t.followUps.map((f, i) => (
+                          <li key={i}>
+                            <p className="font-semibold text-label">Q. {f.q}</p>
+                            <p className="mt-0.5 text-label-2">A. {f.a}</p>
+                          </li>
+                        ))}
+                      </ol>
+                    </div>
+                  )}
                 </div>
               )}
             </li>

--- a/term-board/src/components/QuizView.tsx
+++ b/term-board/src/components/QuizView.tsx
@@ -111,44 +111,48 @@ export function QuizView({ question, selected, isCorrect, onAnswer, onNext }: Pr
           PC は回答前から枠を確保（レイアウトが飛ばない）＋スクロール追従。 */}
       <div className={`${answered ? "" : "hidden lg:block"} lg:sticky lg:top-4`}>
         {answered ? (
-          <div className="hig-card p-6">
-            <p
-              className={`text-lg font-bold ${
-                isCorrect ? "text-emerald-700 dark:text-emerald-400" : "text-rose-700 dark:text-rose-400"
-              }`}
-            >
-              {isCorrect ? "◯ 正解！" : "✕ 不正解"}
-            </p>
-            {question.term.plainMeaning && (
-              <div className="mt-3 rounded-xl bg-sky-50 p-3 ring-1 ring-sky-100 dark:bg-sky-950 dark:ring-sky-900">
-                <p className="text-sm leading-relaxed text-label">
-                  <span className="font-semibold text-accent">かんたんに言うと：</span>
-                  {question.term.plainMeaning}
-                </p>
-              </div>
-            )}
-            <p className="mt-2 text-sm leading-relaxed text-label-2">
-              <span className="font-semibold text-label">正しい意味：</span>
-              {question.answer}
-            </p>
-            <p className="mt-2 text-sm leading-relaxed text-label-2">
-              <span className="font-semibold text-label">面接での言い方：</span>
-              {question.term.interview}
-            </p>
-            {question.term.scene && (
-              <p className="mt-2 text-sm leading-relaxed text-label-2">
-                <span className="font-semibold text-label">現場では：</span>
-                {question.term.scene}
+          // PC では右カラムをビューポート高さに収め、解説＋深掘りだけ内部スクロール、
+          // 「次の問題」は常に下部に見える状態にする（深掘りを開いてもページが伸びない）。
+          <div className="hig-card flex flex-col p-6 lg:max-h-[calc(100vh-2rem)]">
+            <div className="min-h-0 lg:overflow-y-auto">
+              <p
+                className={`text-lg font-bold ${
+                  isCorrect ? "text-emerald-700 dark:text-emerald-400" : "text-rose-700 dark:text-rose-400"
+                }`}
+              >
+                {isCorrect ? "◯ 正解！" : "✕ 不正解"}
               </p>
-            )}
-            {question.term.followUps && question.term.followUps.length > 0 && (
-              <FollowUpChain key={question.term.id} items={question.term.followUps} />
-            )}
+              {question.term.plainMeaning && (
+                <div className="mt-3 rounded-xl bg-sky-50 p-3 ring-1 ring-sky-100 dark:bg-sky-950 dark:ring-sky-900">
+                  <p className="text-sm leading-relaxed text-label">
+                    <span className="font-semibold text-accent">かんたんに言うと：</span>
+                    {question.term.plainMeaning}
+                  </p>
+                </div>
+              )}
+              <p className="mt-2 text-sm leading-relaxed text-label-2">
+                <span className="font-semibold text-label">正しい意味：</span>
+                {question.answer}
+              </p>
+              <p className="mt-2 text-sm leading-relaxed text-label-2">
+                <span className="font-semibold text-label">面接での言い方：</span>
+                {question.term.interview}
+              </p>
+              {question.term.scene && (
+                <p className="mt-2 text-sm leading-relaxed text-label-2">
+                  <span className="font-semibold text-label">現場では：</span>
+                  {question.term.scene}
+                </p>
+              )}
+              {question.term.followUps && question.term.followUps.length > 0 && (
+                <FollowUpChain key={question.term.id} items={question.term.followUps} />
+              )}
+            </div>
             <button
               type="button"
               onClick={onNext}
               autoFocus
-              className="hig-btn-primary mt-4 px-5 py-2.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              className="hig-btn-primary mt-4 shrink-0 px-5 py-2.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
             >
               次の問題 →
             </button>


### PR DESCRIPTION
## 関連 Issue

Closes #547

---

## 変更の概要

深掘り（`followUps`・全274語に付与済み）まわりを2点改善した。

### 1. 用語辞典の展開に深掘りQ&Aを追加（`DictionaryView`）
これまで展開部は「かんたんに／意味／現場では／面接での言い方」のみで深掘りが無かった。4択クイズと同じ `followUps` を表示する。辞典は参照用途のため段階開示せず **Q/A を最初から開いて表示**。

### 2. 4択クイズの深掘りをノースクロール化（`QuizView`）
回答後の右カラム（解説＋深掘り）が、ノートPC（高さ720px等）で深掘りを開くと溢れ、「次の問題」が画面外に出ていた（実測：720pxで221px溢れ・ボタン画面外）。
- 右カラムを `lg:max-h-[calc(100vh-2rem)]` でビューポート高さに収める
- 解説＋深掘りは `min-h-0 lg:overflow-y-auto` で**内部スクロール**
- 「次の問題」は `shrink-0` で**常に下部に固定表示**
- 860px 以上では内部スクロールも出ず全体が1画面に収まる（実測：860pxでページスクロール0・ボタン可視）

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（Chrome DevTools：辞典展開に深掘りQ&A表示／クイズ 720px で深掘り全開でも「次の問題」が常に可視・内部スクロール／860px で完全に収まる）
- [x] 既存の機能が壊れていないことを確認した（lint 0/0・build green）
- [x] `.env` ファイルやパスワードをコミットしていない

## レビュー時に特に確認してほしい点

- クイズ右カラムの内部スクロール＋ボタン固定の挙動（モバイルは `lg:` 限定なので従来どおり縦積み）。