### PR TITLE
fix: apply ロールの S3 権限不足を修正（GetAccelerateConfiguration）

### DIFF
--- a/aws-study/terraform/bootstrap/oidc.tf
+++ b/aws-study/terraform/bootstrap/oidc.tf
@@ -144,10 +144,11 @@ data "aws_iam_policy_document" "apply_infra" {
   statement {
     sid    = "S3SiteManage"
     effect = "Allow"
+    # provider はバケット作成時に accelerate/lifecycle 等のサブ設定を読むため、
+    # リソースを aws-study-* に限定したうえで Get/Put/List を広めに許可する。
     actions = [
-      "s3:CreateBucket", "s3:DeleteBucket", "s3:ListBucket", "s3:GetBucket*", "s3:PutBucket*",
-      "s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:GetEncryptionConfiguration",
-      "s3:PutEncryptionConfiguration", "s3:PutBucketPublicAccessBlock", "s3:GetBucketPublicAccessBlock",
+      "s3:CreateBucket", "s3:DeleteBucket", "s3:DeleteObject",
+      "s3:Get*", "s3:Put*", "s3:List*",
     ]
     resources = ["arn:aws:s3:::aws-study-*", "arn:aws:s3:::aws-study-*/*"]
   }


### PR DESCRIPTION
Closes #604。フル apply で s3:GetAccelerateConfiguration が拒否され失敗したため、S3 権限を aws-study-* 限定のまま Get*/Put*/List* に拡張。