### PR TITLE
chore: CD の paths を capstone 本体に限定（bootstrap/README を除外）

### DIFF
--- a/.github/workflows/terraform-cd.yml
+++ b/.github/workflows/terraform-cd.yml
@@ -7,6 +7,8 @@ on:
     branches: [main]
     paths:
       - "aws-study/terraform/**"
+      - "!aws-study/terraform/bootstrap/**"
+      - "!aws-study/terraform/README.md"
 
 permissions:
   id-token: write # OIDC トークン取得に必須


### PR DESCRIPTION
Closes #608。terraform-cd.yml の paths に bootstrap と README の除外を追加。