### PR TITLE
docs: Terraform CD 化のまとめ（提出用）

### DIFF
--- a/aws-study/docs/cd-submission.md
+++ b/aws-study/docs/cd-submission.md
@@ -1,0 +1,39 @@
+# Terraform を GitHub Actions で CD 化
+
+AWS インフラ（VPC / EC2 / RDS / ALB / CloudFront / Lambda / API Gateway / WAF 等）の Terraform を、GitHub Actions で検査（CI）し、承認を経て自動 apply（CD）する仕組みを構築した。
+
+## 構成
+
+- **CI（`.github/workflows/terraform-ci.yml`・PR 時）**
+  - `terraform-validate`：`fmt -check` / `init -backend=false` / `validate`（AWS 不要・必須チェック）
+  - `terraform-test`：`terraform test`（plan モード・11 ケース。ALB / SG / ターゲットグループのポートや SSH 制限を検証）
+- **CD（`.github/workflows/terraform-cd.yml`・main マージ時）**
+  - トリガ：`aws-study/terraform/**` の変更が main に入った時
+  - `environment: prod` の承認ゲート（承認するまで apply しない）
+  - OIDC apply ロールで認証 → `plan -out=tfplan` → `apply tfplan`（同一ジョブ）→ ALB へ `curl` で反映確認
+
+## 認証・セキュリティ
+
+- **OIDC（短期トークン）**で認証し、長期アクセスキーは使わない
+- **plan / apply ロールを分離**：PR / main は読み取り専用、変更は prod 環境からのみ
+- **最小権限**：IAM は `aws-study-*` に限定、他サービスは動詞ファミリ＋東京リージョン条件
+- **state**：S3 ＋ S3 ネイティブロック＋暗号化、バケットは公開遮断＋ポリシー（TLS 必須・他アカウント拒否）
+- ALB-SG = 80/443、EC2 の SSH = 自分の IP(/32) のみ、RDS は private ＋暗号化
+
+## 実証（テスト → 自動構築 → 変更 → 再CD → 反映）
+
+- フル構築（53 リソース）apply 成功 → ALB が 200
+- CloudWatch アラームしきい値 80 → 70 を変更 → CD で反映（`> 70`）
+- CD run（証跡）:
+  - 自動構築: https://github.com/80-cloud/study-boards/actions/runs/27991809362
+  - 変更反映: https://github.com/80-cloud/study-boards/actions/runs/27993416690
+
+## 関連 PR
+
+- #596 CI と OIDC 認証基盤
+- #599 CD ワークフロー
+- #601 運用ドキュメント
+- #603 変更 → 反映デモ（しきい値変更）
+- #605 apply ロールの権限修正
+
+（証跡スクリーンショットは本 PR の説明に添付）


### PR DESCRIPTION
## 概要

Terraform を GitHub Actions で CD 化した（CI 検査 → 承認 → 自動 apply → 反映確認）。構成・セキュリティの詳細は `aws-study/docs/cd-submission.md` を参照。

Closes #606

## 実証の証跡（CD run・恒久リンク）

- 自動構築（53 リソースを apply 成功）: https://github.com/80-cloud/study-boards/actions/runs/27991809362
- 変更反映（しきい値 80→70 を CD で apply）: https://github.com/80-cloud/study-boards/actions/runs/27993416690

## スクリーンショット（証跡）

下の各見出しの**真下に対応する画像をドラッグ&ドロップ**してください。

### 1. 自動構築：CD でフル apply 成功（prod 承認済み）
<img width="1314" height="662" alt="スクリーンショット 2026-06-23 9 38 49" src="https://github.com/user-attachments/assets/a2d6371e-1fbb-4597-b162-459efd173a76" />


### 2. 変更 → 再CD：しきい値変更の apply 成功（prod 承認済み）
<img width="1299" height="673" alt="スクリーンショット 2026-06-23 9 38 59" src="https://github.com/user-attachments/assets/2b6c318c-dddb-473f-a0b7-cbf8bf9a0427" />


### 3. 反映確認：CloudWatch アラームのしきい値 = 70
<img width="881" height="673" alt="スクリーンショット 2026-06-23 9 55 43" src="https://github.com/user-attachments/assets/98966bd8-cdaf-40ff-9dce-7b85ebeb5c9d" />


### 4. アプリ稼働：ALB 経由で 200（Welcome to nginx）
<img width="1253" height="934" alt="スクリーンショット 2026-06-23 9 18 35" src="https://github.com/user-attachments/assets/265254a3-8f9d-4f41-8939-443704806f1d" />


### 5. 承認ゲート：prod 環境の Required reviewers = 80-cloud
<img width="967" height="925" alt="スクリーンショット 2026-06-23 9 51 39" src="https://github.com/user-attachments/assets/d938836b-99e8-4dec-9a6a-ba9ee1c1f9a6" />


## 関連 PR

- #596 CI と OIDC 認証基盤
- #599 CD ワークフロー
- #601 運用ドキュメント
- #603 変更 → 反映デモ（しきい値変更）
- #605 apply ロールの権限修正