### PR TITLE
fix: 発行済みの招待リンクを後から再表示できるように

### DIFF
--- a/review-board/backend/src/main/java/com/reviewboard/domain/invite/CohortInvite.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/invite/CohortInvite.java
@@ -30,6 +30,14 @@ public class CohortInvite {
     @Column(name = "code_hash", nullable = false, unique = true, length = 64)
     private String codeHash;
 
+    /**
+     * #563：生コードの at-rest 暗号化値（{@code v1:...}・{@link com.reviewboard.domain.mfa.SecretCipher}）。
+     * 講師/管理者の一覧で復号して招待リンクを再表示するために保持する。平文は保存しない。
+     * 鍵未設定の環境や V25 より前に発行した招待では null（その場合は再表示不可＝従来挙動）。
+     */
+    @Column(name = "code_encrypted")
+    private String codeEncrypted;
+
     /** 発行者（退会時は DB 側で SET NULL）。 */
     @Column(name = "created_by")
     private Long createdBy;

--- a/review-board/backend/src/main/java/com/reviewboard/domain/invite/InviteController.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/invite/InviteController.java
@@ -53,11 +53,16 @@ public class InviteController {
                 .body(InviteResponse.withRawCode(issued.invite(), issued.rawCode(), OffsetDateTime.now()));
     }
 
-    /** 自 cohort の招待一覧（生コードは含まない）。 */
+    /**
+     * 自 cohort の招待一覧。講師/管理者のみ（クラスの {@code @PreAuthorize}）アクセスでき、
+     * 再表示用に復号した生コードを含む（#563）。暗号文が無い招待は rawCode=null。
+     */
     @GetMapping
     public List<InviteResponse> list(@AuthenticationPrincipal AuthPrincipal principal) {
         OffsetDateTime now = OffsetDateTime.now();
-        return inviteService.list(principal).stream().map(i -> InviteResponse.of(i, now)).toList();
+        return inviteService.list(principal).stream()
+                .map(i -> InviteResponse.withRawCode(i.invite(), i.rawCode(), now))
+                .toList();
     }
 
     /** 招待を失効させる（自 cohort 以外は 404）。 */

--- a/review-board/backend/src/main/java/com/reviewboard/domain/invite/InviteService.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/invite/InviteService.java
@@ -3,6 +3,7 @@ package com.reviewboard.domain.invite;
 import com.reviewboard.common.InvalidRequestException;
 import com.reviewboard.common.ResourceNotFoundException;
 import com.reviewboard.domain.auth.AuthPrincipal;
+import com.reviewboard.domain.mfa.SecretCipher;
 import com.reviewboard.domain.user.UserRole;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,19 +22,27 @@ public class InviteService {
 
     private final CohortInviteRepository inviteRepository;
     private final InviteCodeGenerator codeGenerator;
+    private final SecretCipher secretCipher;
 
-    public InviteService(CohortInviteRepository inviteRepository, InviteCodeGenerator codeGenerator) {
+    public InviteService(CohortInviteRepository inviteRepository, InviteCodeGenerator codeGenerator,
+                         SecretCipher secretCipher) {
         this.inviteRepository = inviteRepository;
         this.codeGenerator = codeGenerator;
+        this.secretCipher = secretCipher;
     }
 
-    /** 招待を発行する（自 cohort）。生コードは戻り値でのみ返す（保存は hash）。 */
+    /**
+     * 招待を発行する（自 cohort）。生コードは戻り値で返すほか、後から再表示できるよう
+     * at-rest 暗号化（{@link SecretCipher}）して保存する（検証用は別途 SHA-256 hash）。
+     * 暗号鍵未設定の環境では暗号文を保存せず（再表示不可）、発行自体は成功させる（#563）。
+     */
     @Transactional
     public Issued issue(AuthPrincipal principal, int maxUses, int expiresInDays, UserRole targetRole) {
         String rawCode = codeGenerator.generateRawCode();
         CohortInvite invite = new CohortInvite();
         invite.setCohortId(principal.cohortId());
         invite.setCodeHash(codeGenerator.hash(rawCode));
+        invite.setCodeEncrypted(secretCipher.isEnabled() ? secretCipher.encrypt(rawCode) : null);
         invite.setCreatedBy(principal.userId());
         invite.setExpiresAt(OffsetDateTime.now().plusDays(expiresInDays));
         invite.setMaxUses(maxUses);
@@ -43,10 +52,22 @@ public class InviteService {
         return new Issued(invite, rawCode);
     }
 
-    /** 自 cohort の招待一覧（新しい順）。 */
+    /**
+     * 自 cohort の招待一覧（新しい順）。各招待は復号した生コード（再表示用）を伴う。
+     * 暗号文が無い招待（鍵未設定 / V25 以前）は rawCode=null（再表示不可＝従来挙動）。
+     * 呼び出し元は講師/管理者に限定済み（{@code InviteController} の {@code @PreAuthorize}）。
+     */
     @Transactional(readOnly = true)
-    public List<CohortInvite> list(AuthPrincipal principal) {
-        return inviteRepository.findByCohortIdOrderByCreatedAtDesc(principal.cohortId());
+    public List<Listed> list(AuthPrincipal principal) {
+        return inviteRepository.findByCohortIdOrderByCreatedAtDesc(principal.cohortId()).stream()
+                .map(inv -> new Listed(inv, decryptCode(inv)))
+                .toList();
+    }
+
+    /** 保存済み暗号文を復号して生コードに戻す。暗号文が無ければ null。 */
+    private String decryptCode(CohortInvite invite) {
+        String stored = invite.getCodeEncrypted();
+        return stored != null ? secretCipher.decrypt(stored) : null;
     }
 
     /** 招待を失効させる。自 cohort 以外・存在しないものは 404（存在を漏らさない）。 */
@@ -77,6 +98,10 @@ public class InviteService {
 
     /** 発行結果（生コードは 1 度だけ返す）。 */
     public record Issued(CohortInvite invite, String rawCode) {
+    }
+
+    /** 一覧の 1 件（招待＋再表示用の生コード。暗号文が無ければ rawCode=null）。 */
+    public record Listed(CohortInvite invite, String rawCode) {
     }
 
     /** 消費結果（登録時に適用する cohort と role）。 */

--- a/review-board/backend/src/main/java/com/reviewboard/domain/invite/dto/InviteResponse.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/invite/dto/InviteResponse.java
@@ -6,8 +6,9 @@ import com.reviewboard.domain.user.UserRole;
 import java.time.OffsetDateTime;
 
 /**
- * 招待レスポンス（Issue #165 / #511）。
- * {@code rawCode} は発行直後の 1 度だけ値が入り（受講生に渡す元データ）、一覧では常に null。
+ * 招待レスポンス（Issue #165 / #511 / #563）。
+ * {@code rawCode} は招待リンクの元データ。発行直後に加え、講師/管理者の一覧でも
+ * 復号して再表示する（#563）。暗号文を持たない招待（鍵未設定 / V25 以前）では null。
  * {@code targetRole} は招待で作成されるユーザーのロール（STUDENT または TEACHER）。
  * {@code status} は ACTIVE / EXPIRED / USED_UP / REVOKED を読み側で算出。
  */
@@ -23,15 +24,7 @@ public record InviteResponse(
         OffsetDateTime createdAt,
         String status) {
 
-    /** 一覧用（rawCode は保持していないので null）。 */
-    public static InviteResponse of(CohortInvite inv, OffsetDateTime now) {
-        return new InviteResponse(inv.getId(), inv.getCohortId(), null,
-                inv.getMaxUses(), inv.getCurrentUses(), inv.getTargetRole(),
-                inv.getExpiresAt(), inv.getRevokedAt(),
-                inv.getCreatedAt(), status(inv, now));
-    }
-
-    /** 発行直後用（生コードを 1 度だけ返す）。 */
+    /** 発行直後・一覧の再表示用（生コードを伴う。暗号文が無ければ rawCode=null）。 */
     public static InviteResponse withRawCode(CohortInvite inv, String rawCode, OffsetDateTime now) {
         return new InviteResponse(inv.getId(), inv.getCohortId(), rawCode,
                 inv.getMaxUses(), inv.getCurrentUses(), inv.getTargetRole(),

--- a/review-board/backend/src/main/java/com/reviewboard/domain/mfa/SecretCipher.java
+++ b/review-board/backend/src/main/java/com/reviewboard/domain/mfa/SecretCipher.java
@@ -46,6 +46,11 @@ public class SecretCipher {
         this.key = new SecretKeySpec(raw, "AES");
     }
 
+    /** 暗号鍵が設定済みか（未設定なら暗号化・v1 復号は利用不可）。 */
+    public boolean isEnabled() {
+        return key != null;
+    }
+
     /** 平文を暗号化し {@code v1:...} 形式で返す。鍵未設定なら例外。 */
     public String encrypt(String plaintext) {
         requireKey();

--- a/review-board/backend/src/main/resources/db/migration/V25__add_invite_code_encrypted.sql
+++ b/review-board/backend/src/main/resources/db/migration/V25__add_invite_code_encrypted.sql
@@ -1,0 +1,7 @@
+-- #563：発行済みの招待リンクを後から再表示できるようにする。
+-- 生コードを平文では保存せず、TOTP と同じ at-rest 暗号化（AES-256-GCM・SecretCipher）で
+-- 暗号化した値だけを保持する。講師/管理者のみアクセスできる一覧 API で復号して返す。
+-- 既存の招待（暗号文なし）は NULL のままで、従来どおり「発行時のみ表示」の扱いになる。
+
+ALTER TABLE cohort_invites
+    ADD COLUMN code_encrypted VARCHAR(255);

--- a/review-board/backend/src/test/java/com/reviewboard/domain/invite/InviteFlowIntegrationTest.java
+++ b/review-board/backend/src/test/java/com/reviewboard/domain/invite/InviteFlowIntegrationTest.java
@@ -56,6 +56,22 @@ class InviteFlowIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    void teacher_can_redisplay_invite_link_from_list() throws Exception {
+        // #563：発行済みの招待リンクを一覧から再表示できる（生コードを暗号化保存→復号して返す）。
+        Cohort a = newCohort("A");
+        newUser("teacher-a@test", UserRole.TEACHER, a.getId());
+        Cookie teacher = login("teacher-a@test");
+
+        String code = issueCode(teacher, "{}");
+
+        MvcResult list = mockMvc.perform(get("/api/invites").cookie(teacher))
+                .andExpect(status().isOk())
+                .andReturn();
+        String listedCode = JsonPath.parse(list.getResponse().getContentAsString()).read("$[0].rawCode");
+        assertThat(listedCode).isEqualTo(code);
+    }
+
+    @Test
     void student_cannot_issue_invite_403() throws Exception {
         Cohort a = newCohort("A");
         newUser("student-a@test", UserRole.STUDENT, a.getId());

--- a/review-board/frontend/src/pages/InvitesPage.jsx
+++ b/review-board/frontend/src/pages/InvitesPage.jsx
@@ -42,6 +42,9 @@ export default function InvitesPage() {
   const [members, setMembers] = useState([]);
   // #496 P5：無効化対象（confirm 待ち）
   const [pendingDisable, setPendingDisable] = useState(null);
+  // #563：一覧でリンクを開いている招待 id と、コピー済みの招待 id
+  const [openInviteId, setOpenInviteId] = useState(null);
+  const [copiedInviteId, setCopiedInviteId] = useState(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -82,6 +85,22 @@ export default function InvitesPage() {
       setCopied(true);
     } catch {
       setCopied(false);
+    }
+  };
+
+  // #563：発行済みの招待リンクを一覧から再表示・コピーする。
+  const onToggleInviteLink = (id) => {
+    setCopiedInviteId(null);
+    setOpenInviteId((cur) => (cur === id ? null : id));
+  };
+
+  const onCopyInviteLink = async (inv) => {
+    if (!inv.rawCode) return;
+    try {
+      await navigator.clipboard.writeText(shareLink(inv.rawCode));
+      setCopiedInviteId(inv.id);
+    } catch {
+      setCopiedInviteId(null);
     }
   };
 
@@ -188,21 +207,49 @@ export default function InvitesPage() {
         <ul className="space-y-2">
           {invites.map((inv) => {
             const s = STATUS_LABEL[inv.status] ?? STATUS_LABEL.EXPIRED;
+            const canShowLink = inv.status === 'ACTIVE' && !!inv.rawCode;
+            const open = openInviteId === inv.id;
             return (
-              <li key={inv.id} className="mac-card flex flex-wrap items-center justify-between gap-3 p-4">
-                <div className="text-sm">
-                  <span className={`mr-2 rounded-full px-2 py-0.5 text-xs font-bold ${s.cls}`}>{s.text}</span>
-                  <span className={`mr-2 rounded-full px-2 py-0.5 text-xs font-bold ${(ROLE_BADGE[inv.targetRole] ?? ROLE_BADGE.STUDENT).cls}`}>
-                    {(ROLE_BADGE[inv.targetRole] ?? ROLE_BADGE.STUDENT).text}
-                  </span>
-                  <span className="text-gray-700">利用 {inv.currentUses}/{inv.maxUses}</span>
-                  <span className="ml-3 text-xs text-gray-400">期限 {fmt(inv.expiresAt)}</span>
+              <li key={inv.id} className="mac-card p-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div className="text-sm">
+                    <span className={`mr-2 rounded-full px-2 py-0.5 text-xs font-bold ${s.cls}`}>{s.text}</span>
+                    <span className={`mr-2 rounded-full px-2 py-0.5 text-xs font-bold ${(ROLE_BADGE[inv.targetRole] ?? ROLE_BADGE.STUDENT).cls}`}>
+                      {(ROLE_BADGE[inv.targetRole] ?? ROLE_BADGE.STUDENT).text}
+                    </span>
+                    <span className="text-gray-700">利用 {inv.currentUses}/{inv.maxUses}</span>
+                    <span className="ml-3 text-xs text-gray-400">期限 {fmt(inv.expiresAt)}</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {canShowLink && (
+                      <button onClick={() => onToggleInviteLink(inv.id)}
+                        aria-expanded={open}
+                        className="rounded-lg border border-black/10 bg-white px-3 py-1.5 text-sm font-medium text-navy-700 transition hover:bg-black/[0.03]">
+                        {open ? 'リンクを隠す' : 'リンクを表示'}
+                      </button>
+                    )}
+                    {inv.status === 'ACTIVE' && (
+                      <button onClick={() => onRevoke(inv.id)}
+                        className="rounded-lg border border-black/10 bg-white px-3 py-1.5 text-sm font-medium text-rose-600 transition hover:bg-rose-50">
+                        失効させる
+                      </button>
+                    )}
+                  </div>
                 </div>
-                {inv.status === 'ACTIVE' && (
-                  <button onClick={() => onRevoke(inv.id)}
-                    className="rounded-lg border border-black/10 bg-white px-3 py-1.5 text-sm font-medium text-rose-600 transition hover:bg-rose-50">
-                    失効させる
-                  </button>
+                {/* #563：発行済みのリンクを再表示（暗号化保存した生コードを復号して取得） */}
+                {canShowLink && open && (
+                  <div className="mt-3 flex items-center gap-2 rounded-xl border border-brand-200 bg-brand-50/60 p-3">
+                    <input readOnly value={shareLink(inv.rawCode)}
+                      className="mac-input flex-1 font-mono text-xs" aria-label="招待リンク" />
+                    <button onClick={() => onCopyInviteLink(inv)}
+                      className="mac-btn-navy whitespace-nowrap px-4 py-2 text-sm">
+                      {copiedInviteId === inv.id ? 'コピー済み ✓' : 'コピー'}
+                    </button>
+                  </div>
+                )}
+                {/* 暗号文を持たない旧い招待は再表示できない（発行時のみ表示） */}
+                {inv.status === 'ACTIVE' && !inv.rawCode && (
+                  <p className="mt-2 text-xs text-gray-400">このリンクは発行時のみ表示できます（再表示するには新しく発行してください）。</p>
                 )}
               </li>
             );


### PR DESCRIPTION
## 関連 Issue

Closes #563

---

## 変更の概要

「発行済みの招待」をクリックしても何も表示されず、発行後に招待リンクを再取得できなかった問題を修正。
原因は権限ではなく保存方式（生コードを SHA-256 ハッシュのみ保存＝サーバーが再表示できない）。

TOTP で実績のある at-rest 暗号化 `SecretCipher`（AES-256-GCM）を再利用し、生コードを暗号化して保存。
講師/管理者のみアクセスできる一覧 API（`@PreAuthorize("hasAnyRole('TEACHER','ADMIN')")`・cohort 境界）で
復号して返し、フロントの「リンクを表示／コピー」で再共有できるようにした。

- 暗号鍵未設定の環境では暗号文を保存せず発行は成功（再表示なしにフォールバック）
- 既存の招待（暗号文なし）は従来どおり「発行時のみ表示」の扱い
- 平文は保存しない（at-rest は暗号化のみ）

### 主な変更
- `V25__add_invite_code_encrypted.sql`：`code_encrypted` 列を追加（nullable）
- `CohortInvite`：`codeEncrypted` フィールド追加
- `InviteService`：発行時に暗号化保存／一覧で復号して返す（鍵未設定はフォールバック）
- `InviteController`：一覧で復号した生コードを返す
- `InviteResponse`：未使用の `of` を削除し `withRawCode` に一本化
- `SecretCipher`：鍵設定有無を返す `isEnabled()` を追加
- フロント `InvitesPage.jsx`：一覧に「リンクを表示／隠す・コピー」を追加。暗号文なしの旧招待は注記表示

---

## 変更の種別

- [x] fix（バグ修正）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（管理者ログイン→/invites→「リンクを表示」で復号リンク・コピー、ダッシュボードも正常）
- [x] 既存の機能が壊れていないことを確認した（バックエンド全テスト GREEN・新規統合テスト追加・フロント lint/build OK）
- [x] `.env` ファイルやパスワードをコミットしていない

---

## スクリーンショット（任意）

検証時の画面（一覧から復号リンクを再表示・コピー可）はローカルに保存（GitHub ストレージ節約のため未コミット）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)