### PR TITLE
chore: Terraform CI と OIDC 認証基盤を追加

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -1,0 +1,46 @@
+name: terraform-ci
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  id-token: write # terraform-test の OIDC 用
+
+jobs:
+  # 必須チェックにする方。AWS 不要のオフライン検査だけ＝全PRで走り常に緑。
+  terraform-validate:
+    name: terraform-validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: aws-study/terraform
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: "1.15.2"
+      - run: terraform fmt -check -recursive
+      - run: terraform init -backend=false
+      - run: terraform validate
+
+  # 非必須。OIDC plan ロールで terraform test（plan モード・$0）を CI でも回す。
+  terraform-test:
+    name: terraform-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: aws-study/terraform
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: ${{ secrets.AWS_PLAN_ROLE_ARN }}
+          aws-region: ap-northeast-1
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: "1.15.2"
+      - run: terraform init
+      - run: terraform test

--- a/aws-study/terraform/bootstrap/oidc.tf
+++ b/aws-study/terraform/bootstrap/oidc.tf
@@ -1,0 +1,226 @@
+# GitHub Actions -> AWS を OIDC（短期トークン）で認証する踏み台。
+# 長期アクセスキーを Secrets に置かないための要。state バケットと同じくローカル state で
+# 一度だけ apply し常設（CD が動く前に存在している必要がある）。
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  account_id       = data.aws_caller_identity.current.account_id
+  repo             = "80-cloud/study-boards"
+  sub_pull_request = "repo:${local.repo}:pull_request"
+  sub_main         = "repo:${local.repo}:ref:refs/heads/main"
+  sub_env_prod     = "repo:${local.repo}:environment:prod" # environment 指定で sub はこれに変わる
+}
+
+# ---- GitHub Actions 用 OIDC プロバイダ（アカウントに1つ） ----
+# thumbprint_list は省略可（AWS が自動取得・管理）。
+resource "aws_iam_openid_connect_provider" "github" {
+  url            = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
+}
+
+# ============== (A) plan ロール：PR(CI)・main(CD) から assume・読取のみ ==============
+data "aws_iam_policy_document" "plan_trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = [local.sub_pull_request, local.sub_main]
+    }
+  }
+}
+
+resource "aws_iam_role" "plan" {
+  name               = "aws-study-tf-plan"
+  assume_role_policy = data.aws_iam_policy_document.plan_trust.json
+}
+
+# 読取は AWS 管理の ReadOnlyAccess（変更系を含まない＝壊せない）
+resource "aws_iam_role_policy_attachment" "plan_readonly" {
+  role       = aws_iam_role.plan.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+# plan でも use_lockfile のロック(.tflock)を state バケットに置くため state だけ書込可
+resource "aws_iam_role_policy" "plan_state" {
+  name   = "tf-state-access"
+  role   = aws_iam_role.plan.id
+  policy = data.aws_iam_policy_document.state_access.json
+}
+
+# ============== (B) apply ロール：environment:prod（承認済み実行）からのみ・変更可 ==============
+data "aws_iam_policy_document" "apply_trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+    condition { # 承認ゲートを通った prod 環境ジョブだけ
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = [local.sub_env_prod]
+    }
+  }
+}
+
+resource "aws_iam_role" "apply" {
+  name               = "aws-study-tf-apply"
+  assume_role_policy = data.aws_iam_policy_document.apply_trust.json
+}
+
+resource "aws_iam_role_policy" "apply_state" {
+  name   = "tf-state-access"
+  role   = aws_iam_role.apply.id
+  policy = data.aws_iam_policy_document.state_access.json
+}
+
+resource "aws_iam_role_policy" "apply_infra" {
+  name   = "tf-infra-manage"
+  role   = aws_iam_role.apply.id
+  policy = data.aws_iam_policy_document.apply_infra.json
+}
+
+# ============== 共通：state バケットアクセス（plan/apply 両方） ==============
+data "aws_iam_policy_document" "state_access" {
+  statement {
+    sid       = "ListStateBucket"
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = ["arn:aws:s3:::${var.state_bucket_name}"]
+  }
+  statement {
+    sid       = "ReadWriteState"
+    effect    = "Allow"
+    actions   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"] # .tflock も含む
+    resources = ["arn:aws:s3:::${var.state_bucket_name}/*"]
+  }
+}
+
+# ============== apply の変更権限（iam は aws-study-* 限定・他は動詞ファミリ＋東京限定） ==============
+data "aws_iam_policy_document" "apply_infra" {
+  # provider 初期化で呼ばれる（modules/alb も data.aws_caller_identity を使用）
+  statement {
+    sid       = "StsIdentity"
+    effect    = "Allow"
+    actions   = ["sts:GetCallerIdentity"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "IamScopedToProject"
+    effect = "Allow"
+    actions = [
+      "iam:GetRole", "iam:CreateRole", "iam:DeleteRole", "iam:TagRole", "iam:UntagRole",
+      "iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy", "iam:ListRolePolicies",
+      "iam:AttachRolePolicy", "iam:DetachRolePolicy", "iam:ListAttachedRolePolicies",
+      "iam:CreateInstanceProfile", "iam:DeleteInstanceProfile", "iam:GetInstanceProfile",
+      "iam:AddRoleToInstanceProfile", "iam:RemoveRoleFromInstanceProfile",
+      "iam:ListInstanceProfilesForRole", "iam:PassRole",
+    ]
+    resources = [
+      "arn:aws:iam::${local.account_id}:role/aws-study-*",
+      "arn:aws:iam::${local.account_id}:instance-profile/aws-study-*",
+    ]
+  }
+
+  statement {
+    sid    = "S3SiteManage"
+    effect = "Allow"
+    actions = [
+      "s3:CreateBucket", "s3:DeleteBucket", "s3:ListBucket", "s3:GetBucket*", "s3:PutBucket*",
+      "s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:GetEncryptionConfiguration",
+      "s3:PutEncryptionConfiguration", "s3:PutBucketPublicAccessBlock", "s3:GetBucketPublicAccessBlock",
+    ]
+    resources = ["arn:aws:s3:::aws-study-*", "arn:aws:s3:::aws-study-*/*"]
+  }
+
+  statement {
+    sid       = "CloudFront" # グローバル
+    effect    = "Allow"
+    actions   = ["cloudfront:*Distribution*", "cloudfront:*OriginAccessControl*", "cloudfront:Get*", "cloudfront:List*", "cloudfront:TagResource", "cloudfront:UntagResource"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "RegionalInfra"
+    effect = "Allow"
+    actions = [
+      "ec2:Describe*", "ec2:Create*", "ec2:Delete*", "ec2:Modify*", "ec2:Associate*",
+      "ec2:Disassociate*", "ec2:Attach*", "ec2:Detach*", "ec2:Authorize*", "ec2:Revoke*",
+      "ec2:RunInstances", "ec2:TerminateInstances", "ec2:Start*", "ec2:Stop*",
+      "ec2:AllocateAddress", "ec2:ReleaseAddress",
+      "elasticloadbalancing:*",
+      "rds:Describe*", "rds:Create*", "rds:Delete*", "rds:Modify*", "rds:AddTagsToResource", "rds:RemoveTagsFromResource", "rds:ListTagsForResource",
+      "cloudwatch:Describe*", "cloudwatch:Get*", "cloudwatch:List*", "cloudwatch:PutMetricAlarm", "cloudwatch:DeleteAlarms", "cloudwatch:TagResource", "cloudwatch:UntagResource",
+      "logs:Describe*", "logs:Get*", "logs:List*", "logs:CreateLogGroup", "logs:DeleteLogGroup", "logs:PutRetentionPolicy", "logs:TagResource", "logs:UntagResource",
+      "sns:Get*", "sns:List*", "sns:CreateTopic", "sns:DeleteTopic", "sns:Subscribe", "sns:Unsubscribe", "sns:SetTopicAttributes", "sns:TagResource", "sns:UntagResource",
+      "secretsmanager:Describe*", "secretsmanager:Get*", "secretsmanager:List*", "secretsmanager:CreateSecret", "secretsmanager:DeleteSecret", "secretsmanager:PutSecretValue", "secretsmanager:UpdateSecret", "secretsmanager:TagResource", "secretsmanager:UntagResource",
+      "lambda:*",
+      "apigateway:*",
+      "wafv2:*",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestedRegion"
+      values   = [var.region]
+    }
+  }
+}
+
+# ---- state バケットをアカウント内＋TLS のみに限定（PAB と二重防御・追補①） ----
+data "aws_iam_policy_document" "state_bucket" {
+  statement {
+    sid    = "DenyInsecureTransport"
+    effect = "Deny"
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    actions   = ["s3:*"]
+    resources = [aws_s3_bucket.state.arn, "${aws_s3_bucket.state.arn}/*"]
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+  statement {
+    sid    = "DenyOtherAccounts"
+    effect = "Deny"
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    actions   = ["s3:*"]
+    resources = [aws_s3_bucket.state.arn, "${aws_s3_bucket.state.arn}/*"]
+    condition {
+      test     = "StringNotEquals"
+      variable = "aws:PrincipalAccount"
+      values   = [local.account_id]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "state" {
+  bucket = aws_s3_bucket.state.id
+  policy = data.aws_iam_policy_document.state_bucket.json
+}

--- a/aws-study/terraform/bootstrap/outputs.tf
+++ b/aws-study/terraform/bootstrap/outputs.tf
@@ -1,3 +1,11 @@
 output "state_bucket" {
   value = aws_s3_bucket.state.id
 }
+
+output "tf_plan_role_arn" {
+  value = aws_iam_role.plan.arn
+}
+
+output "tf_apply_role_arn" {
+  value = aws_iam_role.apply.arn
+}

--- a/aws-study/terraform/modules/lambda/main.tf
+++ b/aws-study/terraform/modules/lambda/main.tf
@@ -28,7 +28,7 @@ resource "aws_cloudwatch_log_group" "this" {
 resource "aws_lambda_function" "this" {
   function_name    = "${var.project}-${var.function_name}"
   role             = aws_iam_role.this.arn
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs22.x"
   handler          = "handler.handler"
   filename         = data.archive_file.this.output_path
   source_code_hash = data.archive_file.this.output_base64sha256

--- a/aws-study/terraform/tests/coverage.tftest.hcl
+++ b/aws-study/terraform/tests/coverage.tftest.hcl
@@ -1,0 +1,97 @@
+# 追加カバレッジ（plan モード・$0）。serverless.tftest.hcl と一緒に走ります。
+
+# Lambda：ハンドラ指定とログ保持
+run "lambda_handler_and_logs" {
+  command = plan
+  module { source = "./modules/lambda" }
+  variables {
+    project       = "aws-study"
+    function_name = "hello"
+  }
+  assert {
+    condition     = aws_lambda_function.this.handler == "handler.handler"
+    error_message = "handler は handler.handler であるべき"
+  }
+  assert {
+    condition     = aws_cloudwatch_log_group.this.retention_in_days == 7
+    error_message = "ロググループの保持は7日であるべき"
+  }
+}
+
+# API Gateway：HTTP API / AWS_PROXY / payload 2.0 / ルート
+run "apigw_config" {
+  command = plan
+  module { source = "./modules/apigw" }
+  variables {
+    project              = "aws-study"
+    lambda_invoke_arn    = "arn:aws:lambda:ap-northeast-1:123456789012:function:dummy/invocations"
+    lambda_function_name = "dummy"
+  }
+  assert {
+    condition     = aws_apigatewayv2_api.this.protocol_type == "HTTP"
+    error_message = "HTTP API であるべき"
+  }
+  assert {
+    condition     = aws_apigatewayv2_integration.lambda.integration_type == "AWS_PROXY"
+    error_message = "統合は AWS_PROXY であるべき"
+  }
+  assert {
+    condition     = aws_apigatewayv2_integration.lambda.payload_format_version == "2.0"
+    error_message = "payload_format_version は 2.0 であるべき"
+  }
+  assert {
+    condition     = aws_apigatewayv2_route.hello.route_key == "GET /api/hello"
+    error_message = "ルートは GET /api/hello であるべき"
+  }
+}
+
+# 静的サイト：index.html を text/html で配置
+run "static_site_object" {
+  command = plan
+  module { source = "./modules/static_site" }
+  variables {
+    project = "aws-study"
+    suffix  = "test"
+  }
+  assert {
+    condition     = aws_s3_object.index.key == "index.html"
+    error_message = "オブジェクトキーは index.html であるべき"
+  }
+  assert {
+    condition     = aws_s3_object.index.content_type == "text/html"
+    error_message = "content_type は text/html であるべき"
+  }
+}
+
+# CloudFront：既定ルートオブジェクトと OAC
+run "cdn_config" {
+  command = plan
+  module { source = "./modules/cdn" }
+  variables {
+    project        = "aws-study"
+    s3_domain_name = "dummy.s3.ap-northeast-1.amazonaws.com"
+    s3_bucket_id   = "dummy"
+    s3_bucket_arn  = "arn:aws:s3:::dummy"
+    api_host       = "dummy.execute-api.ap-northeast-1.amazonaws.com"
+  }
+  assert {
+    condition     = aws_cloudfront_distribution.this.default_root_object == "index.html"
+    error_message = "default_root_object は index.html であるべき"
+  }
+  assert {
+    condition     = aws_cloudfront_origin_access_control.s3.signing_behavior == "always"
+    error_message = "OAC の signing_behavior は always であるべき"
+  }
+}
+
+# my_ip：正しい形式(x.x.x.x/32)なら通る（③の逆＝ポジティブ）
+run "accepts_valid_my_ip" {
+  command = plan
+  variables {
+    my_ip = "203.0.113.10/32"
+  }
+  assert {
+    condition     = output.lambda_function_name == "aws-study-hello"
+    error_message = "正しい my_ip ならプランが通り、出力が得られるはず"
+  }
+}

--- a/aws-study/terraform/tests/security.tftest.hcl
+++ b/aws-study/terraform/tests/security.tftest.hcl
@@ -1,0 +1,78 @@
+# §9: ALB / TargetGroup / SecurityGroup のセキュリティをテストで保証（plan モード＝$0）。
+# 実行: terraform test
+# 注意: ① の ALB テストは modules/alb の data(aws_elb_service_account / aws_caller_identity)
+#       のため AWS 認証情報が必要。②③ の security モジュールは data 無しで完全オフライン。
+
+# ① ターゲットグループのポートがアプリ(8080)と一致
+run "target_group_port_is_8080" {
+  command = plan
+
+  module {
+    source = "./modules/alb"
+  }
+  variables {
+    project           = "aws-study"
+    vpc_id            = "vpc-12345678" # plan 用ダミー（実在不要）
+    public_subnet_ids = ["subnet-aaa", "subnet-bbb"]
+    alb_sg_id         = "sg-12345678"
+    instance_id       = "i-1234567890abcdef0"
+  }
+
+  assert {
+    condition     = aws_lb_target_group.this.port == 8080
+    error_message = "ターゲットグループのポートはアプリと同じ 8080 であるべき"
+  }
+}
+
+# ② ALB-SG は HTTP/HTTPS のみ（SSH(22) を開けていない）
+run "alb_sg_is_http_https_only" {
+  command = plan
+
+  module {
+    source = "./modules/security"
+  }
+  variables {
+    project = "aws-study"
+    vpc_id  = "vpc-12345678"
+    my_ip   = "203.0.113.10/32"
+  }
+
+  assert {
+    condition = alltrue([
+      for r in aws_security_group.alb.ingress : contains([80, 443], r.from_port)
+    ])
+    error_message = "ALB-SG の ingress は 80/443 のみ（SSH 等を開けない）であるべき"
+  }
+}
+
+# ③ EC2-SG の SSH(22) は my_ip(/32) のみ・0.0.0.0/0 で開けない
+run "ec2_sg_ssh_is_my_ip_only" {
+  command = plan
+
+  module {
+    source = "./modules/security"
+  }
+  variables {
+    project = "aws-study"
+    vpc_id  = "vpc-12345678"
+    my_ip   = "203.0.113.10/32"
+  }
+
+  # 22 番に 0.0.0.0/0 が無いこと
+  assert {
+    condition = alltrue([
+      for r in aws_security_group.ec2.ingress :
+      r.from_port != 22 || !contains(coalesce(r.cidr_blocks, []), "0.0.0.0/0")
+    ])
+    error_message = "EC2-SG の SSH(22) を 0.0.0.0/0 に開けてはいけない"
+  }
+
+  # 22 番が my_ip(/32) から許可されていること
+  assert {
+    condition = anytrue([
+      for r in aws_security_group.ec2.ingress :
+      r.from_port == 22 && contains(coalesce(r.cidr_blocks, []), var.my_ip)
+    ])
+    error_message = "EC2-SG の SSH(22) は my_ip(/32) のみから許可されているべき"
+  }
+}

--- a/aws-study/terraform/tests/serverless.tftest.hcl
+++ b/aws-study/terraform/tests/serverless.tftest.hcl
@@ -1,0 +1,56 @@
+# Terraform ネイティブテスト（plan モード＝実リソースを作らない・$0）
+# 実行: terraform test
+
+# ① Lambda のランタイムが現行(nodejs22.x)であること（EOL回帰テスト）
+run "lambda_uses_supported_runtime" {
+  command = plan
+
+  module {
+    source = "./modules/lambda"
+  }
+  variables {
+    project       = "aws-study"
+    function_name = "hello"
+  }
+
+  assert {
+    condition     = aws_lambda_function.this.runtime == "nodejs22.x"
+    error_message = "Lambda runtime は nodejs22.x であるべき（20.x は EOL）"
+  }
+}
+
+# ② 静的サイトS3 が「公開を全ブロック」していること（最小権限）
+run "s3_blocks_all_public_access" {
+  command = plan
+
+  module {
+    source = "./modules/static_site"
+  }
+  variables {
+    project = "aws-study"
+    suffix  = "test"
+  }
+
+  assert {
+    condition = (
+      aws_s3_bucket_public_access_block.this.block_public_acls &&
+      aws_s3_bucket_public_access_block.this.block_public_policy &&
+      aws_s3_bucket_public_access_block.this.ignore_public_acls &&
+      aws_s3_bucket_public_access_block.this.restrict_public_buckets
+    )
+    error_message = "S3 バケットは公開を全ブロックすべき"
+  }
+}
+
+# ③ my_ip に全開放(0.0.0.0/0)を入れたら validation で弾かれること
+run "rejects_wide_open_my_ip" {
+  command = plan
+
+  variables {
+    my_ip = "0.0.0.0/0"
+  }
+
+  expect_failures = [
+    var.my_ip,
+  ]
+}


### PR DESCRIPTION
## 関連 Issue

Closes #596

---

## 変更の概要

Terraform を GitHub Actions で CD 化する準備として、CI（自動検査）と OIDC（短期トークン認証）の基盤を追加する。

- **bootstrap/oidc.tf**：GitHub Actions 用 OIDC プロバイダ＋plan/apply ロール（最小権限）＋state バケットポリシー（TLS 強制・他アカウント遮断）。長期アクセスキーなしで Actions から AWS を操作するための土台。
- **.github/workflows/terraform-ci.yml**：terraform-validate（AWS 不要のオフライン検査＝fmt/init/validate）と terraform-test（OIDC plan ロールで terraform test・plan モード）。
- **tests/**：terraform test スイート（serverless / coverage / security・計11本）。security では ALB/SG/TG のポートと SSH 制限を検証。

## 変更の種別

- [x] chore（設定・ツール・依存関係の変更）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（terraform validate は Success・terraform test は 11 passed・fmt -check クリーン）
- [x] 既存の機能が壊れていないことを確認した
- [x] .env ファイルやパスワードをコミットしていない

---

## レビュー時に特に確認してほしい点

- OIDC の信頼条件：plan ロールは PR/main から、apply ロールは environment:prod からのみ assume 可。
- 最小権限：IAM は aws-study-* 限定、他サービスは動詞ファミリ＋東京リージョン条件。