### PR TITLE
fix: EC2 AMIをAL2023標準版に固定（minimal版を除外）

### DIFF
--- a/aws-study/terraform/modules/compute/main.tf
+++ b/aws-study/terraform/modules/compute/main.tf
@@ -1,10 +1,11 @@
-# 最新の Amazon Linux 2023（x86_64）を自動取得（AMI ID を直書きしない）
+# 最新の Amazon Linux 2023 標準版（x86_64）を自動取得（AMI ID を直書きしない）。
+# 「al2023-ami-2023.*」で標準版に限定（minimal 版は SSM agent/python3 が無く SSM デプロイ不可）。
 data "aws_ami" "al2023" {
   most_recent = true
   owners      = ["amazon"]
   filter {
     name   = "name"
-    values = ["al2023-ami-*-x86_64"]
+    values = ["al2023-ami-2023.*-x86_64"]
   }
   filter {
     name   = "architecture"


### PR DESCRIPTION
## 不具合
EC2 が SSM 未登録（PingStatus null）→ Ansible が TargetNotConnected で失敗。

## 原因
AMI フィルタ `al2023-ami-*-x86_64` が minimal 版にもマッチし most_recent が `al2023-ami-minimal-*` を選択。minimal には amazon-ssm-agent / python3 が無く SSM デプロイ不可。

## 修正
`al2023-ami-2023.*-x86_64` に変更し標準版のみに限定。標準 AL2023 は SSM agent・python3 を同梱。

Closes #618