### PR TITLE
fix: ansible.cfg の廃止された yaml callback を削除

### DIFF
--- a/aws-study/ansible/ansible.cfg
+++ b/aws-study/ansible/ansible.cfg
@@ -1,5 +1,4 @@
 [defaults]
 inventory = ./inventory/hosts.ini
 host_key_checking = False
-stdout_callback = yaml
 remote_tmp = /tmp/.ansible


### PR DESCRIPTION
Closes #612。community.general.yaml callback 廃止による playbook 起動失敗を修正。