### PR TITLE
fix: タブ favicon を 🐬 に固定（DuckDNS の duck 推測を上書き）

### DIFF
--- a/review-board/frontend/index.html
+++ b/review-board/frontend/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- #557：DuckDNS サブドメインから推測される 🦆 を上書きし 🐬 を明示する。SVG インラインで外部依存ゼロ。 -->
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20100%20100%22%3E%3Ctext%20y%3D%22.9em%22%20font-size%3D%2290%22%3E%F0%9F%90%AC%3C%2Ftext%3E%3C%2Fsvg%3E" />
     <!-- 初期表示用フォールバック。実行時は App が constants.APP_NAME で document.title を上書きする。 -->
     <title>レビューラボ</title>
   </head>


### PR DESCRIPTION
Closes #557

## 変更
- `frontend/index.html` にインライン SVG favicon（🐬）を追加
- 外部リソース不要・1 リクエストも増えない

## 検証
- [x] npm run build 成功