### PR TITLE
feat: 面接練習を面接対策向けの2カラムレイアウトに刷新

### DIFF
--- a/term-board/src/App.tsx
+++ b/term-board/src/App.tsx
@@ -195,6 +195,7 @@ export default function App() {
     : view === "quiz" ? "max-w-5xl"
     : view === "card" ? "max-w-4xl"
     : view === "dictionary" ? "max-w-5xl"
+    : view === "interview" ? "max-w-5xl"
     : "max-w-2xl";
   // ヘッダーはビュー切替で幅が動くと違和感が出るため、常に広い幅で固定。
   const headerWidth = sidebar ? "max-w-5xl" : "max-w-6xl";

--- a/term-board/src/components/InterviewView.tsx
+++ b/term-board/src/components/InterviewView.tsx
@@ -93,10 +93,8 @@ export function InterviewView({ userQuestions }: Props) {
 
   return (
     <section className="flex flex-col gap-5" aria-live="polite">
+      {/* ヘッダー：進捗とタグ絞り込み（進め方は左カラムのカードで案内）。 */}
       <div className="flex flex-wrap items-center justify-center gap-3">
-        <p className="text-sm text-label-2">
-          声に出して答えてから「模範回答を見る」
-        </p>
         {sessionAsked > 0 && (
           <p className="text-sm font-medium text-label-2" aria-live="polite">
             この練習：言えた {sessionSaid} ／ {sessionAsked}
@@ -120,92 +118,125 @@ export function InterviewView({ userQuestions }: Props) {
         )}
       </div>
 
-      <div className="hig-card p-6">
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="text-sm font-medium text-accent">{current.category}</span>
-          {current.source === "shared" && (
-            <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900 dark:text-amber-200">
-              もらった問題
-            </span>
-          )}
-          {current.source === "user" && (
-            <span className="rounded-full bg-fill-quaternary px-2 py-0.5 text-xs font-medium text-label">
-              自作
-            </span>
-          )}
-          {current.tags?.map((tg) => (
-            <span key={tg} className="rounded-full bg-sky-100 px-2 py-0.5 text-xs font-medium text-sky-800 dark:bg-sky-900 dark:text-sky-200">
-              {tg}
-            </span>
-          ))}
-        </div>
-        <h2 className="mt-1 text-2xl font-bold text-label">{current.question}</h2>
-      </div>
-
-      {!revealed ? (
-        <button
-          type="button"
-          onClick={() => setRevealed(true)}
-          className="hig-btn-primary px-5 py-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-        >
-          模範回答を見る
-        </button>
-      ) : (
-        <div className="hig-card p-6">
-          <p className="text-sm leading-relaxed text-label-2">
-            <span className="font-semibold text-label">模範回答：</span>
-            {current.answer}
-          </p>
-          {current.template && (
-            <div className="mt-3 rounded-control bg-sky-50 p-3 ring-1 ring-sky-100 dark:bg-sky-950 dark:ring-sky-900">
-              <p className="text-sm leading-relaxed text-label">
-                <span className="font-semibold text-accent">回答の型：</span>
-                {current.template}
-              </p>
+      {/* 面接対策レイアウト（PC）：左＝面接官の質問＋自分で答える、
+          右＝模範解答＋面接官の追い質問。本番の「問われて答える」流れに合わせる。
+          モバイルは従来どおり縦積み。 */}
+      <div className="flex flex-col gap-5 lg:grid lg:grid-cols-2 lg:items-start lg:gap-6">
+        {/* 左：面接官からの質問＋自分のターン */}
+        <div className="flex flex-col gap-5">
+          <div className="hig-card p-6">
+            <p className="text-xs font-semibold text-accent">面接官からの質問</p>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              <span className="text-sm font-medium text-label-2">{current.category}</span>
+              {current.source === "shared" && (
+                <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900 dark:text-amber-200">
+                  もらった問題
+                </span>
+              )}
+              {current.source === "user" && (
+                <span className="rounded-full bg-fill-quaternary px-2 py-0.5 text-xs font-medium text-label">
+                  自作
+                </span>
+              )}
+              {current.tags?.map((tg) => (
+                <span key={tg} className="rounded-full bg-sky-100 px-2 py-0.5 text-xs font-medium text-sky-800 dark:bg-sky-900 dark:text-sky-200">
+                  {tg}
+                </span>
+              ))}
             </div>
-          )}
-          {current.ngExample && (
-            <div className="mt-2 rounded-control bg-rose-50 p-3 ring-1 ring-rose-100 dark:bg-rose-950 dark:ring-rose-900">
-              <p className="text-sm leading-relaxed text-label">
-                <span className="font-semibold text-rose-700 dark:text-rose-300">NG例と改善：</span>
-                {current.ngExample}
-              </p>
-            </div>
-          )}
-          {current.memo && (
-            <p className="mt-2 text-sm leading-relaxed text-label-2">
-              <span className="font-semibold text-label">メモ：</span>
-              {current.memo}
-            </p>
-          )}
-          {/* 深掘り「なぜ?」チェーン（4択クイズと同じ・面接官の追い質問）。 */}
-          {current.followUps && current.followUps.length > 0 && (
-            <FollowUpChain key={current.id} items={current.followUps} />
-          )}
-          <div className="mt-4 flex flex-col gap-2">
-            <p className="text-sm font-medium text-label-2">
-              自分の言葉で言えましたか？
-            </p>
-            <div className="flex flex-wrap gap-2">
-              <button
-                type="button"
-                onClick={() => selfAssess(true)}
-                autoFocus
-                className="rounded-control bg-emerald-700 px-5 py-2.5 font-semibold text-white transition hover:bg-emerald-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 active:scale-[0.98]"
-              >
-                ◯ 言えた
-              </button>
-              <button
-                type="button"
-                onClick={() => selfAssess(false)}
-                className="rounded-control bg-fill-quaternary px-5 py-2.5 font-semibold text-label transition hover:brightness-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent active:scale-[0.98]"
-              >
-                △ 言えなかった
-              </button>
-            </div>
+            <h2 className="mt-2 text-2xl font-bold text-label">{current.question}</h2>
           </div>
+
+          {!revealed && (
+            <div className="hig-card p-5">
+              <p className="text-sm leading-relaxed text-label-2">
+                まず<span className="font-semibold text-label">声に出して</span>自分の言葉で答えてみましょう。言い切ってから、模範解答と面接官の追い質問で答え合わせします。
+              </p>
+              <button
+                type="button"
+                onClick={() => setRevealed(true)}
+                className="hig-btn-primary mt-4 w-full px-5 py-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              >
+                模範回答を見る
+              </button>
+            </div>
+          )}
         </div>
-      )}
+
+        {/* 右：模範解答＋面接官の追い質問。回答前はPCのみプレースホルダで枠を確保。
+            内容は内部スクロール、自己評価は下部に固定（深掘りを開いても常に見える）。 */}
+        <div className={`${revealed ? "" : "hidden lg:block"} lg:sticky lg:top-4`}>
+          {revealed ? (
+            <div className="hig-card flex flex-col p-6 lg:max-h-[calc(100vh-2rem)]">
+              <div className="min-h-0 lg:overflow-y-auto">
+                <p className="text-xs font-semibold text-accent">模範解答と面接官の追い質問</p>
+                <p className="mt-2 text-sm leading-relaxed text-label-2">
+                  <span className="font-semibold text-label">模範回答：</span>
+                  {current.answer}
+                </p>
+                {current.template && (
+                  <div className="mt-3 rounded-control bg-sky-50 p-3 ring-1 ring-sky-100 dark:bg-sky-950 dark:ring-sky-900">
+                    <p className="text-sm leading-relaxed text-label">
+                      <span className="font-semibold text-accent">回答の型：</span>
+                      {current.template}
+                    </p>
+                  </div>
+                )}
+                {current.ngExample && (
+                  <div className="mt-2 rounded-control bg-rose-50 p-3 ring-1 ring-rose-100 dark:bg-rose-950 dark:ring-rose-900">
+                    <p className="text-sm leading-relaxed text-label">
+                      <span className="font-semibold text-rose-700 dark:text-rose-300">NG例と改善：</span>
+                      {current.ngExample}
+                    </p>
+                  </div>
+                )}
+                {current.memo && (
+                  <p className="mt-2 text-sm leading-relaxed text-label-2">
+                    <span className="font-semibold text-label">メモ：</span>
+                    {current.memo}
+                  </p>
+                )}
+                {/* 深掘り「なぜ?」チェーン（面接官の追い質問）。 */}
+                {current.followUps && current.followUps.length > 0 && (
+                  <FollowUpChain key={current.id} items={current.followUps} />
+                )}
+              </div>
+              {/* 自己評価は内部スクロール領域の外＝常に下部に固定表示。 */}
+              <div className="mt-4 flex shrink-0 flex-col gap-2 border-t border-separator pt-4">
+                <p className="text-sm font-medium text-label-2">
+                  自分の言葉で言えましたか？
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={() => selfAssess(true)}
+                    autoFocus
+                    className="rounded-control bg-emerald-700 px-5 py-2.5 font-semibold text-white transition hover:bg-emerald-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 active:scale-[0.98]"
+                  >
+                    ◯ 言えた
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => selfAssess(false)}
+                    className="rounded-control bg-fill-quaternary px-5 py-2.5 font-semibold text-label transition hover:brightness-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent active:scale-[0.98]"
+                  >
+                    △ 言えなかった
+                  </button>
+                </div>
+              </div>
+            </div>
+          ) : (
+            // PC のみ：回答前のプレースホルダ（右カラムの枠を確保し、回答時のガタつきを防ぐ）。
+            <div className="hig-card flex min-h-[16rem] items-center justify-center p-6 text-center">
+              <p className="text-sm leading-relaxed text-label-3">
+                まず声に出して答えてから「模範回答を見る」を押すと、
+                <br />
+                ここに模範解答と面接官の追い質問が表示されます。
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## 関連 Issue

Closes #553

---

## 変更の概要

面接練習（`InterviewView`）を、4択クイズの深掘りを移植しただけの縦並びから、**面接対策に合わせた専用レイアウト**に刷新した。

- **PC（lg〜）で2カラム**：左＝「面接官からの質問」＋自分のターン（声に出して答える案内＋『模範回答を見る』）、右＝「模範解答と面接官の追い質問」（模範回答・回答の型・NG例・メモ・深掘り）。本番の『問われて自分で答える→答え合わせ』の流れに合わせた。
- 右カラムは `lg:max-h-[calc(100vh-2rem)]` で内部スクロール、自己評価（言えた/言えなかった）を下部に固定。**深掘りを開いても自己評価が常に見える**。
- 回答前はPCのみ右に枠を確保（ガタつき防止）。
- モバイルは従来どおり**縦積み**（`lg:` 限定の変更）。
- `App`：面接練習の幅を PC で `max-w-5xl` に拡張。

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（Chrome DevTools：PC 1280×860 で2カラム・1画面に収まる／回答前は案内＋プレースホルダ／モバイル 390px で縦積み）
- [x] 既存の機能が壊れていないことを確認した（lint 0/0・build green）
- [x] `.env` ファイルやパスワードをコミットしていない