### PR TITLE
docs: Terraform の state・OIDC・CI/CD 運用をドキュメント化

### DIFF
--- a/aws-study/docs/state-management.md
+++ b/aws-study/docs/state-management.md
@@ -1,0 +1,51 @@
+# state と CI/CD の運用
+
+Terraform の state 管理、および GitHub Actions による検査・デプロイの運用をまとめる。
+
+## state バックエンド
+
+- 保存先：S3 バケット `aws-study-tfstate-hideharu`、キー `capstone/terraform.tfstate`
+- ロック：S3 ネイティブロック（`use_lockfile = true`）で同時 apply の競合を防ぐ（DynamoDB は使わない）
+- 暗号化：`encrypt = true`（保存時に暗号化）
+- 置き場の作成：`bootstrap/` スタックで一度だけ作る（このスタック自身は鶏と卵を避けるためローカル state）。state バケットには `aws_s3_bucket_policy` で「TLS 必須・このアカウント以外は拒否」を付け、Public Access Block と二重で保護する。
+
+## GitHub Actions の認証（OIDC）
+
+長期アクセスキーを Secrets に置かず、OIDC（短期トークン）で AWS を認証する。`bootstrap/oidc.tf` で OIDC プロバイダと 2 つのロールを作る。
+
+| ロール | assume できる条件 | 権限 |
+|---|---|---|
+| `aws-study-tf-plan` | PR / main から | 読み取り専用（ReadOnlyAccess）＋ state ロックの書き込み |
+| `aws-study-tf-apply` | `environment: prod` から | 変更可（下記の最小権限） |
+
+- **plan と apply を分離**：PR や main では読み取りだけ（壊せない）。変更できるのは prod 環境を通った実行のみ。
+- apply ロールの権限は最小化：IAM は `aws-study-*` のロール／インスタンスプロファイルに限定＋ PassRole、他サービスは動詞ファミリ（`Describe*`/`Create*`/`Delete*`/`Modify*` など）＋東京リージョン条件で絞る。広い `*:*` は使わない。
+- 信頼条件：`aud` は `sts.amazonaws.com`、`sub` は plan が `pull_request` / `ref:refs/heads/main`、apply が `environment:prod`。
+
+## CI（terraform-ci.yml・PR 時）
+
+- `terraform-validate`：`fmt -check` / `init -backend=false` / `validate`。AWS 不要のオフライン検査で、全 PR で走り常に通る（必須チェック）。
+- `terraform-test`：plan ロールで `terraform test`（plan モード）。ALB／SG／ターゲットグループのポートや SSH 制限などをコード上で検証する。
+
+## CD（terraform-cd.yml・main マージ時）
+
+- トリガ：main への push（`aws-study/terraform/**` が変わった時だけ）。
+- 承認ゲート：`environment: prod` の required reviewers。承認するまで apply は走らない。
+- 流れ：apply ロールを assume → `plan -out=tfplan` → `apply tfplan` を**同一ジョブ**で実行 → ALB の DNS に `curl` して反映を確認。
+- 承認者：リポジトリ管理者（本人）。
+
+### plan を artifact にしない理由
+
+このリポジトリは公開設定で、plan ファイルは state や変数の値を含む。公開リポの artifact は誰でもダウンロードできるため、plan を artifact 化して別ジョブに渡す方式は使わず、**1 つのジョブの中で `plan -out` → `apply` まで完結**させる。これで保存した plan をそのまま適用しつつ、plan を外に出さない。
+
+## 版の固定
+
+- Terraform：CI/CD は `1.15.2` に固定（ローカルも同じ版に合わせる）。`required_version = "~> 1.10"`。
+- AWS provider：`~> 6.0` ＋ `.terraform.lock.hcl` をコミットして確定。
+- GitHub Actions：各 action を 40 桁の commit SHA で固定（タグ差し替えによる予期せぬ変更を防ぐ）。
+
+## ネットワーク／SG 構成（要点）
+
+- ALB：internet-facing・public 2AZ。ALB SG は 80／443 のみ。
+- EC2 SG：アプリ 8080 は ALB SG からのみ、SSH 22 は `my_ip`（/32）からのみ。
+- ターゲットグループ：ポート 8080（アプリと一致）。

--- a/aws-study/terraform/README.md
+++ b/aws-study/terraform/README.md
@@ -52,17 +52,17 @@ AWS 上に **VPC / EC2 / RDS / ALB / WAF / CloudWatch** 一式を Terraform で�
 
 ## state バックエンドの準備（最初の 1 回だけ）
 
-state を S3 に保存するため、先に置き場（S3 バケット＋ DynamoDB テーブル）を作ります。これは `bootstrap/` の小さなスタックで行います（このスタック自身は鶏と卵を避けるためローカル state）。
+state を S3 に保存するため、先に置き場を作ります。これは `bootstrap/` の小さなスタックで行います（このスタック自身は鶏と卵を避けるためローカル state）。`bootstrap/` は state 用の S3 バケット（バージョニング・暗号化・公開遮断・バケットポリシー付き）と、GitHub Actions 用の OIDC プロバイダ／ロールを作成します。
 
 ```bash
 cd bootstrap
 terraform init
-terraform apply        # S3 バケット + DynamoDB テーブルを作成（ほぼ無料・常設）
+terraform apply        # state 用 S3 バケット＋OIDC ロールを作成（ほぼ無料・常設）
 ```
 
 作成したバケット名を本体の `backend.tf` の `bucket` と一致させます（既定: `aws-study-tfstate-hideharu`）。バケット名は世界で一意のため、必要に応じて変更してください。
 
-> 補足：state のロックは S3 ネイティブロック（`use_lockfile = true`・Terraform 1.10 以上が必要）を採用しています。以前は DynamoDB テーブルでロックするのが一般的でしたが、現在は非推奨のため使いません。`bootstrap/` が作成する DynamoDB テーブルは現状では使われないため、後で削除しても構いません。
+> 補足：state のロックは S3 ネイティブロック（`use_lockfile = true`・Terraform 1.10 以上が必要）を採用しています。以前は DynamoDB テーブルでロックするのが一般的でしたが、現在は非推奨のため使いません。
 
 ## デプロイ
 
@@ -94,6 +94,12 @@ terraform destroy -var="my_ip=$(curl -s https://checkip.amazonaws.com)/32"
 > RDS は既定で破棄時に最終スナップショットを残す（`skip_final_snapshot = false`）ため、誤操作によるデータ消失を防げる。学習で一括破棄したい時だけ `-var="skip_final_snapshot=true"` を追加で渡す（この場合は最終スナップショットを作らず削除する）。
 
 > state 置き場（`bootstrap/` の S3・DynamoDB）はほぼ無料なので残してよい。完全に消す場合は `bootstrap/` でも `terraform destroy` を実行する。
+
+## CI/CD（GitHub Actions）
+
+-  **CI（`terraform-ci.yml`・PR 時）**：`fmt -check` / `validate` のオフライン検査（必須チェック）と、`terraform test`（plan モード）で構成と安全性を検証する。AWS へは OIDC の読み取り専用ロールで接続する。
+- **CD（`terraform-cd.yml`・main マージ時）**：`aws-study/terraform/**` の変更が main に入ると起動し、`environment: prod` の承認を経てから apply する（承認するまで何も適用しない）。apply 後に ALB の DNS へ `curl` して反映を確認する。
+- 認証は OIDC（短期トークン）で長期アクセスキーは使わない。詳細は [docs/state-management.md](../docs/state-management.md) を参照。
 
 ## モジュール構成
 


### PR DESCRIPTION
## 関連 Issue

Closes #600

## 変更の概要
- 新規 `aws-study/docs/state-management.md`：state バックエンド／OIDC 認証（plan・apply ロール分離）／CI・CD の運用／plan を artifact 化しない設計判断／版固定／SG・ALB・TG 構成。
- `README.md`：CI/CD 節を追加。bootstrap の DynamoDB 撤去（#595）に伴う stale な記述を修正。

## 変更の種別
- [x] docs

## 動作確認チェックリスト
- [x] 既存の機能が壊れていないことを確認した
- [x] .env やパスワードをコミットしていない