### PR TITLE
feat: 深掘りQ/Aの片方だけ入力を防ぐガード（警告＋追加/更新ボタン無効化）

### DIFF
--- a/term-board/src/components/AuthorView.tsx
+++ b/term-board/src/components/AuthorView.tsx
@@ -92,6 +92,9 @@ function InterviewForm({ user }: Props) {
   const [fu2a, setFu2a] = useState("");
   const valid = category.trim() && question.trim() && answer.trim();
   const isEditing = editingId !== null;
+  // 深掘りは Q/A 両方そろって初めて登録される。片方だけの「中途半端なペア」を検出。
+  const fuIncomplete =
+    (!!fu1q.trim() !== !!fu1a.trim()) || (!!fu2q.trim() !== !!fu2a.trim());
 
   const resetForm = () => {
     setEditingId(null);
@@ -261,8 +264,13 @@ function InterviewForm({ user }: Props) {
             </div>
           </div>
         </details>
+        {fuIncomplete && (
+          <p role="alert" className="rounded-control bg-amber-50 px-3 py-2 text-xs font-medium text-amber-800 ring-1 ring-amber-200 dark:bg-amber-950 dark:text-amber-200 dark:ring-amber-900">
+            深掘りは Q（追い質問）と A（答え方）の両方を入力してください。片方だけだと登録されません（両方空ならOK）。
+          </p>
+        )}
         <div className="flex flex-wrap gap-2">
-          <button type="submit" disabled={!valid || isDuplicate} className={primaryBtn}>
+          <button type="submit" disabled={!valid || isDuplicate || fuIncomplete} className={primaryBtn}>
             {isEditing ? "更新する" : "追加する"}
           </button>
           {isEditing && (
@@ -311,6 +319,9 @@ function QuizForm({ user }: Props) {
     term.trim() && category.trim() && meaning.trim() && interview.trim() &&
     d0.trim() && d1.trim() && d2.trim();
   const isEditing = editingId !== null;
+  // 深掘りは Q/A 両方そろって初めて登録される。片方だけの「中途半端なペア」を検出。
+  const fuIncomplete =
+    (!!fu1q.trim() !== !!fu1a.trim()) || (!!fu2q.trim() !== !!fu2a.trim());
 
   const resetForm = () => {
     setEditingId(null);
@@ -444,8 +455,13 @@ function QuizForm({ user }: Props) {
             </div>
           </div>
         </details>
+        {fuIncomplete && (
+          <p role="alert" className="rounded-control bg-amber-50 px-3 py-2 text-xs font-medium text-amber-800 ring-1 ring-amber-200 dark:bg-amber-950 dark:text-amber-200 dark:ring-amber-900">
+            深掘りは Q（追い質問）と A（答え方）の両方を入力してください。片方だけだと登録されません（両方空ならOK）。
+          </p>
+        )}
         <div className="flex flex-wrap gap-2">
-          <button type="submit" disabled={!valid || isDuplicate} className={primaryBtn}>
+          <button type="submit" disabled={!valid || isDuplicate || fuIncomplete} className={primaryBtn}>
             {isEditing ? "更新する" : "追加する"}
           </button>
           {isEditing && (


### PR DESCRIPTION
## 関連 Issue

Closes #577

---

## 変更の概要

深掘りは Q（追い質問）と A（答え方）の両方そろったペアだけ登録され、片方だけだと黙って捨てられて「保存されない」混乱の元だった。**片方だけ入力のときに警告を出し、追加/更新ボタンを無効化**する。

- **4択用語フォーム・面接Q&Aフォームの両方**に適用。
- 不完全ペア（Q/A の片方だけ）を検出したら：
  - 「Q と A の両方を入力してください」警告（amber）を表示
  - 「追加する／更新する」ボタンを `disabled`（両方空ならOK）
- 既存の必須・重複チェックと併用。

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（Chrome：Qのみ入力→ボタン無効＋警告表示を確認。lint 0/0・build（tsc）・test 33件 green）
- [x] 既存の機能が壊れていないことを確認した（両方入力/両方空は従来どおり保存）
- [x] `.env` ファイルやパスワードをコミットしていない