### PR TITLE
feat: Terraform を main マージで自動 apply する CD を追加

### DIFF
--- a/.github/workflows/terraform-cd.yml
+++ b/.github/workflows/terraform-cd.yml
@@ -1,0 +1,48 @@
+name: terraform-cd
+
+# main へ terraform 変更がマージされた時だけ起動する。
+# environment: prod の承認ゲートで止まり、承認するまで apply は走らない（＝課金は承認時だけ）。
+on:
+  push:
+    branches: [main]
+    paths:
+      - "aws-study/terraform/**"
+
+permissions:
+  id-token: write # OIDC トークン取得に必須
+  contents: read
+
+# 同時 apply による state 衝突を防ぐ
+concurrency:
+  group: terraform-cd-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    name: terraform-apply
+    runs-on: ubuntu-latest
+    environment: prod # required reviewers = 承認ゲート（ジョブ開始前に停止）
+    timeout-minutes: 60 # RDS 作成に ~10-15分かかる
+    defaults:
+      run:
+        working-directory: aws-study/terraform
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: "1.15.2"
+      - uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: ${{ secrets.AWS_APPLY_ROLE_ARN }}
+          aws-region: ap-northeast-1
+      - run: terraform init
+      - run: terraform plan -out=tfplan -input=false -var="my_ip=${{ secrets.MY_IP_CIDR }}"
+      - run: terraform apply -input=false tfplan
+      - name: verify-on-aws
+        run: |
+          DNS=$(terraform output -raw alb_dns)
+          for i in $(seq 1 30); do
+            if curl -fsS "http://$DNS/"; then echo "healthy"; exit 0; fi
+            echo "waiting app boot... ($i)"; sleep 10
+          done
+          echo "did not become healthy"; exit 1


### PR DESCRIPTION
## 関連 Issue

Closes #598

---

## 変更の概要

Issue #596 で整えた CI／OIDC 基盤の上に、CD（継続的デリバリ）を追加する。

- `.github/workflows/terraform-cd.yml` を新規追加
  - トリガ：push to main（paths: aws-study/terraform/**）＝terraform 変更がマージされた時だけ起動
  - **environment: prod の承認ゲート**：承認するまで apply は走らない（＝課金は承認した短時間だけ）
  - OIDC apply ロール（環境 prod からのみ assume 可）で認証 → plan -out=tfplan → apply tfplan を**同一ジョブ**で実行
  - apply 後に ALB DNS へ curl して反映確認（アプリ起動待ちのリトライ付き）
  - destroy ジョブは作らない（破壊は手動のみ）

## 変更の種別

- [x] feat（新機能の追加）

---

## 動作確認チェックリスト

- [x] ローカルで動作確認した（YAML 構造を確認・既存 terraform-ci.yml と同形式）
- [x] 既存の機能が壊れていないことを確認した
- [x] .env ファイルやパスワードをコミットしていない

---

## レビュー時に特に確認してほしい点

- public リポのため plan を artifact 化せず単一ジョブで plan→apply する設計（plan は機密を含むため）。
- このPRをマージしても apply は走らない（.github/ のみ変更で paths に不一致＋承認ゲート）。実 apply は次の terraform 変更時。