### PR TITLE
fix: app-deployのboto3導入先をansible-coreに修正＋Secrets即時削除

### DIFF
--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -66,12 +66,12 @@ jobs:
           terraform -chdir=aws-study/terraform apply -input=false tfplan
 
       # 4) Ansible/SSM 前提を導入
-      - name: Install session-manager-plugin and Ansible
+      - name: Install session-manager-plugin and Ansible deps
         run: |
           curl -s "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o /tmp/smp.deb
           sudo dpkg -i /tmp/smp.deb
-          pipx install --include-deps ansible
-          pipx inject ansible boto3 botocore
+          # runner は ansible を ansible-core venv でプリインストール済み。実際に動くその venv へ boto3 を入れる。
+          pipx inject ansible-core boto3 botocore
           ansible-galaxy collection install -r aws-study/ansible/requirements.yml
 
       # 5) インスタンスID/転送バケットを取得 → SSM Online を待つ → inventory 生成

--- a/aws-study/terraform/modules/secrets/main.tf
+++ b/aws-study/terraform/modules/secrets/main.tf
@@ -13,8 +13,9 @@ resource "random_password" "jwt" {
 
 # Secrets Manager に DB 認証＋JWT 鍵を JSON で保管
 resource "aws_secretsmanager_secret" "db" {
-  name        = "${var.project}-db-credentials"
-  description = "App credentials (DB master + JWT signing key)"
+  name                    = "${var.project}-db-credentials"
+  description             = "App credentials (DB master + JWT signing key)"
+  recovery_window_in_days = 0 # destroy 時に即削除（同名再作成の復旧待ちブロックを防ぐ・学習用）
 }
 
 resource "aws_secretsmanager_secret_version" "db" {


### PR DESCRIPTION
## 不具合
app-deploy の Ansible ステップが `Failed to import the required Python library (boto3)`（/opt/pipx/venvs/ansible-core/bin/python）で失敗。

## 原因
runner は ansible を `ansible-core` venv でプリインストール済み。`pipx install ansible`＋`pipx inject ansible boto3` は別venv `ansible` に boto3 を入れていたため、実際に動く `ansible-core` に boto3 が無く aws_ssm 接続が確立できなかった。

## 修正
- `pipx inject ansible-core boto3 botocore` に変更。
- `modules/secrets` に `recovery_window_in_days = 0` を追加（destroy 後の同名 secret 復旧待ちによる再 apply 失敗を防止）。

Closes #616