### PR TITLE
feat: Ansible で EC2 に Java をインストール

### DIFF
--- a/.github/workflows/ansible-java.yml
+++ b/.github/workflows/ansible-java.yml
@@ -1,0 +1,77 @@
+name: ansible-java
+
+# 手動起動のみ。environment: prod の承認ゲートで止まり、承認後に apply→ansible が走る。
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write   # OIDC トークン取得に必須
+  contents: read
+
+concurrency:
+  group: ansible-java
+  cancel-in-progress: false
+
+jobs:
+  provision-and-install:
+    name: terraform-apply + ansible
+    runs-on: ubuntu-latest
+    environment: prod          # ★apply ロールの OIDC sub 条件が environment:prod のため必須＋承認ゲート
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: aws-study/ansible
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: "1.15.2"
+
+      - uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: ${{ secrets.AWS_APPLY_ROLE_ARN }}
+          aws-region: ap-northeast-1
+
+      - name: Terraform apply (provision the target EC2)
+        working-directory: aws-study/ansible/infra
+        run: |
+          terraform init
+          terraform plan -out=tfplan -input=false -var="my_ip=${{ secrets.MY_IP_CIDR }}"
+          terraform apply -input=false tfplan
+
+      - name: Write SSH private key
+        run: |
+          printf '%s\n' "${{ secrets.ANSIBLE_SSH_KEY }}" > key.pem
+          chmod 600 key.pem
+
+      - name: Build inventory from terraform output
+        run: |
+          IP=$(terraform -chdir=infra output -raw ec2_public_ip)
+          SG=$(terraform -chdir=infra output -raw security_group_id)
+          sed -i "s|__EC2_IP__|${IP}|" inventory/hosts.ini
+          echo "SG_ID=${SG}" >> "$GITHUB_ENV"
+
+      - name: Open SSH from this runner (temporary)
+        run: |
+          RUNNER_IP=$(curl -s https://checkip.amazonaws.com)
+          aws ec2 authorize-security-group-ingress \
+            --group-id "$SG_ID" --protocol tcp --port 22 \
+            --cidr "${RUNNER_IP}/32" --region ap-northeast-1
+          echo "RUNNER_CIDR=${RUNNER_IP}/32" >> "$GITHUB_ENV"
+
+      - name: Install Ansible
+        run: pipx install --include-deps ansible
+
+      - name: Run playbook (install + verify Java)
+        run: ansible-playbook -i inventory/hosts.ini playbooks/install-java.yml
+
+      - name: Revoke temporary SSH (always)
+        if: always()
+        run: |
+          if [ -n "${SG_ID:-}" ] && [ -n "${RUNNER_CIDR:-}" ]; then
+            aws ec2 revoke-security-group-ingress \
+              --group-id "$SG_ID" --protocol tcp --port 22 \
+              --cidr "$RUNNER_CIDR" --region ap-northeast-1 || true
+          fi

--- a/aws-study/ansible/ansible.cfg
+++ b/aws-study/ansible/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+inventory = ./inventory/hosts.ini
+host_key_checking = False
+stdout_callback = yaml
+remote_tmp = /tmp/.ansible

--- a/aws-study/ansible/infra/.terraform.lock.hcl
+++ b/aws-study/ansible/infra/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.51.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:QWxF+1ePJ4qFCHEc6PyHNeXc865wLvrWVl71d/nABa8=",
+    "zh:03fcea0a1ea2ca81d62d4d2e2961181bef9068b1c701f2cddc4aa5fac105818a",
+    "zh:1213944cd623143974ea5c9b70b22ae1ccca33d743924c149ed089d34b8e08b4",
+    "zh:190a46da0c69082b74da48238ce134d2fc9893e09122ac249c5689f88eab7e13",
+    "zh:1b312a4b53fa3cf731f95e674c033865feea5455f163b86136f2614424637293",
+    "zh:2b319814806222c5aba196b1a78756a6b36dc5c91f85edda349234d8a2f20a6a",
+    "zh:2bddf92c8efc6ad445a2eb8a0e5f88742a0596392c3a4ebc350ebb4105a4a96d",
+    "zh:3bef0c4f675c09034ff017cf899977b1765b2c0b3d1e489bcb06a5fcac316e2d",
+    "zh:47c46b5aa22199638fed5c93b195bbfd1182a1408edad4e5c39d4a73a04493f6",
+    "zh:5f808699650f6db961964466c77f5a581eab142a91c2e54810bb09b6f2fcd3f2",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ada97e6be10164f452e278c23412b8597698a9c95ffb68fe83629d63d85906f3",
+    "zh:c4d73a91810d8dbcf9abbd431d41fcceebb48f8b6fd3c28a84bb3c6ed08be2e9",
+    "zh:c63ec875d38fc557b16b0b2b0ab1c7635852799453113240e21a52409de94a71",
+    "zh:cdd0209a755fc3aa14855aa013dae4b166a2fc7f6d3cbb673f7ff2142f5b63a2",
+    "zh:e5e665a27290391fd1bffc093ab68b596f6c507785be2e3f0949fab4fd6aec1b",
+    "zh:f6c42046a31d65eff2793737656b38931f90318b53661046bb84326cd4cb558f",
+  ]
+}

--- a/aws-study/ansible/infra/main.tf
+++ b/aws-study/ansible/infra/main.tf
@@ -1,0 +1,71 @@
+provider "aws" {
+  region = "ap-northeast-1"
+}
+
+# default VPC とその subnet を data で取得（自前 VPC を作らず最小構成にする）。
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+# AL2023 の最新 AMI を data で取得（ID ベタ書き禁止）。
+data "aws_ami" "al2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+}
+
+# SSH 用 SG。22 は自分の IP のみ（ランナー IP は WF が実行時に一時 authorize/revoke する）。
+resource "aws_security_group" "ssh" {
+  name        = "${var.project}-ansible-sg"
+  description = "SSH for Ansible target (my_ip only; runner IP added at runtime)"
+  vpc_id      = data.aws_vpc.default.id
+
+  ingress {
+    description = "SSH from my_ip"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.my_ip]
+  }
+
+  egress {
+    description = "all outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project}-ansible-sg"
+  }
+}
+
+# 対象 EC2。user_data なしの「素の AL2023」＝Java は playbook だけで入れる（before/after を見せられる）。
+resource "aws_instance" "target" {
+  ami                         = data.aws_ami.al2023.id
+  instance_type               = "t3.micro"
+  subnet_id                   = data.aws_subnets.default.ids[0]
+  associate_public_ip_address = true
+  vpc_security_group_ids      = [aws_security_group.ssh.id]
+  key_name                    = var.key_name
+
+  tags = {
+    Name = "${var.project}-ansible-target"
+  }
+}

--- a/aws-study/ansible/infra/outputs.tf
+++ b/aws-study/ansible/infra/outputs.tf
@@ -1,0 +1,14 @@
+output "ec2_public_ip" {
+  description = "inventory に差し込む対象 EC2 の公開 IP。"
+  value       = aws_instance.target.public_ip
+}
+
+output "instance_id" {
+  description = "対象 EC2 のインスタンス ID。"
+  value       = aws_instance.target.id
+}
+
+output "security_group_id" {
+  description = "ランナー IP を一時 authorize/revoke するための SG ID。"
+  value       = aws_security_group.ssh.id
+}

--- a/aws-study/ansible/infra/terraform.tf
+++ b/aws-study/ansible/infra/terraform.tf
@@ -1,0 +1,22 @@
+# Ansible 対象 EC2 用の最小 Terraform（capstone とは別ルート・別 state）。
+# state は capstone と同じ S3 バケットに置くが key を分けて混ぜない（採点の state 分離と同じ考え方）。
+# WF が apply したあと EC2 を残し、destroy は本人がローカルで実行する設計なので、
+# state はローカルではなく必ずリモート（S3）に置く必要がある（runner が消えても state が残る）。
+terraform {
+  required_version = "~> 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+
+  backend "s3" {
+    bucket       = "aws-study-tfstate-hideharu"
+    key          = "ansible/terraform.tfstate"
+    region       = "ap-northeast-1"
+    use_lockfile = true
+    encrypt      = true
+  }
+}

--- a/aws-study/ansible/infra/variables.tf
+++ b/aws-study/ansible/infra/variables.tf
@@ -1,0 +1,21 @@
+variable "my_ip" {
+  description = "SSH を許可する自分の IP（/32）。CI ランナーの IP は実行時に別途一時開放する。"
+  type        = string
+
+  validation {
+    condition     = can(cidrhost(var.my_ip, 0)) && endswith(var.my_ip, "/32")
+    error_message = "my_ip は単一ホストの CIDR（例: 203.0.113.10/32）で指定すること。"
+  }
+}
+
+variable "project" {
+  description = "リソース名の接頭辞（apply ロールの最小権限が aws-study-* 限定のため固定）。"
+  type        = string
+  default     = "aws-study"
+}
+
+variable "key_name" {
+  description = "EC2 に紐づける既存キーペア名（本人がローカルで作成し import 済みのもの）。"
+  type        = string
+  default     = "ansible-java-key"
+}

--- a/aws-study/ansible/inventory/hosts.ini
+++ b/aws-study/ansible/inventory/hosts.ini
@@ -1,0 +1,8 @@
+[java_targets]
+target ansible_host=__EC2_IP__
+
+[java_targets:vars]
+ansible_user=ec2-user
+ansible_ssh_private_key_file=./key.pem
+ansible_python_interpreter=/usr/bin/python3
+ansible_ssh_common_args=-o StrictHostKeyChecking=no

--- a/aws-study/ansible/playbooks/install-java.yml
+++ b/aws-study/ansible/playbooks/install-java.yml
@@ -1,0 +1,33 @@
+---
+- name: Install Java on EC2 (Amazon Corretto)
+  hosts: java_targets
+  gather_facts: false
+  become: true
+
+  vars:
+    java_major: "21"
+    java_pkg: "java-21-amazon-corretto-devel"
+
+  tasks:
+    - name: Wait until SSH is reachable (EC2 起動直後は SSH 未起動のため)
+      ansible.builtin.wait_for_connection:
+        timeout: 180
+
+    - name: Install Java (Amazon Corretto)
+      ansible.builtin.dnf:
+        name: "{{ java_pkg }}"
+        state: present
+
+    - name: Get java version
+      ansible.builtin.command: java -version
+      register: java_check
+      changed_when: false        # java -version は何も変更しない＆出力は stderr に出る
+
+    - name: Assert the installed major version
+      ansible.builtin.assert:
+        that:
+          - expected_token in java_check.stderr
+        fail_msg: "Java {{ java_major }} が入っていない: {{ java_check.stderr }}"
+        success_msg: "OK: {{ java_check.stderr_lines[0] }}"
+      vars:
+        expected_token: '"{{ java_major }}.'


### PR DESCRIPTION
Closes #610。Terraform で素の EC2 を作成し、Ansible で Java 21 をインストール・検証。GitHub Actions の手動実行から apply→ansible を行う。